### PR TITLE
Graph: Fixing labels rendering for links, configurable label text color

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-link-label/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-link-label/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { VisSingleContainer, VisGraph } from '@unovis/react'
+import { generateNodeLinkData, NodeDatum, LinkDatum } from '@src/utils/data'
+import { GraphCircleLabel } from '@unovis/ts'
+
+export const title = 'Node and Link Circle Labels'
+export const subTitle = 'with custom configuration'
+export const category = 'Graph'
+
+export const component = (): JSX.Element => {
+  const data = generateNodeLinkData(15)
+  const linkLabels: GraphCircleLabel[] = data.links.map((link, i) => {
+    const hasCustomAppearance = Math.random() > 0.8
+    return {
+      text: hasCustomAppearance ? `${i}${i}${i}` : `${i * 10}`,
+      fontSize: hasCustomAppearance ? '8px' : undefined,
+      radius: hasCustomAppearance ? 0 : 5 + 10 * Math.random(),
+      cursor: 'pointer',
+      textColor: hasCustomAppearance ? 'blue' : undefined,
+    }
+  })
+
+  const getNodeSideLabels = (d: NodeDatum, i: number): GraphCircleLabel[] => i === 5
+    ? [{ text: '🏈', color: '#eee' }, { text: '⚾️', color: '#ff351d' }]
+    : [{ text: String.fromCharCode(70 + i), color: '#eee', radius: 8 }]
+
+  return (
+    <>
+      <VisSingleContainer data={data} height={600}>
+        <VisGraph<NodeDatum, LinkDatum>
+          nodeIcon={n => n.id}
+          linkLabel={(l, i) => linkLabels[i as number]}
+          nodeSideLabels={getNodeSideLabels}
+        />
+      </VisSingleContainer>
+    </>
+  )
+}
+

--- a/packages/ts/src/components/graph/modules/link/index.ts
+++ b/packages/ts/src/components/graph/modules/link/index.ts
@@ -181,22 +181,27 @@ export function updateLinks<N extends GraphInputNode, L extends GraphInputLink> 
 
     labelsEnter.append('text')
       .attr('class', linkSelectors.labelContent)
-      .attr('dy', 1)
 
     // Update
     const labelsUpdate = labels.merge(labelsEnter)
 
     smartTransition(labelsUpdate.select(`.${linkSelectors.labelCircle}`), duration)
-      .attr('r', LINK_LABEL_RADIUS)
+      .attr('r', label => label.radius ?? LINK_LABEL_RADIUS)
       .style('fill', label => label.color)
 
     labelsUpdate.select(`.${linkSelectors.labelContent}`)
       .text(label => label.text)
-      .style('fill', label => getLinkLabelTextColor(label))
-      .style('font-size', label => `${10 / Math.pow(label.text.toString().length, 0.3)}px`)
+      .attr('dy', '0.1em')
+      .style('fill', label => label.textColor ?? getLinkLabelTextColor(label))
+      .style('font-size', label => {
+        if (label.fontSize) return label.fontSize
+        const radius = label.radius ?? LINK_LABEL_RADIUS
+        return `${radius / Math.pow(label.text.toString().length, 0.4)}px`
+      })
 
     smartTransition(labelsUpdate, duration)
       .attr('transform', labelTranslate)
+      .style('cursor', label => label.cursor)
       .style('opacity', 1)
 
     // Exit

--- a/packages/ts/src/components/graph/modules/link/style.ts
+++ b/packages/ts/src/components/graph/modules/link/style.ts
@@ -105,7 +105,7 @@ export const labelGroups = css`
 
 export const labelGroup = css`
   label: label-group;
-  pointer-events: none;
+  pointer-events: all;
 `
 
 export const labelCircle = css`

--- a/packages/ts/src/components/graph/modules/node/index.ts
+++ b/packages/ts/src/components/graph/modules/node/index.ts
@@ -206,7 +206,7 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
     // Update Node Icon
     icon
       .style('font-size', `${getNumber(d, nodeIconSize, d._index) ?? 2.5 * Math.sqrt(nodeSizeValue)}px`)
