### PR TITLE
Vis Svelte | Fix component lifecycle logic

### DIFF
--- a/packages/svelte/autogen/component.ts
+++ b/packages/svelte/autogen/component.ts
@@ -11,21 +11,24 @@ export function getComponentCode (
   styles?: string[]
 ): string {
   const genericsStr = generics ? `<${generics?.map(g => g.name).join(', ')}>` : ''
-  const setterStr = `set${elementSuffix.charAt(0).toUpperCase()}${elementSuffix.substring(1)}`
   const configType = `${componentName}ConfigInterface${genericsStr}`
   const typeDefs = generics ? generics.map(g => `type ${g.name} = $$Generic${g.extends ? `<${g.extends}>` : ''}`) : []
-  const onDestroy = elementSuffix === 'component' ? 'removeComponent(component)' : `${setterStr}(undefined)`
   const props = requiredProps.map(c => `export let ${c.name}: ${c.type}`)
   const propDefs = dataType ? [`export let data: ${dataType} = undefined`, ...props] : props
-
+  const componentType = [componentName, genericsStr].join('')
+  const componentInit = `${componentType}(${isStandAlone ? `ref, config${dataType ? ', data' : ''}` : 'config'})`
+  const lifecycleMethod = isStandAlone
+    ? ['onMount(() => {', `component = new ${componentInit}`, 'return () => component.destroy()', '})'].join('\n    ')
+    : 'onDestroy(() => component.destroy())'
   return `<script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   ${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n  ')}
-  import { ${!isStandAlone ? 'getContext, ' : ''}onMount } from 'svelte'
+  import { ${isStandAlone ? 'onMount' : 'getContext, onDestroy'} } from 'svelte'
+  ${!isStandAlone ? '\n  import type { Lifecycle } from \'../../utils/context\'' : ''}
   import { arePropsEqual } from '../../utils/props'
-  ${typeDefs.length ? `\n  // type defs\n  ${typeDefs.join('\n  ')}` : ''}
+  ${typeDefs.length ? `// type defs\n  ${typeDefs.join('\n  ')}` : ''}
   ${propDefs.length ? `
-   // data and required props
+  // data and required props
   // eslint-disable-next-line no-undef-init\n${propDefs.join('\n  ')}\n` : ''}
   // config
   let prevConfig: ${configType}
@@ -33,15 +36,10 @@ export function getComponentCode (
   $: config = {${requiredProps.map(c => ` ${c.name},`).join(' ')} ...$$restProps }
 
   // component declaration
-  let component: ${componentName}${genericsStr}
-  ${isStandAlone ? 'let ref: HTMLDivElement' : `const { ${setterStr}${elementSuffix === 'component' ? ', removeComponent' : ''} } = getContext('container')`}
+  ${isStandAlone ? 'let' : 'const'} component${isStandAlone ? `: ${componentType}` : `= new ${componentInit}`}
+  ${isStandAlone ? 'let ref: HTMLDivElement' : 'const lifecycle = getContext<Lifecycle>(\'container\')'}
 
-  onMount(() => {
-    component = new ${componentName}${genericsStr}(${isStandAlone ? `ref, config${dataType ? ', data' : ''}` : 'config'})
-    ${isStandAlone ? '' : `${setterStr}(component)`}
-    return () => { ${isStandAlone ? 'component.destroy() ' : onDestroy} as void }
-  })
-  ${dataType ? '\n  $: component?.setData(data)' : ''}
+  ${lifecycleMethod}${dataType ? '\n  $: component?.setData(data)' : ''}
   $: if(!arePropsEqual(prevConfig, config)) {
     component?.${componentName === 'BulletLegend' ? 'update' : 'setConfig'}(config)
     prevConfig = config
@@ -52,7 +50,7 @@ export function getComponentCode (
 
 </script>
 
-<vis-${elementSuffix}${isStandAlone ? ' bind:this={ref}' : ''}/>
+<vis-${elementSuffix} ${isStandAlone ? 'bind:this={ref}' : 'use:lifecycle={component}'}/>
 ${isStandAlone ? `\n<style>\n  vis-${elementSuffix} {\n    ${styles?.join(';\n    ')};\n  }\n</style>` : ''}
 `
 }

--- a/packages/svelte/src/components/area/area.svelte
+++ b/packages/svelte/src/components/area/area.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Area, AreaConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: Area<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Area<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Area<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/axis/axis.svelte
+++ b/packages/svelte/src/components/axis/axis.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Axis, AxisConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -17,15 +18,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Axis<Datum>
-  const { setAxis } = getContext('container')
+  const component = new Axis<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Axis<Datum>(config)
-    setAxis(component)
-    return () => { setAxis(undefined) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -37,5 +33,5 @@
 
 </script>
 
-<vis-axis/>
+<vis-axis use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/brush/brush.svelte
+++ b/packages/svelte/src/components/brush/brush.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Brush, BrushConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -17,15 +18,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Brush<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Brush<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Brush<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -37,5 +33,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/chord-diagram/chord-diagram.svelte
+++ b/packages/svelte/src/components/chord-diagram/chord-diagram.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { ChordDiagram, ChordDiagramConfigInterface, ChordInputNode, ChordInputLink } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type N = $$Generic<ChordInputNode>
   type L = $$Generic<ChordInputLink>
@@ -18,15 +19,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: ChordDiagram<N, L>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new ChordDiagram<N, L>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new ChordDiagram<N, L>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -38,5 +34,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/crosshair/crosshair.svelte
+++ b/packages/svelte/src/components/crosshair/crosshair.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Crosshair, CrosshairConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -17,15 +18,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Crosshair<Datum>
-  const { setCrosshair } = getContext('container')
+  const component = new Crosshair<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Crosshair<Datum>(config)
-    setCrosshair(component)
-    return () => { setCrosshair(undefined) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -37,5 +33,5 @@
 
 </script>
 
-<vis-crosshair/>
+<vis-crosshair use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/donut/donut.svelte
+++ b/packages/svelte/src/components/donut/donut.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Donut, DonutConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -18,15 +19,10 @@
   $: config = { value, ...$$restProps }
 
   // component declaration
-  let component: Donut<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Donut<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Donut<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -38,5 +34,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/free-brush/free-brush.svelte
+++ b/packages/svelte/src/components/free-brush/free-brush.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { FreeBrush, FreeBrushConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -17,15 +18,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: FreeBrush<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new FreeBrush<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new FreeBrush<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -37,5 +33,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/graph/graph.svelte
+++ b/packages/svelte/src/components/graph/graph.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Graph, GraphConfigInterface, GraphInputNode, GraphInputLink } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type N = $$Generic<GraphInputNode>
   type L = $$Generic<GraphInputLink>
@@ -18,15 +19,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Graph<N, L>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Graph<N, L>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Graph<N, L>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -38,5 +34,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/grouped-bar/grouped-bar.svelte
+++ b/packages/svelte/src/components/grouped-bar/grouped-bar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { GroupedBar, GroupedBarConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: GroupedBar<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new GroupedBar<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new GroupedBar<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/line/line.svelte
+++ b/packages/svelte/src/components/line/line.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Line, LineConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: Line<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Line<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Line<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/sankey/sankey.svelte
+++ b/packages/svelte/src/components/sankey/sankey.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Sankey, SankeyConfigInterface, SankeyInputNode, SankeyInputLink } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type N = $$Generic<SankeyInputNode>
   type L = $$Generic<SankeyInputLink>
@@ -18,15 +19,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Sankey<N, L>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Sankey<N, L>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Sankey<N, L>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -38,5 +34,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/scatter/scatter.svelte
+++ b/packages/svelte/src/components/scatter/scatter.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Scatter, ScatterConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: Scatter<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Scatter<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Scatter<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/stacked-bar/stacked-bar.svelte
+++ b/packages/svelte/src/components/stacked-bar/stacked-bar.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { StackedBar, StackedBarConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: StackedBar<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new StackedBar<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new StackedBar<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/timeline/timeline.svelte
+++ b/packages/svelte/src/components/timeline/timeline.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Timeline, TimelineConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -18,15 +19,10 @@
   $: config = { x, ...$$restProps }
 
   // component declaration
-  let component: Timeline<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new Timeline<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Timeline<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -38,5 +34,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/tooltip/tooltip.svelte
+++ b/packages/svelte/src/components/tooltip/tooltip.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { Tooltip, TooltipConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
+  import { getContext, onDestroy } from 'svelte'
+
+  import type { Lifecycle } from '../../utils/context'
   import { arePropsEqual } from '../../utils/props'
 
 
@@ -11,15 +13,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: Tooltip
-  const { setTooltip } = getContext('container')
+  const component = new Tooltip(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new Tooltip(config)
-    setTooltip(component)
-    return () => { setTooltip(undefined) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
     prevConfig = config
@@ -30,5 +27,5 @@
 
 </script>
 
-<vis-tooltip/>
+<vis-tooltip use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/topojson-map/topojson-map.svelte
+++ b/packages/svelte/src/components/topojson-map/topojson-map.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { TopoJSONMap, TopoJSONMapConfigInterface } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type AreaDatum = $$Generic
   type PointDatum = $$Generic
@@ -19,15 +20,10 @@
   $: config = { ...$$restProps }
 
   // component declaration
-  let component: TopoJSONMap<AreaDatum, PointDatum, LinkDatum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new TopoJSONMap<AreaDatum, PointDatum, LinkDatum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new TopoJSONMap<AreaDatum, PointDatum, LinkDatum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/components/xy-labels/xy-labels.svelte
+++ b/packages/svelte/src/components/xy-labels/xy-labels.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
   import { XYLabels, XYLabelsConfigInterface, NumericAccessor } from '@unovis/ts'
-  import { getContext, onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
+  import { getContext, onDestroy } from 'svelte'
 
+  import type { Lifecycle } from '../../utils/context'
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic
 
@@ -19,15 +20,10 @@
   $: config = { x, y, ...$$restProps }
 
   // component declaration
-  let component: XYLabels<Datum>
-  const { setComponent, removeComponent } = getContext('container')
+  const component = new XYLabels<Datum>(config)
+  const lifecycle = getContext<Lifecycle>('container')
 
-  onMount(() => {
-    component = new XYLabels<Datum>(config)
-    setComponent(component)
-    return () => { removeComponent(component) as void }
-  })
-
+  onDestroy(() => component.destroy())
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)
@@ -39,5 +35,5 @@
 
 </script>
 
-<vis-component/>
+<vis-component use:lifecycle={component}/>
 

--- a/packages/svelte/src/containers/xy-container/xy-container.svelte
+++ b/packages/svelte/src/containers/xy-container/xy-container.svelte
@@ -1,45 +1,41 @@
 <script lang="ts">
-  import { XYContainer, XYComponentCore, XYContainerConfigInterface, Tooltip, Axis, AxisType, Crosshair } from '@unovis/ts'
-  import { onMount, onDestroy, setContext } from 'svelte'
+  import { XYContainer, XYComponentCore, XYContainerConfigInterface, Tooltip } from '@unovis/ts'
+  import { onMount, setContext } from 'svelte'
+  import { Lifecycle, getConfigKey } from '../../utils/context'
 
   type Datum = $$Generic
-  let components: XYComponentCore<Datum>[] = []
 
   export let data: Datum[]
 
   let chart: XYContainer<Datum>
-  let config: XYContainerConfigInterface<Datum> = {}
+  const config: XYContainerConfigInterface<Datum> = {
+    components: [],
+    crosshair: undefined,
+    tooltip: undefined,
+    xAxis: undefined,
+    yAxis: undefined,
+  }
   let ref: HTMLDivElement
 
   $: chart?.setData(data, true)
   $: chart?.updateContainer({ ...config, ...($$restProps as XYContainerConfigInterface<Datum>) })
 
   onMount(() => {
-    chart = new XYContainer(ref)
+    chart = new XYContainer(ref, config, data)
+    return () => chart.destroy()
   })
 
-  onDestroy(() => {
-    chart?.destroy()
-  })
-
-  const updateConfig = (c: XYContainerConfigInterface<Datum>) => {
-    config = { components, ...config, ...c }
-  }
-
-  setContext('container', {
-    setCrosshair: (c: Crosshair<Datum>) => updateConfig({ crosshair: c }),
-    setTooltip: (t: Tooltip) => updateConfig({ tooltip: t }),
-    setAxis: (axis: Axis<Datum>) => updateConfig({
-      [axis.config.type === AxisType.Y ? 'yAxis' : 'xAxis']: axis,
-    }),
-    setComponent: (c: XYComponentCore<Datum>) => {
-      components = [...components, c]
-      updateConfig({ components })
-    },
-    removeComponent: (c: XYComponentCore<Datum>) => {
-      components = components.filter(comp => c !== comp)
-      updateConfig({ components })
-    },
+  setContext<Lifecycle>('container', (_, c: XYComponentCore<Datum> | Tooltip) => {
+    const key = getConfigKey(c)
+    if (key && key in config) {
+      const coreComponent = key === 'components'
+      config[key] = coreComponent ? [...config.components, c] : c
+      return {
+        destroy: () => {
+          config[key] = coreComponent ? config.components.filter(comp => comp !== c) : undefined
+        },
+      }
+    }
   })
 </script>
 

--- a/packages/svelte/src/containers/xy-container/xy-container.svelte
+++ b/packages/svelte/src/containers/xy-container/xy-container.svelte
@@ -28,11 +28,11 @@
   setContext<Lifecycle>('container', (_, c: XYComponentCore<Datum> | Tooltip) => {
     const key = getConfigKey(c)
     if (key && key in config) {
-      const coreComponent = key === 'components'
-      config[key] = coreComponent ? [...config.components, c] : c
+      const isCoreComponent = key === 'components'
+      config[key] = isCoreComponent ? [...config.components, c] : c
       return {
         destroy: () => {
-          config[key] = coreComponent ? config.components.filter(comp => comp !== c) : undefined
+          config[key] = isCoreComponent ? config.components.filter(comp => comp !== c) : undefined
         },
       }
     }

--- a/packages/svelte/src/html-components/bullet-legend/bullet-legend.svelte
+++ b/packages/svelte/src/html-components/bullet-legend/bullet-legend.svelte
@@ -2,6 +2,7 @@
   // !!! This code was automatically generated. You should not change it !!!
   import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface } from '@unovis/ts'
   import { onMount } from 'svelte'
+
   import { arePropsEqual } from '../../utils/props'
 
 
@@ -20,10 +21,8 @@
 
   onMount(() => {
     component = new BulletLegend(ref, config)
-
-    return () => { component.destroy() }
+    return () => component.destroy()
   })
-
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.update(config)
     prevConfig = config

--- a/packages/svelte/src/html-components/leaflet-flow-map/leaflet-flow-map.svelte
+++ b/packages/svelte/src/html-components/leaflet-flow-map/leaflet-flow-map.svelte
@@ -2,8 +2,8 @@
   // !!! This code was automatically generated. You should not change it !!!
   import { LeafletFlowMap, LeafletFlowMapConfigInterface, GenericDataRecord, MapLibreStyleSpecs } from '@unovis/ts'
   import { onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
 
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type PointDatum = $$Generic<GenericDataRecord>
   type FlowDatum = $$Generic<GenericDataRecord>
@@ -24,10 +24,8 @@
 
   onMount(() => {
     component = new LeafletFlowMap<PointDatum, FlowDatum>(ref, config, data)
-
-    return () => { component.destroy() }
+    return () => component.destroy()
   })
-
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)

--- a/packages/svelte/src/html-components/leaflet-map/leaflet-map.svelte
+++ b/packages/svelte/src/html-components/leaflet-map/leaflet-map.svelte
@@ -2,8 +2,8 @@
   // !!! This code was automatically generated. You should not change it !!!
   import { LeafletMap, LeafletMapConfigInterface, GenericDataRecord, MapLibreStyleSpecs } from '@unovis/ts'
   import { onMount } from 'svelte'
-  import { arePropsEqual } from '../../utils/props'
 
+  import { arePropsEqual } from '../../utils/props'
   // type defs
   type Datum = $$Generic<GenericDataRecord>
 
@@ -23,10 +23,8 @@
 
   onMount(() => {
     component = new LeafletMap<Datum>(ref, config, data)
-
-    return () => { component.destroy() }
+    return () => component.destroy()
   })
-
   $: component?.setData(data)
   $: if (!arePropsEqual(prevConfig, config)) {
     component?.setConfig(config)

--- a/packages/svelte/src/utils/context.ts
+++ b/packages/svelte/src/utils/context.ts
@@ -1,0 +1,16 @@
+import { Axis, AxisType, ComponentCore, Crosshair, Tooltip, XYComponentCore } from '@unovis/ts'
+
+export type Lifecycle = (_: HTMLElement, c: ComponentCore<unknown> | Tooltip) => ({
+  destroy: () => void;
+})
+
+export function getConfigKey (c: ComponentCore<unknown> | Tooltip): string {
+  if (c instanceof Tooltip) return 'tooltip'
+  if (c instanceof Axis) {
+    if (c.config.type === AxisType.X) return 'xAxis'
+    if (c.config.type === AxisType.Y) return 'yAxis'
+  }
+  if (c instanceof Crosshair) return 'crosshair'
+  if (c instanceof XYComponentCore) return 'components'
+  if (c instanceof ComponentCore) return 'component'
+}

--- a/packages/ts/src/components/leaflet-flow-map/config.ts
+++ b/packages/ts/src/components/leaflet-flow-map/config.ts
@@ -7,7 +7,7 @@ import { LeafletMapConfig, LeafletMapConfigInterface } from 'components/leaflet-
 import { ColorAccessor, NumericAccessor } from 'types/accessor'
 import { GenericDataRecord } from 'types/data'
 
-export interface LeafletFlowMapConfigInterface<PointDatum extends GenericDataRecord, FlowDatum> extends LeafletMapConfigInterface<PointDatum> {
+export interface LeafletFlowMapConfigInterface<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> extends LeafletMapConfigInterface<PointDatum> {
   /** Flow source point longitude accessor function or value. Default:.`f => f.sourceLongitude` */
   sourceLongitude?: NumericAccessor<FlowDatum>;
   /** Flow source point latitude accessor function or value. Default: `f => f.sourceLatitude` */

--- a/packages/website/src/examples/multi-line-chart/multi-line-chart.svelte
+++ b/packages/website/src/examples/multi-line-chart/multi-line-chart.svelte
@@ -1,5 +1,6 @@
 <script lang='ts'>
-  import { VisXYContainer, VisLine, VisAxis, VisBulletLegend, Scale } from '@unovis/svelte'
+  import { Scale } from '@unovis/ts'
+  import { VisXYContainer, VisLine, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import { data, labels, CityTemps } from './data'
 
   const x = (d: CityTemps) => +(new Date(d.date))

--- a/packages/website/src/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
+++ b/packages/website/src/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
@@ -1,6 +1,7 @@
 <script lang='ts'>
   import type { NumericAccessor } from '@unovis/ts'
-  import { VisXYContainer, VisAxis, VisArea, VisBulletLegend, CurveType } from '@unovis/svelte'
+  import { CurveType } from '@unovis/ts'
+  import { VisXYContainer, VisAxis, VisArea, VisBulletLegend } from '@unovis/svelte'
   import { countries, Country, data, DataRecord } from './data'
 
   const x = (_: DataRecord, i: number) => i


### PR DESCRIPTION
Fixes #86 

@rokotyan I spent some time investigating this and it seemed like the best thing to do was to change the way we handle component lifecycles in our svelte wrapper.

Before:
- _onMount_: the setter method provided by the container is called (i.e. setAxis) which updates the container's config.
- _onDestroy_: the same method is called with `undefined` to remove it from the container's config. This created a unique issue for axis because we need to know which config key (i.e. xAxis or yAxis) to make `undefined`. A workaround could have been to make an additional method called `removeAxis` but that seemed convoluted to me. I wanted to rethink our current approach and further separate the component logic from the container's.

**Changes**:
- The component mounts/destroys independent of the container, but uses the action provided by the container as a side effect. So now after the axis mounts, the container will determine its type and create the `onDestroy` that will be called later.
- The `destroy()` method is called on the wrapped components themselves now. I'm not sure how important it is but I realized we didn't do that before like we do in our react wrapper.