### PR TITLE
Graph: Configurable node labels trimming

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { VisSingleContainer, VisGraph } from '@unovis/react'
+import { generateNodeLinkData, NodeDatum, LinkDatum } from '@src/utils/data'
+import { sample } from '@src/utils/array'
+
+export const title = 'Node Labels and Sub-labels'
+export const subTitle = 'Trimming'
+export const category = 'Graph'
+
+export const component = (): JSX.Element => {
+  const data = generateNodeLinkData(15)
+  const regions = ['Australian', 'South American', 'Siberian', 'European', 'Asian']
+  const colors = ['Vermilion', 'Verdigris', 'Bisque', 'Cattleya']
+  const animals = ['Elephant', 'Mountain Lion', 'Sea Otter', 'Bear']
+  const labels = data.nodes.map((d, i) => ({
+    label: `${sample(animals)} ${sample(colors)}`,
+    subLabel: `${sample(regions)} ${sample(colors)} ${sample(animals)}`,
+    labelTrim: Math.random() > 0.5,
+    subLabelTrim: Math.random() > 0.5,
+  }))
+  return (
+    <VisSingleContainer data={data} height={600}>
+      <VisGraph<NodeDatum, LinkDatum>
+        nodeLabel={(_, i) => labels[i].label}
+        nodeLabelTrim={(_, i) => labels[i].labelTrim}
+        nodeSubLabel={(_, i) => labels[i].subLabel}
+        nodeSubLabelTrim={(_, i) => labels[i].subLabelTrim}
+      />
+    </VisSingleContainer>
+  )
+}
+

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { VisSingleContainer, VisGraph } from '@unovis/react'
+import { TrimMode } from '@unovis/ts'
 import { generateNodeLinkData, NodeDatum, LinkDatum } from '@src/utils/data'
 import { sample } from '@src/utils/array'
 
@@ -12,19 +13,28 @@ export const component = (): JSX.Element => {
   const regions = ['Australian', 'South American', 'Siberian', 'European', 'Asian']
   const colors = ['Vermilion', 'Verdigris', 'Bisque', 'Cattleya']
   const animals = ['Elephant', 'Mountain Lion', 'Sea Otter', 'Bear']
+  const trimModes = Object.values(TrimMode)
   const labels = data.nodes.map((d, i) => ({
     label: `${sample(animals)} ${sample(colors)}`,
     subLabel: `${sample(regions)} ${sample(colors)} ${sample(animals)}`,
-    labelTrim: Math.random() > 0.5,
-    subLabelTrim: Math.random() > 0.5,
+    labelTrim: Math.random() > 0.2,
+    labelTrimMode: sample(trimModes),
+    labelTrimLength: Math.round(3 + 12 * Math.random()),
+    subLabelTrim: Math.random() > 0.2,
+    subLabelTrimMode: sample(trimModes),
+    subLabelTrimLength: Math.round(3 + 12 * Math.random()),
   }))
   return (
     <VisSingleContainer data={data} height={600}>
       <VisGraph<NodeDatum, LinkDatum>
         nodeLabel={(_, i) => labels[i].label}
         nodeLabelTrim={(_, i) => labels[i].labelTrim}
+        nodeLabelTrimMode={(_, i) => labels[i].labelTrimMode}
+        nodeLabelTrimLength={(_, i) => labels[i].labelTrimLength}
         nodeSubLabel={(_, i) => labels[i].subLabel}
         nodeSubLabelTrim={(_, i) => labels[i].subLabelTrim}
+        nodeSubLabelTrimMode={(_, i) => labels[i].subLabelTrimMode}
+        nodeSubLabelTrimLength={(_, i) => labels[i].subLabelTrimLength}
       />
     </VisSingleContainer>
   )

--- a/packages/dev/src/utils/array.ts
+++ b/packages/dev/src/utils/array.ts
@@ -4,3 +4,5 @@ export function groupBy<T extends Record<string, any>> (arr: T[], key: string): 
     {} as Record<string, T[]>
   )
 }
+
+export const sample = <T>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)]

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -143,8 +143,12 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   nodeIconSize?: NumericAccessor<N>;
   /** Node label accessor function or constant value. Default: `node => node.label` */
   nodeLabel?: StringAccessor<N>;
+  /** Defines whether to trim the node labels or not. Default: `true` */
+  nodeLabelTrim?: BooleanAccessor<N>;
   /** Node sub-label accessor function or constant value: Default: `''` */
   nodeSubLabel?: StringAccessor<N>;
+  /** Defines whether to trim the node sub-labels or not. Default: `true` */
+  nodeSubLabelTrim?: BooleanAccessor<N>;
   /** Node circular side labels accessor function. The function should return an array of GraphCircleLabel objects. Default: `undefined` */
   nodeSideLabels?: GenericAccessor<GraphCircleLabel[], N>;
   /** Node bottom icon accessor function. Default: `undefined` */
