### PR TITLE
Timeline: Enabling pointer-events for lines even when no events were set up

### DIFF
--- a/packages/dev/src/examples/xy-components/timeline-tooltip/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline-tooltip/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { VisXYContainer, VisTimeline, VisAxis, VisTooltip } from '@unovis/react'
+import { Timeline } from '@unovis/ts'
+
+import { TimeDataRecord, generateTimeSeries } from '@src/utils/data'
+
+export const title = 'Tooltip and Scrolling'
+export const subTitle = 'Generated Data'
+export const category = 'Timeline'
+
+export const component = (): JSX.Element => {
+  const data = generateTimeSeries(25, 10, 10).map((d, i) => ({
+    ...d,
+  }))
+  return (<>
+    <VisXYContainer<TimeDataRecord> data={data} height={300}>
+      <VisTimeline x={(d: TimeDataRecord) => d.timestamp} rowHeight={50} lineWidth={10} showLabels/>
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => new Date(x).toDateString()}/>
+      <VisTooltip triggers={{
+        [Timeline.selectors.line]: (d: TimeDataRecord) =>
+          `${(new Date(d.timestamp)).toDateString()} — ${(new Date(d.timestamp + d.length)).toDateString()}`,
+      }}/>
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/dev/src/utils/data.ts
+++ b/packages/dev/src/utils/data.ts
@@ -38,12 +38,12 @@ export function generateXYDataRecords (n = 10): XYDataRecord[] {
   }))
 }
 
-export function generateTimeSeries (n = 10, types = n): TimeDataRecord[] {
+export function generateTimeSeries (n = 10, types = n, lengthMultiplier = 1): TimeDataRecord[] {
   const groups = Array(types).fill(0).map((_, i) => String.fromCharCode(i + 65))
   return Array(n).fill(0).map((_, i: number) => ({
-    timestamp: Date.now() + i * 1000 * 60 * 60 * 24,
+    timestamp: Date.now() + i * 1000 * 60 * 60 * 24 + (Math.random() - 0.5) * 5 * 1000 * 60 * 60 * 24,
     value: i / 10 + Math.sin(i / 5) + Math.cos(i / 3),
-    length: Math.round(1000 * 60 * 60 * 24) * Math.random(),
+    length: Math.round(lengthMultiplier * 1000 * 60 * 60 * 24) * (0.2 + Math.random()),
     type: groups[i % groups.length],
   }))
 }

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -187,7 +187,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfig<Datum
     // Scroll Bar
     const contentBBox = this._rowsGroup.node().getBBox() // We determine content size using the rects group because lines are animated
     const absoluteContentHeight = contentBBox.height
-    this._scrollbarHeight = yHeight * yHeight / absoluteContentHeight
+    this._scrollbarHeight = yHeight * yHeight / absoluteContentHeight || 0
     this._maxScroll = Math.max(absoluteContentHeight - yHeight, 0)
 
     this._scrollBarGroup
@@ -207,7 +207,6 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfig<Datum
       .attr('ry', this._scrollBarWidth / 2)
 
     this._updateScrollPosition(0)
-    this._setPointerEvents()
   }
 
   private _positionLines (
@@ -260,16 +259,8 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfig<Datum
     this._linesGroup.attr('pointer-events', 'none')
     clearTimeout(this._scrollTimeoutId)
     this._scrollTimeoutId = setTimeout(() => {
-      this._setPointerEvents()
+      this._linesGroup.attr('pointer-events', null)
     }, 300)
-  }
-
-  private _setPointerEvents (): void {
-    const { config } = this
-
-    const hasLineEvents = Object.keys(config.events).includes(s.line)
-    const hasLinesGroupEvents = Object.keys(config.events).includes(s.lines)
-    this._linesGroup.attr('pointer-events', (hasLineEvents || hasLinesGroupEvents) ? null : 'none')
   }
 
   private _updateScrollPosition (diff: number): void {


### PR DESCRIPTION
Needed for Tooltip to work with Timeline. Fixes #103 
![Screen Recording 2023-01-25 at 12 26 05 PM](https://user-images.githubusercontent.com/755708/214682873-ce7ec172-66ef-49dd-a61d-096332015b89.gif)