### PR TITLE
Component | LeafletMap: Calling `fitView` and `fitToPoints` in the next frame

### DIFF
--- a/packages/dev/src/App.module.css
+++ b/packages/dev/src/App.module.css
@@ -28,5 +28,5 @@ textarea:focus, input:focus, input[type]:focus, .uneditable-input:focus {
   display: flex;
   flex-direction: row;
   color: var(--color-black);
-  padding: 8px 0 0 8px;
+  padding: 8px 8px 8px 8px;
 }

--- a/packages/dev/src/components/ExampleViewer/style.module.css
+++ b/packages/dev/src/components/ExampleViewer/style.module.css
@@ -3,6 +3,7 @@
   min-width: 0;
   min-height: 100%;
   overflow: auto;
+  position: relative;
 }
 
 .nothingSelected {

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/cities.json
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/cities.json
@@ -1,0 +1,41 @@
+[{
+  "id": "FRPAR",
+  "latitude": 48.86,
+  "longitude": 2.3444,
+  "city": "Paris"
+  }, {
+  "id": "USNYC",
+  "latitude": 40.667,
+  "longitude": -73.833,
+  "city": "New york"
+  }, {
+  "id": "USSAN",
+  "latitude": 37.792032,
+  "longitude": -122.394613,
+  "city": "San Francisco"
+  }, {
+  "id": "BRBSB",
+  "latitude": -15.781682,
+  "longitude": -47.924195,
+  "city": "Brasilia"
+  }, {
+  "id": "ITROM",
+  "latitude": 41.827637,
+  "longitude": 12.462732,
+  "city": "Roma"
+  }, {
+  "id": "USMIA",
+  "latitude": 25.789125,
+  "longitude": -80.205674,
+  "city": "Miami"
+  }, {
+  "id": "JPTYO",
+  "latitude": 35.687418,
+  "longitude": 139.692306,
+  "city": "Tokyo"
+  }, {
+  "id": "AUSYD",
+  "latitude": -33.917,
+  "longitude": 151.167,
+  "city": "Sydney"
+}]

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/index.tsx
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/index.tsx
@@ -1,0 +1,51 @@
+import React, { useRef, useState } from 'react'
+import { VectorSourceSpecification } from 'maplibre-gl'
+import { VisLeafletMap, VisLeafletMapRef } from '@unovis/react'
+import { MapLibreArcticDark, MapLibreArcticLight } from '@unovis/ts'
+
+// Data
+import cities from './cities.json'
+
+// Style
+import s from './style.module.css'
+
+export const title = 'Vector Map'
+export const subTitle = 'Vector rendering with MapLibre'
+export const category = 'Leaflet Map'
+
+type MapPointDatum = typeof cities[0]
+
+export const component = (): JSX.Element => {
+  const mapRef = useRef<VisLeafletMapRef<MapPointDatum> | null>(null)
+  const [isMapVisible, setMapVisible] = useState(true)
+  const mapSources = {
+    sources: {
+      openmaptiles: {
+        type: 'vector',
+        url: `${UNOVIS_MAP_TILE_SERVER_URL}/data/v3.json`,
+      } as VectorSourceSpecification,
+    },
+    glyphs: `${UNOVIS_MAP_TILE_SERVER_URL}/fonts/{fontstack}/{range}.pbf`,
+  }
+
+  const handleClick = (): void => {
+    setMapVisible(!isMapVisible)
+    if (isMapVisible) mapRef.current?.component?.fitView()
+  }
+
+  return (<>
+    <button className={s.showHideButton} onClick={handleClick}>{isMapVisible ? 'Hide' : 'Show'} Map</button>
+    { isMapVisible ? <VisLeafletMap<MapPointDatum>
+      ref={mapRef}
+      data={cities}
+      pointColor={'#3556FF'}
+      pointBottomLabel={d => d.city}
+      style={{ ...MapLibreArcticLight, ...mapSources }}
+      styleDarkTheme={{ ...MapLibreArcticDark, ...mapSources }}
+      attribution={[
+        '<a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>',
+        '<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>',
+      ]}
+    /> : null }
+  </>)
+}

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/style.module.css
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/style.module.css
@@ -1,0 +1,6 @@
+.showHideButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 999;
+}

--- a/packages/dev/src/global.d.ts
+++ b/packages/dev/src/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  const UNOVIS_MAP_TILE_SERVER_API_KEY: string
+  const UNOVIS_MAP_TILE_SERVER_URL: string
+}
+
+export {}

--- a/packages/dev/webpack.config.js
+++ b/packages/dev/webpack.config.js
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const { DefinePlugin } = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 const ReactRefreshTypeScript = require('react-refresh-typescript')
 const path = require('path')
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
-
 module.exports = {
   entry: './src/index.tsx',
   devtool: 'source-map',
@@ -41,7 +41,8 @@ module.exports = {
             options: {
               importLoaders: 1,
               modules: {
-                localIdentName: '[local]__[hash:base64:5]',
+                localIdentName: '[local]', // Using '[local]' for importing Leaflet's global styles correctly. See `ts/src/components/leaflet-map/leaflet.css`.
+                exportLocalsConvention: 'camelCaseOnly',
               },
             },
           },
@@ -85,6 +86,10 @@ module.exports = {
       template: 'public/index.html',
       hash: true,
       filename: '../dist/index.html',
+    }),
+    new DefinePlugin({
+      UNOVIS_MAP_TILE_SERVER_API_KEY: JSON.stringify(process.env.UNOVIS_MAP_TILE_SERVER_API_KEY),
+      UNOVIS_MAP_TILE_SERVER_URL: JSON.stringify(process.env.UNOVIS_MAP_TILE_SERVER_URL),
     }),
     isDevelopment && new ReactRefreshWebpackPlugin(),
   ].filter(Boolean),


### PR DESCRIPTION
An enhancement that will help avoiding issues described in #132.
* Calling `fitView` and `fitToPoints` in the next frame to avoid errors when the parent element was hidden prior to rendering;
* New dev app example: Vector Leaflet Map (requires setting `UNOVIS_MAP_TILE_SERVER_URL` env variable).

[](https://user-images.githubusercontent.com/755708/221695661-130b7840-36bf-4301-bc96-090d575dc3c8.mp4)

