### PR TITLE
React: Fix rendering issue

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
@@ -4,7 +4,7 @@ import { Graph } from '@unovis/ts'
 import { generateNodeLinkData, NodeDatum, LinkDatum } from '@src/utils/data'
 
 export const title = 'Basic Graph'
-export const subTitle = 'Generated Data'
+export const subTitle = 'Select Node on Click'
 export const category = 'Graph'
 
 export const component = (): JSX.Element => {

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
@@ -1,0 +1,44 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { VisSingleContainer, VisGraph, VisGraphRef } from '@unovis/react'
+import { Graph } from '@unovis/ts'
+import { generateNodeLinkData, NodeDatum, LinkDatum } from '@src/utils/data'
+
+export const title = 'Basic Graph'
+export const subTitle = 'Generated Data'
+export const category = 'Graph'
+
+export const component = (): JSX.Element => {
+  const data = generateNodeLinkData()
+  const ref = useRef<VisGraphRef<NodeDatum, LinkDatum>>(null)
+  const [selectedNode, setSelectedNode] = useState<string | undefined>()
+  const [text, setText] = useState<string>()
+
+  useEffect(() => {
+    const external = selectedNode ?? 'undefined'
+    const internal = ref.current?.component?.config.selectedNodeId ?? 'undefined'
+    setText([external, internal].join(' / '))
+  }, [selectedNode])
+
+  return (
+    <>
+      <div>Selected node: {text}</div>
+      <VisSingleContainer data={data} height={600}>
+        <VisGraph
+          ref={ref}
+          nodeIcon={(n: NodeDatum) => n.id}
+          events={{
+            [Graph.selectors.node]: {
+              click: useCallback((n: NodeDatum) => { setSelectedNode(n.id) }, []),
+            },
+            [Graph.selectors.background]: {
+              click: useCallback(() => { setSelectedNode(undefined) }, []),
+            },
+          }}
+          selectedNodeId={selectedNode}
+        />
+      </VisSingleContainer>
+
+    </>
+  )
+}
+

--- a/packages/dev/webpack.config.js
+++ b/packages/dev/webpack.config.js
@@ -65,6 +65,8 @@ module.exports = {
       core: path.resolve(__dirname, '../ts/src/core/'),
       styles: path.resolve(__dirname, '../ts/src/styles/'),
       'data-models': path.resolve(__dirname, '../ts/src/data-models/'),
+
+      react: path.resolve('./node_modules/react'),
     },
   },
   devServer: {

--- a/packages/react/src/utils/react.ts
+++ b/packages/react/src/utils/react.ts
@@ -1,12 +1,12 @@
-import { ReactElement, ReactNode } from 'react'
+import { Children, ReactElement, ReactNode } from 'react'
 import _isEqual from 'lodash-es/isEqual.js'
 
 export function arePropsEqual<PropTypes extends { children?: ReactNode }> (prevProps: PropTypes, nextProps: PropTypes): boolean {
   if (typeof prevProps.children !== typeof nextProps.children) return false
 
-  if (Array.isArray(prevProps.children) && Array.isArray(nextProps.children)) {
-    const prevChildren = prevProps.children as ReactElement[]
-    const nextChildren = nextProps.children as ReactElement[]
+  if (prevProps.children && nextProps.children) {
+    const prevChildren = Children.toArray(prevProps.children) as ReactElement[]
+    const nextChildren = Children.toArray(nextProps.children) as ReactElement[]
     if (prevChildren.length !== nextChildren.length) return false
 
     for (let i = 0; i < nextChildren.length; i += 1) {


### PR DESCRIPTION
#108 

Previously, our `arePropsEqual` would only check if child props had changed for multiple children, but in the case of only one child it would always return `true`. This prevented the re-rendering of the child component even though it had updated props.

Added a new dev demo page based on #107 to reflect the change.