### PR TITLE
Vis Svelte | Build: Resolve svelte-check unused local hints

### DIFF
--- a/packages/svelte/src/components/axis/axis.svelte
+++ b/packages/svelte/src/components/axis/axis.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Axis, AxisConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Axis, AxisConfigInterface } from '@unovis/ts'
   import { getContext, onMount } from 'svelte'
   import { arePropsEqual } from '../../utils/props'
 

--- a/packages/svelte/src/components/brush/brush.svelte
+++ b/packages/svelte/src/components/brush/brush.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Brush, BrushConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Brush, BrushConfigInterface } from '@unovis/ts'
   import { getContext, onMount } from 'svelte'
   import { arePropsEqual } from '../../utils/props'
 

--- a/packages/svelte/src/components/crosshair/crosshair.svelte
+++ b/packages/svelte/src/components/crosshair/crosshair.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Crosshair, CrosshairConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Crosshair, CrosshairConfigInterface } from '@unovis/ts'
   import { getContext, onMount } from 'svelte'
   import { arePropsEqual } from '../../utils/props'
 

--- a/packages/svelte/src/components/free-brush/free-brush.svelte
+++ b/packages/svelte/src/components/free-brush/free-brush.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { FreeBrush, FreeBrushConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { FreeBrush, FreeBrushConfigInterface } from '@unovis/ts'
   import { getContext, onMount } from 'svelte'
   import { arePropsEqual } from '../../utils/props'
 


### PR DESCRIPTION
#56

After changes from #41, the autogenerator was still including the corresponding types in the import statements and triggering `noUnusedLocal` messages in svelte-check. This PR fixes that.

<img width="478" alt="Screen Shot 2022-12-14 at 12 29 55 PM" src="https://user-images.githubusercontent.com/52078477/207708025-3ea1664d-171e-466a-8e6b-44d99c9ff552.png">
