### PR TITLE
Website | Gallery: Resolve production build bugs

### DIFF
--- a/packages/website/src/pages/gallery/view.tsx
+++ b/packages/website/src/pages/gallery/view.tsx
@@ -17,7 +17,7 @@ export default function Home (): JSX.Element {
   return (
     <Layout
       title="Gallery"
-      description="A modular data visualization framework for React, Angular and vanilla TypeScript"
+      description="A modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript"
     >
       <BrowserOnly>{() => {
         const location = useLocation()


### PR DESCRIPTION
#49 

Since our examples rely on URL parameters, the initial render doesn't have that data resulting in the _Example Not Found_ page being loaded instead and creating unexpected behavior. We override this by not rendering anything unless we are in a browser environment https://docusaurus.io/docs/advanced/ssg#useisbrowser