-      .attr('dy', 1)
+      .attr('dy', '0.1em')
       .style('fill', getNodeIconColor(d, nodeFill, d._index, selection.node()))
       .html(getString(d, nodeIcon, d._index))
 
@@ -226,8 +226,8 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
 
     // Side label text
     sideLabelsUpdate.select(`.${nodeSelectors.sideLabel}`).html(d => d.text)
-      .attr('dy', '1px')
-      .style('fill', l => getSideLabelTextColor(l, selection.node()))
+      .attr('dy', '0.1em')
+      .style('fill', l => l.textColor ?? getSideLabelTextColor(l, selection.node()))
       .style('font-size', l => l.fontSize ?? `${(2 + (l.radius ?? SIDE_LABEL_DEFAULT_RADIUS)) / Math.pow(l.text.toString().length, 0.3)}px`)
       // Side label circle background
     sideLabelsUpdate.select(`.${nodeSelectors.sideLabelBackground}`)

--- a/packages/ts/src/components/graph/types.ts
+++ b/packages/ts/src/components/graph/types.ts
@@ -55,9 +55,10 @@ export enum GraphLayoutType {
 
 export type GraphCircleLabel = {
   text: string;
+  textColor?: string | null;
   color?: string | null;
   cursor?: string | null;
-  fontSize?: string;
+  fontSize?: string | null;
   radius?: number;
 }
 

--- a/packages/ts/src/types/accessor.ts
+++ b/packages/ts/src/types/accessor.ts
@@ -1,5 +1,5 @@
-export type NumericAccessor<Datum> = ((d: Datum, i?: number, ...any) => number | null) | number | null | undefined
-export type StringAccessor<Datum> = ((d: Datum, i?: number, ...any) => string | null) | string | null
-export type ColorAccessor<Datum> = ((d: Datum, i?: number, ...any) => string | null | undefined) | string | string[] | null | undefined
-export type BooleanAccessor<Datum> = ((d: Datum, i?: number, ...any) => boolean | null) | boolean | null
-export type GenericAccessor<ReturnType, Datum> = ((d: Datum, i?: number, ...any) => ReturnType | null | undefined) | ReturnType | null | undefined
+export type NumericAccessor<Datum> = ((d: Datum, i: number, ...any) => number | null) | number | null | undefined
+export type StringAccessor<Datum> = ((d: Datum, i: number, ...any) => string | null) | string | null
+export type ColorAccessor<Datum> = ((d: Datum, i: number, ...any) => string | null | undefined) | string | string[] | null | undefined
+export type BooleanAccessor<Datum> = ((d: Datum, i: number, ...any) => boolean | null) | boolean | null
+export type GenericAccessor<ReturnType, Datum> = ((d: Datum, i: number, ...any) => ReturnType | null | undefined) | ReturnType | null | undefined

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -214,9 +214,10 @@ function to `nodeSideLabels` that returns an array of `GraphCircleLabel` objects
 ```ts
 type GraphCircleLabel = {
   text: string;
+  textColor?: string; // Optional text color. By default, the text color will depend on the brightness of the circle color.
   color?: string | null; // Optional color
   cursor?: string | null; // Optional cursor on hover
-  fontSize?: string; // Optional font size as a CSS string
+  fontSize?: string | null; // Optional font size as a CSS string
   radius?: number; // Circle radius in pixels
 }
 ```


### PR DESCRIPTION
<img width="1281" alt="Screen Shot 2023-01-25 at 8 52 56 AM" src="https://user-images.githubusercontent.com/755708/214630233-a78dbe6b-8620-4c20-89a5-0eed9f0a7cf2.png">
Addresses issue #114:

* Fixing link labels support for `fontSize`, `color` and `cursor`;
* Circle labels now support a new configurable `textColor` property;
* Better vertical alignment of circle labels;
* New dev app example;


