### PR TITLE
Component | XYLables: Setting stroke via CSS variables

### DIFF
--- a/packages/dev/src/examples/xy-components/xy-labels/labels-stacked-bar/index.tsx
+++ b/packages/dev/src/examples/xy-components/xy-labels/labels-stacked-bar/index.tsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react'
+import { XYLabels } from '@unovis/ts'
+import { VisXYContainer, VisStackedBar, VisAxis, VisTooltip, VisCrosshair, VisXYLabels } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+
+// Style
+import s from './style.module.css'
+
+export const title = 'Stacked Bar with Labels'
+export const subTitle = 'Alerts and Data Labels'
+export const category = 'XY Labels'
+export const component = (): JSX.Element => {
+  const tooltipRef = useRef(null)
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  const data = generateXYDataRecords(10)
+
+  type AlertDataRecord = { x: number; label: string }
+  const alerts: AlertDataRecord[] = Array(10).fill(null).map(() => ({
+    x: data[Math.floor(Math.random() * data.length)].x,
+    label: '❕',
+  }))
+
+  const labelAccessor = (d: AlertDataRecord): string => d.label
+
+
+  return (
+    <div className={s.stackBarLabels}>
+      <VisXYContainer className={s.stackBarLabels} margin={{ top: 5, left: 5 }}>
+        <VisStackedBar<XYDataRecord> data={data} x={d => d.x} y={accessors} />
+        <VisAxis type='x' numTicks={10}/>
+        <VisAxis type='y' tickFormat={(y: number) => `${y}bps`}/>
+        <VisCrosshair template={(d: XYDataRecord) => `${d.x}`}/>
+        <VisTooltip ref={tooltipRef}/>
+        <VisXYLabels<XYDataRecord>
+          data={data}
+          y={d => d.y / 2}
+          x={d => d.x}
+          label={d => `${d.y.toFixed(1)} bps`}
+        />
+
+        <VisXYLabels<AlertDataRecord>
+          data={alerts}
+          y={0}
+          x={d => d.x}
+          label={labelAccessor}
+          yPositioning='absolute_percentage'
+          backgroundColor='#F64627'
+          clusterBackgroundColor='#F64627'
+          labelFontSize={8}
+          clusterFontSize={12}
+          attributes={{
+            [XYLabels.selectors.labelGroup]: {
+              alert: true,
+            },
+            [XYLabels.selectors.cluster]: {
+              cluster: true,
+            },
+          }}
+        />
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/dev/src/examples/xy-components/xy-labels/labels-stacked-bar/style.module.css
+++ b/packages/dev/src/examples/xy-components/xy-labels/labels-stacked-bar/style.module.css
@@ -1,0 +1,8 @@
+.stackBarLabels g[alert] {
+  --vis-xy-label-stroke-color: white;
+  --vis-xy-label-stroke-width: 1px;
+}
+
+.stackBarLabels g[alert][cluster] {
+  --vis-xy-label-stroke-width: 2px;
+}

--- a/packages/ts/src/components/xy-labels/config.ts
+++ b/packages/ts/src/components/xy-labels/config.ts
@@ -11,9 +11,9 @@ export interface XYLabelsConfigInterface<Datum> extends XYComponentConfigInterfa
   /** Single Y accessor function. Default: `undefined` */
   y: NumericAccessor<Datum>;
   /** Defines how to position the label horizontally: in data space or in screen space. Default: `LabelPositioning.DataSpace` */
-  xPositioning?: GenericAccessor<XYLabelPositioning, Datum>;
+  xPositioning?: GenericAccessor<XYLabelPositioning | string, Datum>;
   /** Defines how to position the label vertically: in data space or in screen space. Default: `LabelPositioning.DataSpace` */
-  yPositioning?: GenericAccessor<XYLabelPositioning, Datum>;
+  yPositioning?: GenericAccessor<XYLabelPositioning | string, Datum>;
   /** Font size accessor function or constant value in pixels. If not provided, the value of CSS variable `--vis-xy-label-font-size` will be used. Default: `undefined` */
   labelFontSize?: NumericAccessor<Datum>;
   /** Label accessor function or string. Default: `undefined` */

--- a/packages/ts/src/components/xy-labels/modules/label.ts
+++ b/packages/ts/src/components/xy-labels/modules/label.ts
@@ -58,7 +58,6 @@ export function updateLabels<Datum> (
       .attr('rx', labelFontSize)
       .attr('ry', labelFontSize)
       .style('fill', backgroundColor)
-      .style('stroke', backgroundColor)
 
     // Label
     if (!labelColor) {

--- a/packages/ts/src/components/xy-labels/style.ts
+++ b/packages/ts/src/components/xy-labels/style.ts
@@ -3,12 +3,13 @@ import { css, injectGlobal } from '@emotion/css'
 export const globalStyles = injectGlobal`
   :root {
     --vis-xy-label-cursor: default;
-    --vis-xy-label-fill-color: var(--vis-color-main);
-    --vis-xy-label-stroke-color: var(--vis-color-main);
+    // Undefined by default to allow proper fallback to var(--vis-color-main)
+    /* --vis-xy-label-fill-color */
+    --vis-xy-label-stroke-color: none;
     --vis-xy-label-stroke-width: 0px;
     --vis-xy-label-fill-opacity: 1;
     --vis-xy-label-stroke-opacity: 1;
-    --vis-xy-label-hover-stroke-width: 2px;
+    --vis-xy-label-hover-stroke-width: 1px;
     --vis-xy-label-font-size: 12px;
     --vis-xy-label-cluster-font-size: 14px;
 
@@ -27,7 +28,7 @@ export const labelGroup = css`
 
   > rect, text {
     cursor: var(--vis-xy-label-cursor);
-    fill: var(--vis-xy-label-fill-color);
+    fill: var(--vis-xy-label-fill-color, var(--vis-color-main));
     fill-opacity: var(--vis-xy-label-fill-opacity);
     stroke-opacity: var(--vis-xy-label-stroke-opacity);
   }


### PR DESCRIPTION
Fixes #98. Stroke can now be set via CSS variables:
```css
.stackBarLabels g[alert] {
  --vis-xy-label-stroke-color: white;
  --vis-xy-label-stroke-width: 1px;
}

.stackBarLabels g[alert][cluster] {
  --vis-xy-label-stroke-width: 2px;
}

```
![Screen Shot 2023-01-12 at 9 49 54 AM](https://user-images.githubusercontent.com/755708/212141819-72da13f0-67db-499a-9615-4bc56caa51a7.png)
