### PR TITLE
React | Tweaks: Supporting `style` and `className`; Removing `@emotion/css` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16265,9 +16265,10 @@
       }
     },
     "node_modules/rollup-plugin-postcss": {
-      "version": "4.0.1",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
+      "integrity": "sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "concat-with-sourcemaps": "^1.1.0",
@@ -20073,7 +20074,6 @@
       "version": "1.0.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@emotion/css": "^11.7.1",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@types/node": "^16.11.17",
         "@types/react": ">=16.8.0",
@@ -20083,6 +20083,8 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.61.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
+        "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-rename-node-modules": "^1.3.1",
         "rollup-plugin-typescript2": "^0.31.1",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "tslib": "^2.3.1",
@@ -20090,7 +20092,6 @@
         "typescript": "~4.2.4"
       },
       "peerDependencies": {
-        "@emotion/css": "^11.7.1",
         "@unovis/ts": "1.0.3",
         "react": ">=16.8.0 || ^17 || ^18",
         "react-dom": ">=16.8.0 || ^17 || ^18"
@@ -23164,7 +23165,6 @@
     "@unovis/react": {
       "version": "file:packages/react",
       "requires": {
-        "@emotion/css": "^11.7.1",
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@types/node": "^16.11.17",
         "@types/react": ">=16.8.0",
@@ -23174,6 +23174,8 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.61.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
+        "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-rename-node-modules": "^1.3.1",
         "rollup-plugin-typescript2": "^0.31.1",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
         "tslib": "^2.3.1",
@@ -32077,7 +32079,9 @@
       "dev": true
     },
     "rollup-plugin-postcss": {
-      "version": "4.0.1",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
+      "integrity": "sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/packages/dev/src/examples/networks-and-flows/chord-diagram/chord-diagram/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/chord-diagram/chord-diagram/index.tsx
@@ -27,8 +27,8 @@ const data = {
 
 export const component = (): JSX.Element => {
   return (
-    <div style={{ display: 'flex', height: '600px' }}>
-      <VisSingleContainer data={data}>
+    <div style={{ display: 'flex', height: '600px', justifyContent: 'space-evenly' }}>
+      <VisSingleContainer data={data} >
         <VisChordDiagram/>
       </VisSingleContainer>
       <VisSingleContainer data={data}>

--- a/packages/react/licences.txt
+++ b/packages/react/licences.txt
@@ -1,17 +1,18 @@
-name                              license period  license type  installed version  author
-----                              --------------  ------------  -----------------  ------
-@emotion/css                      perpetual       MIT           11.7.1             Kye Hohenberger
-@rollup/plugin-node-resolve       perpetual       MIT           13.0.4             Rich Harris
-@types/react                      perpetual       MIT           >=16.8.0           n/a
-@types/node                       perpetual       MIT           16.11.17           n/a
-@zerollup/ts-transform-paths      perpetual       MIT           1.7.18             Stefan Zerkalica
-react                             perpetual       MIT           >=16.8.0           n/a
-react-dom                         perpetual       MIT           >=16.8.0           n/a
-rimraf                            perpetual       ISC           3.0.2              Isaac Z. Schlueter
-rollup                            perpetual       MIT           2.61.1             Rich Harris
-rollup-plugin-peer-deps-external  perpetual       MIT           2.2.4              n/a
-rollup-plugin-typescript2         perpetual       MIT           0.31.1             @ezolenko
-tsconfig-paths-webpack-plugin     perpetual       MIT           3.5.2              Jonas Kello
-tslib                             perpetual       0BSD          2.3.1              Microsoft Corp.
-ttypescript                       perpetual       MIT           1.5.13             cevek
-typescript                        perpetual       Apache-2.0    4.2.4              Microsoft Corp.
+name                               license period  license type  installed version  author
+----                               --------------  ------------  -----------------  ------
+@rollup/plugin-node-resolve        perpetual       MIT           13.0.4             Rich Harris
+@types/react                       perpetual       MIT           >=16.8.0           n/a
+@types/node                        perpetual       MIT           16.11.17           n/a
+@zerollup/ts-transform-paths       perpetual       MIT           1.7.18             Stefan Zerkalica
+react                              perpetual       MIT           >=16.8.0           n/a
+react-dom                          perpetual       MIT           >=16.8.0           n/a
+rimraf                             perpetual       ISC           3.0.2              Isaac Z. Schlueter
+rollup                             perpetual       MIT           2.61.1             Rich Harris
+rollup-plugin-peer-deps-external   perpetual       MIT           2.2.4              n/a
+rollup-plugin-postcss              perpetual       MIT           4.0.2              EGOIST
+rollup-plugin-rename-node-modules  perpetual       MIT           1.3.1              Lazyuki
+rollup-plugin-typescript2          perpetual       MIT           0.31.1             @ezolenko
+tsconfig-paths-webpack-plugin      perpetual       MIT           3.5.2              Jonas Kello
+tslib                              perpetual       0BSD          2.3.1              Microsoft Corp.
+ttypescript                        perpetual       MIT           1.5.13             cevek
+typescript                         perpetual       Apache-2.0    4.2.4              Microsoft Corp.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,13 +35,11 @@
     "publish:dist": "rm -rf dist/.cache; cp ./{LICENSE,README.md,package.json} ./dist; cd ./dist; npm publish"
   },
   "peerDependencies": {
-    "@emotion/css": "^11.7.1",
     "@unovis/ts": "1.0.3",
     "react": ">=16.8.0 || ^17 || ^18",
     "react-dom": ">=16.8.0 || ^17 || ^18"
   },
   "devDependencies": {
-    "@emotion/css": "^11.7.1",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@types/react": ">=16.8.0",
     "@types/node": "^16.11.17",
@@ -51,6 +49,8 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.61.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-typescript2": "^0.31.1",
     "tsconfig-paths-webpack-plugin": "^3.5.2",
     "tslib": "^2.3.1",

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -3,6 +3,8 @@ import resolve from '@rollup/plugin-node-resolve'
 import peerDepsExternal from 'rollup-plugin-peer-deps-external'
 import typescript from 'rollup-plugin-typescript2'
 import transformPaths from '@zerollup/ts-transform-paths'
+import postcss from 'rollup-plugin-postcss'
+import renameNodeModules from 'rollup-plugin-rename-node-modules'
 import pkg from './package.json'
 
 // Array of extensions to be handled by babel
@@ -30,11 +32,15 @@ export default {
     resolve({
       extensions,
     }),
+    postcss({
+      modules: true,
+    }),
     typescript({
       typescript: require('typescript'),
       tsconfig: './tsconfig.lib.json',
       transformers: [(service) => transformPaths(service.getProgram())],
     }),
+    renameNodeModules(),
   ],
   external: regexesOfPackages,
 }

--- a/packages/react/src/composites/time-series/index.tsx
+++ b/packages/react/src/composites/time-series/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo } from 'react'
-import { cx } from '@emotion/css'
 import { Spacing, TextAlign, Scale } from '@unovis/ts'
 import { VisXYContainer } from '@unovis/react/containers/xy-container'
 import { VisArea } from '@unovis/react/components/area'
@@ -8,7 +7,7 @@ import { VisCrosshair } from '@unovis/react/components/crosshair'
 import { VisTooltip } from '@unovis/react/components/tooltip'
 import { VisBrush } from '@unovis/react/components/brush'
 
-import * as s from './style'
+import s from './style.module.css'
 
 export type VisTimeSeriesDatum = {
   timestamp: number;
@@ -76,7 +75,7 @@ export function VisTimeSeries<Datum> (props: VisTimeSeriesProps<Datum>): JSX.Ele
   }, [])
 
   return (
-    <div className={cx(s.timeSeriesContainer, props.className)} style={{ height: props.height }}>
+    <div className={`${s.timeSeriesContainer}${props.className ? `.${props.className}` : ''}`} style={{ height: props.height }}>
       <VisXYContainer
         className={s.timeSeriesModule}
         data={props.data}

--- a/packages/react/src/composites/time-series/style.module.css
+++ b/packages/react/src/composites/time-series/style.module.css
@@ -1,20 +1,18 @@
-import { css } from '@emotion/css'
-
-export const timeSeriesContainer = css`
+.timeSeriesContainer {
   position: relative;
   height: 400px;
   width: 100%;
   font-family: sans-serif;
-`
+}
 
-export const timeSeriesModule = css`
+.timeSeriesModule {
   width: 100%;
   height: 70%;
   position: relative;
-`
+}
 
-export const navigationModule = css`
+.navigationModule {
   width: 100%;
   height: 30%;
   position: relative;
-`
+}

--- a/packages/react/src/containers/single-container/index.tsx
+++ b/packages/react/src/containers/single-container/index.tsx
@@ -10,6 +10,8 @@ import { VisComponentElement } from 'src/types/dom'
 
 export type VisSingleContainerProps<Data> = SingleContainerConfigInterface<Data> & {
   data?: Data;
+  className?: string;
+  style?: React.CSSProperties;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -72,7 +74,7 @@ function VisSingleContainerFC<Data> (props: PropsWithChildren<VisSingleContainer
   })
 
   return (
-    <div ref={container} style={{ width: '100%', height: '100%', position: 'relative' }}>
+    <div ref={container} className={props.className} style={props.style}>
       {props.children}
     </div>
   )

--- a/packages/react/src/containers/xy-container/index.tsx
+++ b/packages/react/src/containers/xy-container/index.tsx
@@ -11,6 +11,7 @@ import { VisComponentElement } from 'src/types/dom'
 export type VisXYContainerProps<Datum> = XYContainerConfigInterface<Datum> & {
   data?: Datum[];
   className?: string;
+  style?: React.CSSProperties;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -83,7 +84,7 @@ export function VisXYContainerFC<Datum> (props: PropsWithChildren<VisXYContainer
   })
 
   return (
-    <div ref={container} className={props.className}>
+    <div ref={container} className={props.className} style={props.style}>
       {props.children}
     </div>
   )

--- a/packages/react/src/declarations.d.ts
+++ b/packages/react/src/declarations.d.ts
@@ -1,13 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import * as React from 'react'
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'vis-component': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-      'vis-tooltip': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-      'vis-crosshair': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-      'vis-axis': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
-    }
-  }
+declare module '*.module.css' {
+  const classes: { [key: string]: string }
+  export default classes
 }

