### PR TITLE
Component | Graph: Fix nodeFill ignoring non-hex color values

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-fill/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-fill/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { VisSingleContainer, VisGraph } from '@unovis/react'
-
 import { generateNodeLinkData, NodeDatum } from '@src/utils/data'
 
 export const title = 'Graph: Custom Node Fills'
@@ -18,10 +17,13 @@ export const component = (): JSX.Element => {
   const colors = [
     { type: 'String', value: 'slategrey', symbol: '"' },
     { type: 'Hex', value: '#00C19A', symbol: '#' },
+    { type: 'Short hex', value: '#eff', symbol: '#' },
+    { type: 'RGB', value: 'rgb(255,255,255)', symbol: '()' },
+    { type: 'None', value: undefined, symbol: '&#0;' },
     { type: 'CSS Variable', value: 'var(--vis-color0)', symbol: '--' },
     { type: 'SVG Def', value: 'url(#gradient)', symbol: '<>' },
   ]
-  const data = generateNodeLinkData(colors.length * 2)
+  const data = generateNodeLinkData(colors.length)
   return (
     <VisSingleContainer svgDefs={svgDefs} height={600}>
       <VisGraph

--- a/packages/ts/src/utils/color.ts
+++ b/packages/ts/src/utils/color.ts
@@ -35,12 +35,7 @@ export function hexToBrightness (hex: string): number {
   return (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255
 }
 
-export function getHexString (s: string, context: HTMLElement | SVGElement): string {
-  if (s.match(/^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i)) return s
-  if (isStringCSSVariable(s)) return getCSSVariableValue(s, context)
-}
-
 export function getHexValue (s: string, context: HTMLElement | SVGElement): string {
-  const hex = getHexString(s, context)
+  const hex = isStringCSSVariable(s) ? getCSSVariableValue(s, context) : s
   return color(hex)?.formatHex()
 }


### PR DESCRIPTION
@rokotyan 

My changes in this this [commit](https://github.com/f5/unovis/commit/9dbbb56d968b7c6f7b8a1849f5d5dbdd9d03122c) produced a bug where some color values for `nodeFill` weren't recognized, resulting in icons being barely visible or not visible at all for bright node colors.

For example, providing the values `#eff` and `rgb(255,255,255)` gives us icons with the color `--vis-graph-node-icon-fill-color-bright` (before):
<img width="286" alt="Screen Shot 2023-01-03 at 3 12 26 PM" src="https://user-images.githubusercontent.com/52078477/210456994-52c618b1-8936-4fec-9ef5-fb72512ec3e2.png">

When we expect `--vis-graph-node-icon-fill-color-dark` (after):
<img width="286" alt="Screen Shot 2023-01-03 at 3 12 56 PM" src="https://user-images.githubusercontent.com/52078477/210456992-2cecadf6-1ec1-4921-a4a3-5b6fcaebc6ea.png">
