### PR TITLE
Component | Tooltip: Changing the way we handle scrolling

### DIFF
--- a/packages/dev/src/examples/xy-components/timeline-tooltip/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline-tooltip/index.tsx
@@ -19,6 +19,7 @@ export const component = (): JSX.Element => {
       <VisTooltip triggers={{
         [Timeline.selectors.line]: (d: TimeDataRecord) =>
           `${(new Date(d.timestamp)).toDateString()} — ${(new Date(d.timestamp + d.length)).toDateString()}`,
+        [Timeline.selectors.row]: (label: string) => `Timeline Row ${label}`,
       }}/>
     </VisXYContainer>
   </>

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -63,15 +63,18 @@ export const rows = css`
   label: rows;
 `
 
-export const rect = css`
-  label: rect;
-  pointer-events: none;
+export const row = css`
+  label: row;
   fill: var(--vis-timeline-row-even-fill-color);
   opacity: var(--vis-timeline-row-background-opacity);
 
   &.odd {
     fill: var(--vis-timeline-row-odd-fill-color);
   }
+`
+
+export const rowOdd = css`
+  label: row-odd;
 `
 
 export const scrollbar = css`


### PR DESCRIPTION
Fixes [#103](https://github.com/f5/unovis/issues/103)

• Enabling `pointer-events` for rows to allow for tooltip events;
• Attaching row type (label) as data to row elements;
• Removing the logic of setting `pointer-events` to `false` while scrolling and adding `this._onMouseWheel` event handler to `[Timeline.selectors.line]`. The tooltip will be hidden upon scrolling.


https://user-images.githubusercontent.com/755708/218609339-4e824eb4-409b-4a2a-837e-f47bf2907907.mp4

