### PR TITLE
Component | Timeline: Fixing odd rows fill color

### DIFF
--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -67,14 +67,11 @@ export const row = css`
   label: row;
   fill: var(--vis-timeline-row-even-fill-color);
   opacity: var(--vis-timeline-row-background-opacity);
-
-  &.odd {
-    fill: var(--vis-timeline-row-odd-fill-color);
-  }
 `
 
 export const rowOdd = css`
   label: row-odd;
+  fill: var(--vis-timeline-row-odd-fill-color);
 `
 
 export const scrollbar = css`


### PR DESCRIPTION
Fixing odd rows fill styles #144

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/755708/221047822-bb97c99f-3965-4671-977c-8701090d7ce2.png">

