### PR TITLE
Vis | Components | Styles: Fixing the `font-family` inheritance logic

### DIFF
--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -6,7 +6,8 @@ export const root = css`
 
 export const globalStyles = injectGlobal`
   :root {
-    --vis-axis-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-axis-font-family: */
     --vis-axis-tick-color: #e8e9ef;
     --vis-axis-tick-label-color: #6c778c;
     --vis-axis-grid-color: #e8e9ef;
@@ -82,7 +83,7 @@ export const tick = css`
 
   text, tspan {
     fill: var(--vis-axis-tick-label-color);
-    font-family: var(--vis-axis-font-family);
+    font-family: var(--vis-axis-font-family, var(--vis-font-family));
     stroke: none;
   }
 `
@@ -91,7 +92,7 @@ export const label = css`
   label: label;
   fill: var(--vis-axis-label-color);
   font-size: var(--vis-axis-label-font-size);
-  font-family: var(--vis-axis-font-family);
+  font-family: var(--vis-axis-font-family, var(--vis-font-family));
   text-anchor: middle;
 `
 

--- a/packages/ts/src/components/bullet-legend/style.ts
+++ b/packages/ts/src/components/bullet-legend/style.ts
@@ -6,7 +6,9 @@ export const root = css`
 
 export const variables = injectGlobal`
   :root {
-    --vis-legend-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-legend-font-family: */
+
     --vis-legend-label-color: #6c778c;
     --vis-legend-label-max-width: 300px;
     --vis-legend-label-font-size: 12px;
@@ -28,7 +30,7 @@ export const variables = injectGlobal`
 export const item = css`
   label: legendItem;
   display: inline;
-  font-family: var(--vis-legend-font-family);
+  font-family: var(--vis-legend-font-family, var(--vis-font-family));
   margin-right: var(--vis-legend-item-spacing);
   white-space: nowrap;
   cursor: default;

--- a/packages/ts/src/components/donut/style.ts
+++ b/packages/ts/src/components/donut/style.ts
@@ -8,12 +8,14 @@ export const variables = injectGlobal`
   :root {
     --vis-donut-central-label-font-size: 16px;
     --vis-donut-central-label-text-color: #5b5f6d;
-    --vis-donut-central-label-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-donut-central-label-font-family: */
     --vis-donut-central-label-font-weight: 600;
 
     --vis-donut-central-sub-label-font-size: 12px;
     --vis-donut-central-sub-label-text-color: #5b5f6d;
-    --vis-donut-central-sub-label-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-donut-central-sub-label-font-family: */
     --vis-donut-central-sub-label-font-weight: 500;
 
     --vis-donut-background-color: #E7E9F3;
@@ -53,7 +55,7 @@ export const centralLabel = css`
   text-anchor: middle;
   dominant-baseline: middle;
   font-size: var(--vis-donut-central-label-font-size);
-  font-family: var(--vis-donut-central-label-font-family);
+  font-family: var(--vis-donut-central-label-font-family, var(--vis-font-family));
   font-weight: var(--vis-donut-central-label-font-weight);
   fill: var(--vis-donut-central-label-text-color);
 `
@@ -63,7 +65,7 @@ export const centralSubLabel = css`
   text-anchor: middle;
   dominant-baseline: middle;
   font-size: var(--vis-donut-central-sub-label-font-size);
-  font-family: var(--vis-donut-central-sub-label-font-family);
+  font-family: var(--vis-donut-central-sub-label-font-family, var(--vis-font-family));
   font-weight: var(--vis-donut-central-sub-label-font-weight);
   fill: var(--vis-donut-central-sub-label-text-color);
 `

--- a/packages/ts/src/components/graph/modules/node/style.ts
+++ b/packages/ts/src/components/graph/modules/node/style.ts
@@ -39,7 +39,8 @@ export const variables = injectGlobal`
     --vis-graph-node-label-text-color: #0F1E57;
     --vis-graph-node-sublabel-text-color: #989aa3;
     --vis-graph-node-sublabel-font-size: 8pt;
-    --vis-graph-node-label-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-graph-node-label-font-family: */
 
     --vis-dark-graph-node-label-background: var(--vis-color-grey);
     --vis-dark-graph-node-label-text-color: #ffffff;
@@ -153,14 +154,14 @@ export const labelTextContent = css`
   label: label-text-content;
 
   fill: var(--vis-graph-node-label-text-color);
-  font-family: var(--vis-graph-node-label-font-family);
+  font-family: var(--vis-graph-node-label-font-family, var(--vis-font-family));
 `
 
 export const subLabelTextContent = css`
   label: sublabel-text-content;
 
   fill: var(--vis-graph-node-sublabel-text-color);
-  font-family: var(--vis-graph-node-label-font-family);
+  font-family: var(--vis-graph-node-label-font-family, var(--vis-font-family));
   font-size: var(--vis-graph-node-sublabel-font-size);
 `
 

--- a/packages/ts/src/components/graph/modules/panel/style.ts
+++ b/packages/ts/src/components/graph/modules/panel/style.ts
@@ -12,7 +12,9 @@ export const variables = injectGlobal`
 
     --vis-graph-panel-label-color: #6c778c;
     --vis-graph-panel-label-background: #ffffff;
-    --vis-graph-panel-label-font-family: var(--vis-font-family);
+
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-graph-panel-label-font-family: */
     --vis-graph-panel-label-font-size: 10pt;
     --vis-graph-panel-label-font-weight: 300;
 
@@ -77,7 +79,7 @@ export const labelText = css`
   font-weight: var(--vis-graph-panel-label-font-weight);;
   cursor: default;
   stroke: none;
-  font-family: var(--vis-graph-panel-label-font-family);
+  font-family: var(--vis-graph-panel-label-font-family, var(--vis-font-family));
 `
 
 export const panelSelectionActive = css`

--- a/packages/ts/src/components/leaflet-map/style.ts
+++ b/packages/ts/src/components/leaflet-map/style.ts
@@ -21,7 +21,8 @@ export const root = css`
 export const variables = injectGlobal`
   :root {
     --vis-map-container-background-color: #dfe5eb;
-    --vis-map-label-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-map-label-font-family, var(--vis-font-family): */
 
     --vis-map-point-default-fill-color: #B9BEC3;
     --vis-map-point-ring-fill-color: #ffffff;
@@ -138,7 +139,7 @@ export const innerLabel = css`
 
   text-anchor: middle;
   fill: var(--vis-map-point-label-text-color-dark);
-  font-family: var(--vis-map-label-font-family);
+  font-family: var(--vis-map-label-font-family, var(--vis-font-family));
   pointer-events: none;
   font-weight: 600;
 `
@@ -148,7 +149,7 @@ export const bottomLabel = css`
 
   text-anchor: middle;
   fill: var(--vis-map-point-label-text-color-dark);
-  font-family: var(--vis-map-label-font-family);
+  font-family: var(--vis-map-label-font-family, var(--vis-font-family));
   pointer-events: none;
   font-weight: 600;
 `

--- a/packages/ts/src/components/sankey/style.ts
+++ b/packages/ts/src/components/sankey/style.ts
@@ -37,7 +37,8 @@ export const variables = injectGlobal`
     --vis-sankey-icon-stroke-opacity: 0.6;
     --vis-sankey-icon-font-family: ${DEFAULT_ICON_FONT_FAMILY};
 
-    --vis-sankey-label-font-family: var(--vis-font-family);
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-sankey-label-font-family: */
 
     --vis-dark-sankey-link-color: var(--vis-color-main-dark);
     --vis-dark-sankey-node-color: var(--vis-color-main);
@@ -109,7 +110,7 @@ export const label = css`
   user-select: none;
 
   &, tspan {
-    font-family: var(--vis-sankey-label-font-family);
+    font-family: var(--vis-sankey-label-font-family, var(--vis-font-family));
     dominant-baseline: hanging;
   }
 `
@@ -122,7 +123,7 @@ export const sublabel = css`
   user-select: none;
 
   &, tspan {
-    font-family: var(--vis-sankey-label-font-family);
+    font-family: var(--vis-sankey-label-font-family, var(--vis-font-family));
     font-weight: var(--vis-sankey-node-sublabel-font-weight);
     dominant-baseline: hanging;
   }

--- a/packages/ts/src/components/scatter/style.ts
+++ b/packages/ts/src/components/scatter/style.ts
@@ -14,6 +14,8 @@ export const globalStyles = injectGlobal`
     --vis-scatter-point-label-text-color-light: #fff;
     --vis-scatter-point-label-text-font-weight: 500;
     --vis-scatter-point-label-text-font-size: 12px;
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-scatter-point-label-text-font-family: */
   }
 `
 
@@ -48,6 +50,7 @@ export const point = css`
   > text {
     font-weight: var(--vis-scatter-point-label-text-font-weight);
     font-size: var(--vis-scatter-point-label-text-font-size);
+    font-family: var(--vis-scatter-point-label-text-font-family, var(--vis-font-family));
     fill: var(--vis-scatter-point-label-text-color-dark);
     user-select: none;
   }

--- a/packages/ts/src/components/topojson-map/style.ts
+++ b/packages/ts/src/components/topojson-map/style.ts
@@ -19,7 +19,9 @@ export const variables = injectGlobal`
 
     --vis-map-point-label-text-color-dark: #5b5f6d;
     --vis-map-point-label-text-color-light: #fff;
-    --vis-map-point-label-font-family: var(--vis-font-family);
+
+    // Undefined by default to allow proper fallback to var(--vis-font-family)
+    /* --vis-map-point-label-font-family: */
     --vis-map-point-label-font-weight: 600;
     --vis-map-point-label-font-size: 12px;
 
@@ -82,7 +84,7 @@ export const pointLabel = css`
   pointer-events:none;
 
   font-size: var(--vis-map-point-label-font-size);
-  font-family: var(--vis-map-point-label-font-family);
+  font-family: var(--vis-map-point-label-font-family, var(--vis-font-family));
   font-weight: var(--vis-map-point-label-font-weight);
   fill: var(--vis-map-point-label-text-color-dark);
 `


### PR DESCRIPTION
@reb-dev CSS variables have a non-obvious inheritance logic. When you have two variable at the root level (e.g. `--vis-font-family` and ` --vis-axis-font-family`), and one of them is assigned to another, when you re-define the base one at your component's level it won't have any affect. So the code below won't work:

```css
:root {
  --vis-font-family: Helvetica;
  --vis-axis-font-family: var(--vis-font-family);
}

.component {
    --vis-font-family: Times;
}
```

I did not realize that in the beginning and made a few mistakes in my code. This MR fixes the issue for font-family, but we still have the same broken logic for some other root variables like colors. So I wanted to show this to you and ask to fix the remaining issue when you're done with the other high priority things.