### PR TITLE
Vis | Style: New color palette

### DIFF
--- a/packages/ts/src/components/sankey/style.ts
+++ b/packages/ts/src/components/sankey/style.ts
@@ -10,12 +10,12 @@ export const root = css`
 export const variables = injectGlobal`
   :root {
     --vis-sankey-link-cursor: default;
-    --vis-sankey-link-color: #cad5f6;
+    --vis-sankey-link-color: var(--vis-color-main-light);
     --vis-sankey-link-opacity: 0.5;
     --vis-sankey-link-hover-opacity: 1.0;
 
     --vis-sankey-node-cursor: default;
-    --vis-sankey-node-color: #4e4dd1;
+    --vis-sankey-node-color: var(--vis-color-main);
     --vis-sankey-node-label-color: #575c65;
     --vis-sankey-node-opacity: 0.9;
     --vis-sankey-node-hover-opacity: 1.0;
@@ -37,8 +37,10 @@ export const variables = injectGlobal`
     --vis-sankey-icon-stroke-opacity: 0.6;
     --vis-sankey-icon-font-family: ${DEFAULT_ICON_FONT_FAMILY};
 
-    --vis-dark-sankey-link-color: #555d75;
-    --vis-dark-sankey-node-color: #6b69ff;
+    --vis-sankey-label-font-family: var(--vis-font-family);
+
+    --vis-dark-sankey-link-color: var(--vis-color-main-dark);
+    --vis-dark-sankey-node-color: var(--vis-color-main);
     --vis-dark-sankey-node-label-color: #eaeaea;
     --vis-dark-sankey-node-label-background-fill-color: #292b34;
     --vis-dark-sankey-node-label-background-stroke-color: #575c65;

--- a/packages/ts/src/styles/colors.ts
+++ b/packages/ts/src/styles/colors.ts
@@ -1,9 +1,28 @@
+import { hsl } from 'd3-color'
 import { isNumber } from 'utils/data'
 
 /** Array of default colors */
-export const colors = globalThis?.UNOVIS_COLORS || ['#6A9DFF', '#a611a5', '#1acb9a', '#8777d9', '#f88080', '#5242aa', '#8ee422']
+export const colors = globalThis?.UNOVIS_COLORS || ['#4D8CFD', '#FF6B7E', '#F4B83E', '#A6CC74', '#00C19A', '#6859BE']
+export const colorsDark = globalThis?.UNOVIS_COLORS_DARK || ['#4D8CFD', '#FF6B7E', '#FFC16D', '#A6CC74', '#00C19A', '#7887E0']
 
 /** Return a CSS Variable name for a given color index or string */
 export const getCSSColorVariable = (suffix: string | number): string => {
   return `--vis-${isNumber(suffix) ? `color${(suffix as number) % colors.length}` : suffix}`
+}
+
+export function getLighterColor (hex: string, percentage = 0.4): string {
+  const c = hsl(hex)
+  c.l = c.l * (1 + percentage)
+  return c.formatHex()
+}
+
+export function getDarkerColor (
+  hex: string,
+  percentageL = 0.4,
+  percentageS = 0.6
+): string {
+  const c = hsl(hex)
+  c.s = c.s * (1 - percentageS)
+  c.l = c.l * (1 - percentageL)
+  return c.formatHex()
 }

--- a/packages/ts/src/styles/index.ts
+++ b/packages/ts/src/styles/index.ts
@@ -1,5 +1,5 @@
 import { css, injectGlobal } from '@emotion/css'
-import { colors, getCSSColorVariable } from './colors'
+import { colors, colorsDark, getCSSColorVariable, getLighterColor, getDarkerColor } from './colors'
 
 export const DEFAULT_ICON_FONT_FAMILY = globalThis?.UNOVIS_ICON_FONT_FAMILY || 'FontAwesome'
 
@@ -65,9 +65,14 @@ export const variables = injectGlobal`
     label: vis-root-styles;
     --vis-font-family: Inter, Arial, "Helvetica Neue", Helvetica, sans-serif;
     --vis-color-main: var(${getCSSColorVariable(0)});
+    --vis-color-main-light: ${getLighterColor(colors[0])};
+    --vis-color-main-dark: ${getDarkerColor(colors[0])};
     --vis-color-grey: #2a2a2a;
     ${colors.map((c, i) => `${getCSSColorVariable(i)}: ${c};`)}
+    ${colorsDark.map((c, i) => `--vis-dark-color${i}: ${c};`)}
+
+    body.theme-dark {
+      ${colors.map((c, i) => `${getCSSColorVariable(i)}: var(--vis-dark-color${i});`)}
+    }
   }
 `
-
-


### PR DESCRIPTION
@reb-dev I'm working on a new default color palette and here is my first iteration. Please let me know if you have any comments

<img width="480" alt="Screen Shot 2022-11-28 at 2 21 53 PM" src="https://user-images.githubusercontent.com/755708/204393505-e6c44653-e103-4785-892b-15a530f5f280.png">
<img width="480" alt="Screen Shot 2022-11-28 at 2 21 56 PM" src="https://user-images.githubusercontent.com/755708/204393516-fe8ed837-d30f-4dd3-b175-0c835eec2327.png">

![Screen Shot 2022-11-28 at 2 24 57 PM](https://user-images.githubusercontent.com/755708/204393967-a5072e98-0068-4627-bac3-9115b186b54f.png)


![Screen Shot 2022-11-28 at 2 25 03 PM](https://user-images.githubusercontent.com/755708/204393981-6f4d4228-e1ec-42ad-b0a3-6dfd945aff8d.png)

![Screen Shot 2022-11-28 at 2 25 46 PM](https://user-images.githubusercontent.com/755708/204393998-86e657e3-7ec0-4d5d-9dbc-ed285760e682.png)


![Screen Shot 2022-11-28 at 2 25 14 PM](https://user-images.githubusercontent.com/755708/204394012-888fc00f-93d1-44a5-abf5-0bbb9ae145cc.png)