@@ -227,7 +231,9 @@ export class GraphConfig<N extends GraphInputNode, L extends GraphInputLink> ext
   nodeIcon = (n: N): string => n['icon']
   nodeIconSize = undefined
   nodeLabel = (n: N): string => n['label']
+  nodeLabelTrim = true
   nodeSubLabel = ''
+  nodeSubLabelTrim = true
   nodeSideLabels = undefined
   nodeBottomIcon = undefined
   nodeDisabled = false

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -3,6 +3,7 @@
 import { ComponentConfigInterface, ComponentConfig } from 'core/component/config'
 
 // Types
+import { TrimMode } from 'types/text'
 import { GraphInputLink, GraphInputNode } from 'types/graph'
 import { BooleanAccessor, ColorAccessor, NumericAccessor, StringAccessor, GenericAccessor } from 'types/accessor'
 
@@ -145,10 +146,18 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   nodeLabel?: StringAccessor<N>;
   /** Defines whether to trim the node labels or not. Default: `true` */
   nodeLabelTrim?: BooleanAccessor<N>;
+  /** Node label trimming mode. Default: `TrimMode.Middle` */
+  nodeLabelTrimMode?: GenericAccessor<TrimMode | string, N>;
+  /** Node label maximum allowed text length above which the label will be trimmed. Default: `15` */
+  nodeLabelTrimLength?: NumericAccessor<N>;
   /** Node sub-label accessor function or constant value: Default: `''` */
   nodeSubLabel?: StringAccessor<N>;
   /** Defines whether to trim the node sub-labels or not. Default: `true` */
   nodeSubLabelTrim?: BooleanAccessor<N>;
+  /** Node sub-label trimming mode. Default: `TrimMode.Middle` */
+  nodeSubLabelTrimMode?: GenericAccessor<TrimMode | string, N>;
+  /** Node sub-label maximum allowed text length above which the label will be trimmed. Default: `15` */
+  nodeSubLabelTrimLength?: NumericAccessor<N>;
   /** Node circular side labels accessor function. The function should return an array of GraphCircleLabel objects. Default: `undefined` */
   nodeSideLabels?: GenericAccessor<GraphCircleLabel[], N>;
   /** Node bottom icon accessor function. Default: `undefined` */
@@ -232,8 +241,12 @@ export class GraphConfig<N extends GraphInputNode, L extends GraphInputLink> ext
   nodeIconSize = undefined
   nodeLabel = (n: N): string => n['label']
   nodeLabelTrim = true
+  nodeLabelTrimLength = 15
+  nodeLabelTrimMode = TrimMode.Middle
   nodeSubLabel = ''
   nodeSubLabelTrim = true
+  nodeSubLabelTrimLength = 15
+  nodeSubLabelTrimMode = TrimMode.Middle
   nodeSideLabels = undefined
   nodeBottomIcon = undefined
   nodeDisabled = false

