### PR TITLE
@unovis/react: Handling `undefined` and `null` children when comparing props

### DIFF
--- a/packages/react/src/utils/react.ts
+++ b/packages/react/src/utils/react.ts
@@ -10,7 +10,7 @@ export function arePropsEqual<PropTypes extends { children?: ReactNode }> (prevP
     if (prevChildren.length !== nextChildren.length) return false
 
     for (let i = 0; i < nextChildren.length; i += 1) {
-      if (!_isEqual(prevChildren[i].props, nextChildren[i].props)) return false
+      if (!_isEqual(prevChildren[i]?.props, nextChildren[i]?.props)) return false
     }
   }
 


### PR DESCRIPTION
Fixes #124