### PR TITLE
Component | Graph: Cancelling the render if the component has been destroyed

### DIFF
--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -189,6 +189,10 @@ export class Graph<
 
     // Apply layout and render
     this._calculateLayout().then((isFirstRender) => {
+      // If the component has been destroyed while the layout calculation
+      // was in progress, we cancel the render
+      if (this.isDestroyed()) return
+
       if (this._setPanels) {
         smartTransition(this._panelsGroup, duration / 2)
           .style('opacity', panels?.length ? 1 : 0)

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -136,5 +136,10 @@ export class ComponentCore<
 
   public destroy (): void {
     this.g?.remove()
+    this.element = undefined
+  }
+
+  public isDestroyed (): boolean {
+    return !this.element
   }
 }


### PR DESCRIPTION
Fixing Graph issues with React 18 Strict Mode. See #92 for more details.