### PR TITLE
Component | LeafletMap: Configurable inner label color

### DIFF
--- a/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
+++ b/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
@@ -162,6 +162,13 @@ export class VisLeafletFlowMapComponent<
   /** Point inner label accessor function. Default: `d => d.point_count ?? ''` */
   @Input() pointLabel?: StringAccessor<LeafletMapPointDatum<PointDatum>>
 
+  /** Point inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-point-inner-label-text-color-light` or to `--vis-map-point-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  @Input() pointLabelColor?: StringAccessor<LeafletMapPointDatum<PointDatum>>
+
   /** Point bottom label accessor function. Default: `''` */
   @Input() pointBottomLabel?: StringAccessor<LeafletMapPointDatum<PointDatum>>
 
@@ -179,6 +186,13 @@ export class VisLeafletFlowMapComponent<
 
   /** Cluster inner label accessor function. Default: `d => d.point_count`  */
   @Input() clusterLabel?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
+
+  /** Cluster inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-cluster-inner-label-text-color-light` or to `--vis-map-cluster-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  @Input() clusterLabelColor?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
 
   /** Cluster bottom label accessor function. Default: `''` */
   @Input() clusterBottomLabel?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
@@ -276,8 +290,8 @@ export class VisLeafletFlowMapComponent<
   }
 
   private getConfig (): LeafletFlowMapConfigInterface<PointDatum, FlowDatum> {
-    const { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave } = this
-    const config = { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave }
+    const { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave } = this
+    const config = { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave }
     const keys = Object.keys(config) as (keyof LeafletFlowMapConfigInterface<PointDatum, FlowDatum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/html-components/leaflet-map/leaflet-map.component.ts
+++ b/packages/angular/src/html-components/leaflet-map/leaflet-map.component.ts
@@ -162,6 +162,13 @@ export class VisLeafletMapComponent<Datum extends GenericDataRecord> implements 
   /** Point inner label accessor function. Default: `d => d.point_count ?? ''` */
   @Input() pointLabel?: StringAccessor<LeafletMapPointDatum<Datum>>
 
+  /** Point inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-point-inner-label-text-color-light` or to `--vis-map-point-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  @Input() pointLabelColor?: StringAccessor<LeafletMapPointDatum<Datum>>
+
   /** Point bottom label accessor function. Default: `''` */
   @Input() pointBottomLabel?: StringAccessor<LeafletMapPointDatum<Datum>>
 
@@ -179,6 +186,13 @@ export class VisLeafletMapComponent<Datum extends GenericDataRecord> implements 
 
   /** Cluster inner label accessor function. Default: `d => d.point_count`  */
   @Input() clusterLabel?: StringAccessor<LeafletMapClusterDatum<Datum>>
+
+  /** Cluster inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-cluster-inner-label-text-color-light` or to `--vis-map-cluster-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  @Input() clusterLabelColor?: StringAccessor<LeafletMapClusterDatum<Datum>>
 
   /** Cluster bottom label accessor function. Default: `''` */
   @Input() clusterBottomLabel?: StringAccessor<LeafletMapClusterDatum<Datum>>
@@ -246,8 +260,8 @@ export class VisLeafletMapComponent<Datum extends GenericDataRecord> implements 
   }
 
   private getConfig (): LeafletMapConfigInterface<Datum> {
-    const { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip } = this
-    const config = { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip }
+    const { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip } = this
+    const config = { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip }
     const keys = Object.keys(config) as (keyof LeafletMapConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/index.tsx
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/index.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { VisLeafletMap, VisLeafletMapRef } from '@unovis/react'
+
+// Data
+import cities from '../leaflet-map-vector/cities.json'
+
+// Style
+import s from './style.module.css'
+
+export const title = 'Light and Dark Theme'
+export const subTitle = 'CSS Variables Configuration'
+export const category = 'Leaflet Map'
+
+type MapPointDatum = typeof cities[0]
+
+export const component = (): JSX.Element => {
+  const mapKey = 'LNln6dGJDxyBa7F3c7Gd'
+  const mapRef = useRef<VisLeafletMapRef<MapPointDatum> | null>(null)
+  const [isDarkTheme, toggleTheme] = useState(false)
+
+  useEffect(() => {
+    return () => document.body.classList.remove('theme-dark')
+  }, [])
+
+  const handleClick = (): void => {
+    toggleTheme(!isDarkTheme)
+    document.body.classList.toggle('theme-dark')
+  }
+
+  return (<>
+    <button className={s.toggleThemeButton} onClick={handleClick}>{isDarkTheme ? 'Light' : 'Dark'} Theme</button>
+    <div className={s.map}>
+      <VisLeafletMap<MapPointDatum>
+        ref={mapRef}
+        data={cities}
+        pointColor={(d: MapPointDatum) => d.longitude > 0 ? '#3556FF' : null}
+        pointLabel={'✸'}
+        pointRadius={12}
+        pointLabelColor={(d: MapPointDatum) => d.id === 'USNYC' ? '#3556FF' : null}
+        clusterLabelColor={'#ff62cd'}
+        clusterRadius={10}
+        clusteringDistance={100}
+        pointBottomLabel={(d: MapPointDatum) => d.city}
+        clusterBottomLabel={c => `${c.point_count} cities`}
+        style={`https://api.maptiler.com/maps/basic-v2-light/style.json?key=${mapKey}`}
+        styleDarkTheme={`https://api.maptiler.com/maps/basic-v2-dark/style.json?key=${mapKey}`}
+      />
+    </div>
+  </>)
+}

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/style.module.css
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/style.module.css
@@ -1,0 +1,19 @@
+.toggleThemeButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 999;
+}
+
+.map {
+  --vis-map-cluster-inner-label-text-color-dark: orange;
+  --vis-map-cluster-inner-label-text-color-light: yellow;
+  --vis-dark-map-cluster-inner-label-text-color-dark: yellow;
+  --vis-dark-map-cluster-inner-label-text-color-light: orange;
+
+
+  --vis-map-point-inner-label-text-color-dark: yellow;
+  --vis-map-point-inner-label-text-color-light: orange;
+  --vis-dark-map-point-inner-label-text-color-dark: green;
+  --vis-dark-map-point-inner-label-text-color-light: white;
+}

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/cities.json
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/cities.json
@@ -4,6 +4,11 @@
   "longitude": 2.3444,
   "city": "Paris"
   }, {
+  "id": "NLAMS",
+  "latitude": 52.370216,
+  "longitude": 4.895168,
+  "city": "Amsterdam"
+  },{
   "id": "USNYC",
   "latitude": 40.667,
   "longitude": -73.833,

--- a/packages/ts/src/components/leaflet-map/config.ts
+++ b/packages/ts/src/components/leaflet-map/config.ts
@@ -84,6 +84,12 @@ export interface LeafletMapConfigInterface<Datum extends GenericDataRecord> exte
   pointRadius?: NumericAccessor<LeafletMapPointDatum<Datum>>;
   /** Point inner label accessor function. Default: `undefined`  */
   pointLabel?: StringAccessor<LeafletMapPointDatum<Datum>>;
+  /** Point inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-point-inner-label-text-color-light` or to `--vis-map-point-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  pointLabelColor?: StringAccessor<LeafletMapPointDatum<Datum>>;
   /** Point bottom label accessor function. Default: `''` */
   pointBottomLabel?: StringAccessor<LeafletMapPointDatum<Datum>>;
   /** Point cursor value or accessor function. Default: `null` */
@@ -100,6 +106,12 @@ export interface LeafletMapConfigInterface<Datum extends GenericDataRecord> exte
   clusterRadius?: NumericAccessor<LeafletMapClusterDatum<Datum>>;
   /** Cluster inner label accessor function. Default: `d => d.point_count`  */
   clusterLabel?: StringAccessor<LeafletMapClusterDatum<Datum>>;
+  /** Cluster inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-cluster-inner-label-text-color-light` or to `--vis-map-cluster-inner-label-text-color-dark` CSS variable.
+   * Default: `undefined`
+  */
+  clusterLabelColor?: StringAccessor<LeafletMapClusterDatum<Datum>>;
   /** Cluster bottom label accessor function. Default: `''` */
   clusterBottomLabel?: StringAccessor<LeafletMapClusterDatum<Datum>>;
   /** The width of the cluster point ring. Default: `1.25` */
@@ -188,6 +200,7 @@ export class LeafletMapConfig<Datum extends GenericDataRecord> extends Component
   pointColor = (d: Datum): string => d['color'] as string
   pointRadius = undefined
   pointLabel = undefined
+  pointLabelColor = undefined
   pointBottomLabel = ''
   pointCursor = null
   pointRingWidth = 1.25
@@ -197,6 +210,7 @@ export class LeafletMapConfig<Datum extends GenericDataRecord> extends Component
   clusterColor = undefined
   clusterRadius = undefined
   clusterLabel = (d: LeafletMapClusterDatum<Datum>): string => `${d.point_count}`
+  clusterLabelColor = undefined
   clusterBottomLabel = ''
   clusterRingWidth = 1.25
   clusterBackground = true

--- a/packages/ts/src/components/leaflet-map/modules/node.ts
+++ b/packages/ts/src/components/leaflet-map/modules/node.ts
@@ -40,6 +40,7 @@ export function createNodes<D extends GenericDataRecord> (
 
   selection.append('text')
     .attr('class', s.innerLabel)
+    .classed(s.innerLabelCluster, d => (d.properties as LeafletMapClusterDatum<D>).cluster)
     .attr('id', d => `label-${d.id}`)
     .attr('dy', '0.32em')
 
@@ -70,6 +71,10 @@ export function updateNodes<D extends GenericDataRecord> (
       ? getString(d.properties as LeafletMapClusterDatum<D>, config.clusterLabel)
       : getString(d.properties as LeafletMapPointDatum<D>, config.pointLabel)
     ) ?? ''
+    const innerLabelColor = (isCluster
+      ? getString(d.properties as LeafletMapClusterDatum<D>, config.clusterLabelColor)
+      : getString(d.properties as LeafletMapPointDatum<D>, config.pointLabelColor)
+    ) ?? null
     const bottomLabelText = (isCluster
       ? getString(d.properties as LeafletMapClusterDatum<D>, config.clusterBottomLabel)
       : getString(d.properties as LeafletMapPointDatum<D>, config.pointBottomLabel)
@@ -108,12 +113,17 @@ export function updateNodes<D extends GenericDataRecord> (
       .text(innerLabelText || null)
       .attr('visibility', innerLabelText ? null : 'hidden')
       .style('fill', () => {
+        if (innerLabelColor) return innerLabelColor
+
+        // Determine the label color based on the point brightness
         const c = getComputedStyle(node.node()).fill
         const hex = color(c)?.hex()
         if (!hex) return null
 
         const brightness = hexToBrightness(hex)
-        return brightness > 0.5 ? 'var(--vis-map-point-label-text-color-dark)' : 'var(--vis-map-point-label-text-color-light)'
+        return brightness > 0.5
+          ? (isCluster ? 'var(--vis-map-cluster-inner-label-text-color-dark)' : 'var(--vis-map-point-inner-label-text-color-dark)')
+          : (isCluster ? 'var(--vis-map-cluster-inner-label-text-color-light)' : 'var(--vis-map-point-inner-label-text-color-light)')
       })
 
     const bottomLabelTextTrimmed = trimTextMiddle(bottomLabelText, 15)

--- a/packages/ts/src/components/leaflet-map/style.ts
+++ b/packages/ts/src/components/leaflet-map/style.ts
@@ -35,11 +35,18 @@ export const variables = injectGlobal`
     --vis-map-cluster-default-stroke-width: 1.5px;
     --vis-map-cluster-donut-fill-color: #959da3;
 
-    --vis-map-point-label-text-color-dark: #5b5f6d;
-    --vis-map-point-label-text-color-light: #fff;
+    --vis-map-cluster-inner-label-text-color-dark: #5b5f6d;
+    --vis-map-cluster-inner-label-text-color-light: #fff;
+
+    --vis-map-point-inner-label-text-color-dark: #5b5f6d;
+    --vis-map-point-inner-label-text-color-light: #fff;
+
+    --vis-map-point-bottom-label-text-color: #5b5f6d;
     --vis-map-point-bottom-label-font-size: 10px;
+
     --vis-map-cluster-expanded-background-fill-color: #fff;
 
+    /* Dark Theme */
     --vis-dark-map-container-background-color: #dfe5eb;
     --vis-dark-map-point-default-fill-color: #B9BEC3;
     --vis-dark-map-point-default-stroke-color: #959da3;
@@ -49,8 +56,13 @@ export const variables = injectGlobal`
     --vis-dark-map-cluster-default-stroke-color: #B9BEC3;
     --vis-dark-map-cluster-donut-fill-color: #959da3;
 
-    --vis-dark-map-point-label-text-color-dark: #fff;
-    --vis-dark-map-point-label-text-color-light: #fff;
+    --vis-dark-map-cluster-inner-label-text-color-dark: #5b5f6d;
+    --vis-dark-map-cluster-inner-label-text-color-light: #fff;
+
+    --vis-dark-map-point-inner-label-text-color-dark: #5b5f6d;
+    --vis-dark-map-point-inner-label-text-color-light: #fff;
+
+    --vis-dark-map-point-bottom-label-text-color: #eee;
 
     --vis-dark-map-cluster-expanded-background-fill-color: #fff;
   }
@@ -65,8 +77,14 @@ export const variables = injectGlobal`
     --vis-map-cluster-default-stroke-color: var(--vis-dark-map-cluster-default-stroke-color);
     --vis-map-cluster-donut-fill-color: var(--vis-dark-map-cluster-donut-fill-color);
 
-    --vis-map-point-label-text-color-dark: var(--vis-dark-map-point-label-text-color-dark);
-    --vis-map-point-label-text-color-light: var(--vis-dark-map-point-label-text-color-light);
+    --vis-map-cluster-inner-label-text-color-dark: var(--vis-dark-map-cluster-inner-label-text-color-dark);
+    --vis-map-cluster-inner-label-text-color-light: var(--vis-dark-map-cluster-inner-label-text-color-light);
+
+    --vis-map-point-inner-label-text-color-dark: var(--vis-dark-map-point-inner-label-text-color-dark);
+    --vis-map-point-inner-label-text-color-light: var(--vis-dark-map-point-inner-label-text-color-light);
+
+    --vis-map-point-bottom-label-text-color: var(--vis-dark-map-point-bottom-label-text-color);
+
     --vis-map-cluster-expanded-background-fill-color: var(--vis-dark-map-cluster-expanded-background-fill-color);
   }
 `
@@ -138,17 +156,22 @@ export const innerLabel = css`
   label: inner-label;
 
   text-anchor: middle;
-  fill: var(--vis-map-point-label-text-color-dark);
+  fill: var(--vis-map-point-inner-label-text-color-dark);
   font-family: var(--vis-map-label-font-family, var(--vis-font-family));
   pointer-events: none;
   font-weight: 600;
+`
+
+export const innerLabelCluster = css`
+  label: inner-label-cluster;
+  fill: var(--vis-map-point-inner-label-text-color-dark);
 `
 
 export const bottomLabel = css`
   label: bottom-label;
 
   text-anchor: middle;
-  fill: var(--vis-map-point-label-text-color-dark);
+  fill: var(--vis-map-point-bottom-label-text-color);
   font-family: var(--vis-map-label-font-family, var(--vis-font-family));
   pointer-events: none;
   font-weight: 600;

--- a/packages/website/docs/maps/LeafletMap.mdx
+++ b/packages/website/docs/maps/LeafletMap.mdx
@@ -92,6 +92,7 @@ Point radius can be set by providing a constant value or a function to the `poin
 <LeafletDoc data={data} height={400} pointRadius={(d) => (Math.sqrt(d.population) / 250) || 10}/>
 
 ### Point Labels
+#### Central
 Points can have two kinds of labels: central and bottom. The label at the center of the point can be set by using
 the `pointLabel` property. This label will fit into the point, so it is supposed to be short.
 <LeafletDoc
@@ -102,8 +103,13 @@ the `pointLabel` property. This label will fit into the point, so it is supposed
 />
 
 ####
-The bottom label is configurable via the `pointBottomLabel` property. Both label properties can accept an accessor
-function as their value. In the example below we set `pointBottomLabel` to `d => d.id`.
+You can control the color of central labels with the `pointLabelColor` and `clusterLabelColor` config properties.
+By default, the label color will be set to a CSS variable, depending on the point brightness, either to
+`--vis-map-point-inner-label-text-color-light` or to `--vis-map-point-inner-label-text-color-dark`.
+
+#### Bottom
+The bottom label is configurable via the `pointBottomLabel` property. All label properties can accept accessor
+functions as their value. In the example below we set `pointBottomLabel` to `d => d.id`.
 <LeafletDoc data={data.slice(0, 20)} height={200} pointBottomLabel={(d) => d.city}/>
 
 ## Clusters
@@ -129,6 +135,11 @@ By default, clusters display the number of contained points in the center. That 
   clusterLabel={d => `${(sum(d.clusterPoints, d => d.population) / 1000000).toFixed(0)}M`}
   clusterBottomLabel={d => `${d.clusterPoints.length} cities`}
 />
+
+
+Similar to regular point labels, you can set the color of central labels with the `clusterLabelColor` config property,
+and use the `--vis-map-cluster-inner-label-text-color-light` and `--vis-map-cluster-inner-label-text-color-dark` CSS
+variables to change the default behaviour.
 
 ### Expand on Click
 If you want clusters to never expand on click, you can set `clusterExpandOnClick` to `false`. In that case when you


### PR DESCRIPTION
This PR adds support for central labels color  #155
* Adding `pointLabelColor` and `clusterLabelColor` config properties;
* Adding new CSS variables: 
```css
    --vis-map-cluster-inner-label-text-color-dark: #5b5f6d;
    --vis-map-cluster-inner-label-text-color-light: #fff;

    --vis-map-point-inner-label-text-color-dark: #5b5f6d;
    --vis-map-point-inner-label-text-color-light: #fff;

    --vis-map-point-bottom-label-text-color: #5b5f6d;
```
* Updated Angular wrapper;
* New dev app example:  <img width="1571" alt="image" src="https://user-images.githubusercontent.com/755708/226064547-41e8d1a0-9da3-4e29-9ca0-eb931cf05ad7.png">
* Updated docs: <img width="823" alt="SCR-20230317-npob" src="https://user-images.githubusercontent.com/755708/226063183-1356af4d-82b6-48cc-8524-b30f238155ba.png"> <img width="832" alt="SCR-20230317-npqx" src="https://user-images.githubusercontent.com/755708/226063195-24d7b9bd-7ee9-4556-95be-f13d6f226c72.png">