--- a/packages/ts/src/components/graph/modules/node/index.ts
+++ b/packages/ts/src/components/graph/modules/node/index.ts
@@ -119,8 +119,9 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
 ): Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> | Transition<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> {
   const {
     nodeGaugeAnimDuration, nodeStrokeWidth, nodeShape, nodeSize, nodeGaugeValue, nodeGaugeFill,
-    nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeSubLabel, nodeSubLabelTrim, nodeSideLabels,
-    nodeStroke, nodeFill, nodeBottomIcon,
+    nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength,
+    nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength,
+    nodeSideLabels, nodeStroke, nodeFill, nodeBottomIcon,
   } = config
 
   // Re-create nodes to update shapes if they were changes
@@ -246,8 +247,12 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
     // Set label and sub-label text
     const labelText = getString(d, nodeLabel, d._index)
     const sublabelText = getString(d, nodeSubLabel, d._index)
-    const labelTextTrimmed = getBoolean(d, nodeLabelTrim, d._index) ? trimText(labelText) : labelText
-    const sublabelTextTrimmed = getBoolean(d, nodeSubLabelTrim, d._index) ? trimText(sublabelText) : sublabelText
+    const labelTextTrimmed = getBoolean(d, nodeLabelTrim, d._index)
+      ? trimText(labelText, getNumber(d, nodeLabelTrimLength, d._index), getValue(d, nodeLabelTrimMode, d._index))
+      : labelText
+    const sublabelTextTrimmed = getBoolean(d, nodeSubLabelTrim, d._index)
+      ? trimText(sublabelText, getNumber(d, nodeSubLabelTrimLength, d._index), getValue(d, nodeSubLabelTrimMode, d._index))
+      : sublabelText
 
     labelTextContent.text(labelTextTrimmed)
     sublabelTextContent.text(sublabelTextTrimmed)

--- a/packages/ts/src/components/graph/modules/node/index.ts
+++ b/packages/ts/src/components/graph/modules/node/index.ts
@@ -119,7 +119,8 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
 ): Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> | Transition<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> {
   const {
     nodeGaugeAnimDuration, nodeStrokeWidth, nodeShape, nodeSize, nodeGaugeValue, nodeGaugeFill,
-    nodeIcon, nodeIconSize, nodeLabel, nodeSubLabel, nodeSideLabels, nodeStroke, nodeFill, nodeBottomIcon,
+    nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeSubLabel, nodeSubLabelTrim, nodeSideLabels,
+    nodeStroke, nodeFill, nodeBottomIcon,
   } = config
 
   // Re-create nodes to update shapes if they were changes
@@ -245,8 +246,8 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
     // Set label and sub-label text
     const labelText = getString(d, nodeLabel, d._index)
     const sublabelText = getString(d, nodeSubLabel, d._index)
-    const labelTextTrimmed = trimText(labelText)
-    const sublabelTextTrimmed = trimText(sublabelText)
+    const labelTextTrimmed = getBoolean(d, nodeLabelTrim, d._index) ? trimText(labelText) : labelText
+    const sublabelTextTrimmed = getBoolean(d, nodeSubLabelTrim, d._index) ? trimText(sublabelText) : sublabelText
 
     labelTextContent.text(labelTextTrimmed)
     sublabelTextContent.text(sublabelTextTrimmed)

--- a/packages/ts/src/components/sankey/config.ts
+++ b/packages/ts/src/components/sankey/config.ts
@@ -110,7 +110,7 @@ export interface SankeyConfigInterface<N extends SankeyInputNode, L extends Sank
   labelMaxWidth?: number;
   /** Expand trimmed label on hover. Default: `true` */
   labelExpandTrimmedOnHover?: boolean;
-  /** Label trimming mode. Default: `TrimMode.MIDDLE` */
+  /** Label trimming mode. Default: `TrimMode.Middle` */
   labelTrimMode?: TrimMode;
   /** Label font size in pixels. If not provided, the value of CSS variable `--vis-sankey-node-label-font-size` will be used. Default: `undefined` */
   labelFontSize?: number;

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -7,7 +7,7 @@ import { TrimMode, VerticalAlign, WrapMode, WrapTextOptions } from 'types/text'
 import { isArray, flatten } from 'utils/data'
 
 export function trimTextStart (str = '', maxLength = 15): string {
-  return str.length > maxLength ? `…${str.substr(0, maxLength)}` : str
+  return str.length > maxLength ? `…${str.substr(str.length - maxLength, maxLength)}` : str
 }
 
 export function trimTextMiddle (str = '', maxLength = 15): string {

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -190,6 +190,9 @@ Node label and sub-label can be set by providing the `nodeLabel` and `nodeSubLab
 :::tip
 By default, long labels will be trimmed and displayed in full only on hover. You can control that behaviour via the
 `nodeLabelTrim` and `nodeSubLabelTrim` config properties.
+
+You can also configure how trimming works by specifying custom  `nodeLabelTrimMode`, `nodeLabelTrimLength`, `nodeSubLabelTrimMode`,
+and `nodeSubLabelTrimLength` values.
 :::
 
 <GraphDoc

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -187,7 +187,15 @@ The icon font can be set via the `--vis-graph-icon-font-family` CSS variable.
 #### At the bottom
 Node label and sub-label can be set by providing the `nodeLabel` and `nodeSubLabel` accessor functions.
 
-<GraphDoc nodeLabel={n => `${n.id}`}  nodeSubLabel={n => 'node'}/>
+:::tip
+By default, long labels will be trimmed and displayed in full only on hover. You can control that behaviour via the
+`nodeLabelTrim` and `nodeSubLabelTrim` config properties.
+:::
+
+<GraphDoc
+  nodeLabel={(n, i) => i === 9 ? 'Long labels will' : `${n.id}`}
+  nodeSubLabel={(n, i) => i === 9 ? 'be trimmed by default' : 'node'}
+/>
 
 The font size of the labels can be controlled via CSS variables. Here is a full list of the variables available to
 control the appearance of the node labels, and their default values:


### PR DESCRIPTION
#120
<img width="1404" alt="image" src="https://user-images.githubusercontent.com/755708/214642874-c8963c2b-ae03-4c7c-8307-bd513f2a42f5.png">

* Configurable trimming of node labels and sub-labels via new `nodeLabelTrim` and `nodeSubLabelTrim` config properties;
* New dev app example
* Updated docs: <img width="1020" alt="Screen Shot 2023-01-26 at 1 17 18 PM" src="https://user-images.githubusercontent.com/755708/214953715-38456c8d-016d-4b42-a6a4-5797ee134fbe.png">