--- a/packages/react/src/global.d.ts
+++ b/packages/react/src/global.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as React from 'react'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'vis-component': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+      'vis-tooltip': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+      'vis-crosshair': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+      'vis-axis': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -9,6 +9,7 @@ export type VisLeafletFlowMapProps<
   data?: { points: PointDatum[]; flows: FlowDatum[] };
   ref?: Ref<VisLeafletFlowMapRef<PointDatum, FlowDatum>>;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export type VisLeafletFlowMapRef<
@@ -45,7 +46,7 @@ export function VisLeafletFlowMapFC<
   })
 
   useImperativeHandle(ref, () => ({ component }))
-  return <div ref={container} className={props.className} />
+  return <div ref={container} className={props.className} style={props.style}/>
 }
 
 // We export a memoized component to avoid unnecessary re-renders

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -6,6 +6,7 @@ export type VisLeafletMapProps<Datum extends Record<string, unknown>> = LeafletM
   data?: Datum[];
   ref?: Ref<VisLeafletMapRef<Datum>>;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export type VisLeafletMapRef<Datum extends Record<string, unknown>> = {
@@ -32,7 +33,7 @@ export function VisLeafletMapFC<Datum extends Record<string, unknown>> (props: V
   })
 
   useImperativeHandle(ref, () => ({ component }))
-  return <div ref={container} className={props.className} />
+  return <div ref={container} className={props.className} style={props.style}/>
 }
 
 // We export a memoized component to avoid unnecessary re-renders

--- a/packages/website/src/examples/topojson-map/topojson-map.tsx
+++ b/packages/website/src/examples/topojson-map/topojson-map.tsx
@@ -67,7 +67,7 @@ export default function TopojsonMap (): JSX.Element {
   return (
     <div className="topojson-map">
       <YearSlider current={year} range={yearRange} onUpdate={setYear}/>
-      <VisSingleContainer data={mapData} height={550} duration={0}>
+      <VisSingleContainer data={mapData} height={550} width="100vw" duration={0}>
         <VisTopoJSONMap topojson={WorldMapTopoJSON} areaColor={getAreaColor} disableZoom/>
         <VisTooltip triggers={tooltipTriggers}/>
       </VisSingleContainer>


### PR DESCRIPTION
A couple of minor tweaks:
* Supporting `style` and `className` in containers and html components
* Removing `@emotion/css` dependency to avoid installation warnings of unmet peer-dependencies