### PR TITLE
Fix: Donut empty segments

### DIFF
--- a/packages/dev/src/examples/misc/donut/donut-empty-segments/index.tsx
+++ b/packages/dev/src/examples/misc/donut/donut-empty-segments/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+
+export const title = 'Donut: Empty Segments'
+export const subTitle = '+ Padding'
+export const category = 'Donut'
+
+export const component = (): JSX.Element => {
+  const data = [0, 2, 0, 4, 0, 1]
+  return (
+    <VisSingleContainer height={400}>
+      <VisDonut
+        value={d => d}
+        data={data}
+        showEmptySegments={true}
+        padAngle={0.02}
+        arcWidth={100}
+      />
+    </VisSingleContainer>
+  )
+}
+

--- a/packages/ts/src/components/donut/config.ts
+++ b/packages/ts/src/components/donut/config.ts
@@ -29,10 +29,12 @@ export interface DonutConfigInterface<Datum> extends ComponentConfigInterface {
   centralSubLabel?: string;
   /** Enables wrapping for the sub-label. Default: `true` */
   centralSubLabelWrap?: boolean;
-  /** When true, the component will display empty segments (the ones that have `0` values) as thin lines.
+  /** When true, the component will display empty segments (the ones that have `0` values) as tiny slices.
    * Default: `false`
   */
   showEmptySegments?: boolean;
+  /** Angular size for empty segments in radians. Default: `0.5 * Math.PI / 180` */
+  emptySegmentAngle?: number;
   /** Show donut background. The color is configurable via
    * the `--vis-donut-background-color` and `--vis-dark-donut-background-color` CSS variables.
    * Default: `true`
@@ -57,6 +59,7 @@ export class DonutConfig<Datum> extends ComponentConfig implements DonutConfigIn
   centralSubLabel = undefined
   centralSubLabelWrap = true
   showEmptySegments = false
+  emptySegmentAngle = 0.5 * Math.PI / 180
   showBackground = true
   backgroundAngleRange = undefined
 }

--- a/packages/ts/src/components/donut/modules/arc.ts
+++ b/packages/ts/src/components/donut/modules/arc.ts
@@ -22,7 +22,7 @@ export function createArc<Datum> (
   config: DonutConfig<Datum>
 ): void {
   selection
-    .style('fill', (d, i) => getColor(d.data, config.color, i))
+    .style('fill', d => getColor(d.data, config.color, d.index))
     .style('opacity', 0)
     .each((d, i, els) => {
       const arcNode: ArcNode = els[i]
@@ -33,6 +33,7 @@ export function createArc<Datum> (
         endAngle: angleCenter + angleHalfWidth,
         innerRadius: d.innerRadius,
         outerRadius: d.outerRadius,
+        padAngle: d.padAngle,
       }
     })
 }
@@ -45,7 +46,7 @@ export function updateArc<Datum> (
 ): void {
   selection
     .style('transition', `fill ${duration}ms`) // Animate color with CSS because we're using CSS-variables
-    .style('fill', (d, i) => getColor(d.data, config.color, i))
+    .style('fill', d => getColor(d.data, config.color, d.index))
 
   const setOpacity = (d: DonutArcDatum<Datum>): number => (config.showEmptySegments || d.value) ? 1 : 0
   if (duration) {
@@ -54,7 +55,13 @@ export function updateArc<Datum> (
 
     transition.attrTween('d', (d, i, els) => {
       const arcNode: ArcNode = els[i]
-      const nextAnimState: DonutArcAnimState = { startAngle: d.startAngle, endAngle: d.endAngle, innerRadius: d.innerRadius, outerRadius: d.outerRadius }
+      const nextAnimState: DonutArcAnimState = {
+        startAngle: d.startAngle,
+        endAngle: d.endAngle,
+        innerRadius: d.innerRadius,
+        outerRadius: d.outerRadius,
+        padAngle: d.padAngle,
+      }
       const datum = interpolate(arcNode._animState, nextAnimState)
 
       return (t: number): string => {

--- a/packages/ts/src/components/donut/types.ts
+++ b/packages/ts/src/components/donut/types.ts
@@ -1,10 +1,17 @@
 import { PieArcDatum } from 'd3-shape'
 
+export type DonutDatum<Datum> = {
+  datum: Datum;
+  /** Original datum index as in unfiltered data */
+  index: number;
+}
+
 /** Data type for Donut Arc Generator */
 export interface DonutArcDatum<Datum> extends PieArcDatum<Datum> {
+  /** Original datum index as in unfiltered data */
   index: number;
   innerRadius: number;
   outerRadius: number;
 }
 
-export type DonutArcAnimState = { startAngle: number; endAngle: number; innerRadius: number; outerRadius: number }
+export type DonutArcAnimState = { startAngle: number; endAngle: number; innerRadius: number; outerRadius: number; padAngle?: number }

--- a/packages/website/docs/misc/Donut.mdx
+++ b/packages/website/docs/misc/Donut.mdx
@@ -64,14 +64,26 @@ Customize the colors for each segment with a `colorAccessor` function:
 Providing a value to the `cornerRadius` property adds rounded corners to your _Donut_'s segments proportional to the _Donut_'s `arcWidth`.
 <InputWrapper {...defaultProps()} property="cornerRadius" defaultValue={5} inputType="range" inputProps={{ min: 0, max: 20}}/>
 
-## Pad angle
+### Pad angle
 Pad each segment with the `padAngle` property.
 <DocWrapper {...defaultProps()} padAngle={0.1}/>
 
-## Show Empty Segments
-When some segments of the donut are empty (i.e. they have 0 values), you can still show them as thin lines by setting
-`showEmptySegments` to `true`;
-<InputWrapper {...defaultProps()} data={[1,2,3,0,4,0,5]} property="showEmptySegments" inputType="checkbox" defaultValue={true}/>
+### Empty Segments
+When segments are empty (i.e. when their values are 0), you may still want them displayed in your _Donut_ as thin slices.
+To do this, set `showEmptySegments` to `true`:
+
+<InputWrapper {...defaultProps()} data={[1, 2, 0, 4, 0, 6]} property="showEmptySegments" inputType="checkbox" defaultValue={true}/>
+
+
+#### Customizing empty segment size
+When `showEmptySegments` is enabled, the default size for empty segments is `0.5 * π / 180` radians. You can tweak this to your
+liking with the `emptySegmentAngle` property which accepts a `number` in radians.
+For example, setting `emptySegmentAngle` to `Math.PI / 12` looks like:
+
+<DocWrapper {...defaultProps()} data={[1, 2, 0, 4, 0, 6]} emptySegmentAngle={Math.PI / 12} showEmptySegments excludeTabs/>
+
+####
+Note that this property will have no effect if `showEmptySegments` is `false`.
 
 ## Background
 By default, _Donut_ has a background underneath the segments, which is useful when your chart is empty. You can turn it off by setting


### PR DESCRIPTION
This PR fixes the appearance of empty segments when `padAngle` is set.

```
showEmptySegments: true
```
<img width="379" alt="Screen Shot 2023-01-23 at 4 21 05 PM" src="https://user-images.githubusercontent.com/52078477/214182468-ff1149c8-5272-4395-a6ab-510554b86882.png">

```
showEmptySegments: true
padAngle: 0.02
```
<img width="434" alt="Screen Shot 2023-01-23 at 4 16 58 PM" src="https://user-images.githubusercontent.com/52078477/214182231-72d6c2a3-3217-4879-b023-26ba6e88c7f0.png">