### PR TITLE
Misc tweaks and fixes

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -163,7 +163,7 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   @Input() tickTextFontSize?: string | null
 
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
-  @Input() tickTextAlign?: TextAlign
+  @Input() tickTextAlign?: TextAlign | string
 
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   @Input() tickPadding?: number

--- a/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
+++ b/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
@@ -10,7 +10,9 @@ import {
   VisEventCallback,
   ColorAccessor,
   NumericAccessor,
+  ChordNodeDatum,
   StringAccessor,
+  GenericAccessor,
   ChordLabelAlignment,
 } from '@unovis/ts'
 import { VisCoreComponent } from '../../core'
@@ -85,13 +87,16 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
   @Input() nodeWidth?: number
 
   /** Node color accessor function ot constant value. Default: `d => d.color` */
-  @Input() nodeColor?: ColorAccessor<N>
+  @Input() nodeColor?: ColorAccessor<ChordNodeDatum<N>>
 
   /** Node label accessor function. Default: `d => d.label ?? d.key` */
-  @Input() nodeLabel?: StringAccessor<N>
+  @Input() nodeLabel?: StringAccessor<ChordNodeDatum<N>>
+
+  /** Node label color accessor function. Default: `undefined` */
+  @Input() nodeLabelColor?: StringAccessor<ChordNodeDatum<N>>
 
   /** Node label alignment. Default: `ChordLabelAlignment.Along` */
-  @Input() nodeLabelAlignment?: ChordLabelAlignment | string
+  @Input() nodeLabelAlignment?: GenericAccessor<ChordLabelAlignment | string, ChordNodeDatum<N>>
 
   /** Pad angle in radians. Constant value or accessor function. Default: `0.02` */
   @Input() padAngle?: NumericAccessor<N>
@@ -125,8 +130,8 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
   }
 
   private getConfig (): ChordDiagramConfigInterface<N, L> {
-    const { duration, events, attributes, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent } = this
-    const config = { duration, events, attributes, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent }
+    const { duration, events, attributes, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent } = this
+    const config = { duration, events, attributes, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent }
     const keys = Object.keys(config) as (keyof ChordDiagramConfigInterface<N, L>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/graph/graph.component.ts
+++ b/packages/angular/src/components/graph/graph.component.ts
@@ -163,7 +163,7 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   /** ELK layout options, see the `elkjs` package for more details: https://github.com/kieler/elkjs.
    * If you want to specify custom layout option for each node group, you can provide an accessor function that
    * receives group name ('root' for the top-level configuration) as the first argument and returns an object containing
-   * layout options. */
+   * layout options. Default: `undefined` */
   @Input() layoutElkSettings?: GenericAccessor<GraphElkLayoutSettings, string> | undefined
 
   /** Array of accessor functions to define nested node groups for the ELK Layered layout.

--- a/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
+++ b/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
@@ -11,7 +11,17 @@ import { VisGenericComponent } from '../../core'
 export class VisBulletLegendComponent implements BulletLegendConfigInterface, AfterViewInit {
   @ViewChild('container', { static: false }) containerRef: ElementRef
 
-  /** Legend items array BulletLegendItemInterface[]. Default: `[]` */
+  /** Legend items. Array of `BulletLegendItemInterface`:
+   * ```
+   * {
+   *   name: string | number;
+   *   color?: string;
+   *   inactive?: boolean;
+   *   hidden?: boolean;
+   *   pointer?: boolean;
+   * }
+   * ```
+  * Default: `[]` */
   @Input() items: BulletLegendItemInterface[]
 
   /** Apply a specific class to the labels. Default: `''` */

--- a/packages/dev/src/examples/networks-and-flows/chord-diagram/chord-diagram-hierarchy-nodes/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/chord-diagram/chord-diagram-hierarchy-nodes/index.tsx
@@ -21,7 +21,7 @@ export const component = (): JSX.Element => {
   const getLabelAlignment = useCallback((n: NodeDatum | ChordHierarchyNode<NodeDatum>) => n.height > 0 ? 'perpendicular' : 'along', [])
   const getLabel = useCallback((n: NodeDatum | ChordHierarchyNode<NodeDatum>) => (n as NodeDatum).label ?? `${n.key} (${n.depth})`, [])
   return (
-    <VisSingleContainer data={data}>
+    <VisSingleContainer data={data} style={{ width: '100%', height: '100%' }}>
       <VisChordDiagram
         nodeLevels={Object.keys(levels)}
         nodeColor={getColor}

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-layout-elk/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-layout-elk/index.tsx
@@ -44,7 +44,7 @@ const data = {
 export const component = (): JSX.Element => {
   return (
     <>
-      <VisSingleContainer data={data}>
+      <VisSingleContainer data={data} height={'100vh'}>
         <VisGraph<NodeDatum, LinkDatum>
           nodeLabel={(n: NodeDatum) => n.id}
           nodeShape={GraphNodeShape.Square}

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -9,7 +9,6 @@ export type VisLeafletFlowMapProps<
   data?: { points: PointDatum[]; flows: FlowDatum[] };
   ref?: Ref<VisLeafletFlowMapRef<PointDatum, FlowDatum>>;
   className?: string;
-  style?: React.CSSProperties;
 }
 
 export type VisLeafletFlowMapRef<
@@ -46,7 +45,7 @@ export function VisLeafletFlowMapFC<
   })
 
   useImperativeHandle(ref, () => ({ component }))
-  return <div ref={container} className={props.className} style={props.style}/>
+  return <div ref={container} className={props.className} />
 }
 
 // We export a memoized component to avoid unnecessary re-renders

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -6,7 +6,6 @@ export type VisLeafletMapProps<Datum extends Record<string, unknown>> = LeafletM
   data?: Datum[];
   ref?: Ref<VisLeafletMapRef<Datum>>;
   className?: string;
-  style?: React.CSSProperties;
 }
 
 export type VisLeafletMapRef<Datum extends Record<string, unknown>> = {
@@ -33,7 +32,7 @@ export function VisLeafletMapFC<Datum extends Record<string, unknown>> (props: V
   })
 
   useImperativeHandle(ref, () => ({ component }))
-  return <div ref={container} className={props.className} style={props.style}/>
+  return <div ref={container} className={props.className} />
 }
 
 // We export a memoized component to avoid unnecessary re-renders

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -48,7 +48,7 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   /** Font size of the tick text as CSS string. Default: `null` */
   tickTextFontSize?: string | null;
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
-  tickTextAlign?: TextAlign;
+  tickTextAlign?: TextAlign | string;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   tickPadding?: number;
 }

--- a/packages/ts/src/components/bullet-legend/config.ts
+++ b/packages/ts/src/components/bullet-legend/config.ts
@@ -4,7 +4,17 @@ import { Config } from 'core/config'
 import { BulletLegendItemInterface } from './types'
 
 export interface BulletLegendConfigInterface {
-  /** Legend items array BulletLegendItemInterface[]. Default: `[]` */
+  /** Legend items. Array of `BulletLegendItemInterface`:
+   * ```
+   * {
+   *   name: string | number;
+   *   color?: string;
+   *   inactive?: boolean;
+   *   hidden?: boolean;
+   *   pointer?: boolean;
+   * }
+   * ```
+  * Default: `[]` */
   items: BulletLegendItemInterface[];
   /** Apply a specific class to the labels. Default: `''` */
   labelClassName?: string;

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -97,16 +97,16 @@ The _Axis_ component supports a wide variety of tick customization options
 You can remove tick labels from your axis by setting the `tickLine` property to false:
 <XYWrapperWithInput {...defaultProps()} inputType="checkbox" defaultValue={false} property="tickLine"/>
 
-### Tick Text Font Size
+### Tick Label Font Size
 To change the font size for the tick labels, you provide the `tickTextFontSize` property with a CSS string.
 <XYWrapperWithInput {...defaultProps()} inputType="text" defaultValue={'50px'} property="tickTextFontSize"/>
 
-### Tick Format
+### Tick Label Format
 You can customize how ticks are formatted using the `tickFormat` property and a label formatter function.
 The following example uses Javascript's built-in Date formatter function `toDateString()`.
 <XYWrapper {...defaultProps()} data={generateTimeSeries(10)} x={d => d.timestamp} tickFormat={d=> new Date(d).toDateString()}/>
 
-### Text Alignment
+### Label Alignment
 Change the tick's label alignment with respect to the tick marker using `tickTextAlign` property with a TextAlign value: `TextAlign.Left`, `TextAlign.Right` or `TextAlign.Center`.
 <XYWrapperWithInput
   {...defaultProps()}
@@ -116,7 +116,7 @@ Change the tick's label alignment with respect to the tick marker using `tickTex
   options={['right', 'center', 'left']}
   property="tickTextAlign"/>
 
-### Text Length
+### Label Length
 To limit the string length of the tick labels, use the `tickTextLength` property:
 <XYWrapperWithInput
   {...defaultProps()}
@@ -128,7 +128,7 @@ To limit the string length of the tick labels, use the `tickTextLength` property
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString()}}
 />
 
-### Text Trim Type
+### Label Trim Type
 When a tick label becomes too long, you can customize the trimming method with the `tickTextLength` property.
 _Axis_ accepts a `TrimMode` or a string. When we provide the previous example with `TrimMode.End` property, we can see the end of the label gets cut off instead of the middle.
 <XYWrapperWithInput inputType="select"
@@ -139,7 +139,7 @@ _Axis_ accepts a `TrimMode` or a string. When we provide the previous example wi
   options={['start', 'middle', 'end']}
   property="tickTextTrimType"/>
 
-### Text Width
+### Label Width
 To limit the width of the tick labels (in pixels), you can use the `tickTextWidth` property.
 <XYWrapperWithInput
   {...defaultProps()}
@@ -150,7 +150,7 @@ To limit the width of the tick labels (in pixels), you can use the `tickTextWidt
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString()}}
 />
 
-### Text Fit Mode
+### Label Fit Mode
 _Axis_ accepts the following values for the tickTextFitMode property: `FitMode.Wrap` or `FitMode.Trim`. This determines how the axis will
 handle tick text overflow. The following example showcases the previous example using `"trim"` instead of `"wrap"`.
 <XYWrapperWithInput inputType="select"
@@ -208,7 +208,7 @@ Set the `minMaxTicksOnly` property to `true` if you only want to see the two end
   defaultValue={true}
   property="minMaxTicksOnly"/>
 
-### Custom Values
+### Set Ticks Explicitly
 You can customize the ticks displayed by providing the _Axis_ component with a number array.
 The following example only shows even values for x after getting the `tickValue` array from a filter function.
 ```ts

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -516,7 +516,10 @@ value can be tweaked with the `layoutAutofitTolerance` property (default value i
 * `0` — Stop fitting after any pan or zoom;
 * `Number.POSITIVE_INFINITY` — Always fit;
 
-You can disable the autofit behavior completely by setting `layoutAutofit` to `false`.
+If you need to re-enable autofit after the graph has been panned or zoomed, you can do so by calling the public
+`resetAutofitState()` method of the component instance.
+
+To disable the autofit behavior completely set `layoutAutofit` to `false`.
 
 ## Panels
 When you use one of the parallel layouts, it can be useful to draw panels around groups and sub-groups. You can define
@@ -596,29 +599,29 @@ const panels = [{
 
 The default panel appearance can be controlled with these CSS variables:
 ```css
-    --vis-graph-panel-border-color: #E6E9F3;
-    --vis-graph-panel-border-opacity: 0.9;
-    --vis-graph-panel-fill-color: #ffffff;
+  --vis-graph-panel-border-color: #E6E9F3;
+  --vis-graph-panel-border-opacity: 0.9;
+  --vis-graph-panel-fill-color: #ffffff;
 
-    --vis-graph-panel-label-color: #6c778c;
-    --vis-graph-panel-label-background: #ffffff;
-    --vis-graph-panel-label-font-family: var(--vis-font-family);
-    --vis-graph-panel-label-font-size: 10pt;
-    --vis-graph-panel-label-font-weight: 300;
+  --vis-graph-panel-label-color: #6c778c;
+  --vis-graph-panel-label-background: #ffffff;
+  --vis-graph-panel-label-font-family: var(--vis-font-family);
+  --vis-graph-panel-label-font-size: 10pt;
+  --vis-graph-panel-label-font-weight: 300;
 
-    --vis-graph-panel-dashed-outline-color: #b7b7b7;
+  --vis-graph-panel-dashed-outline-color: #b7b7b7;
 
-    --vis-graph-panel-side-icon-symbol-color: #9ea7b8;
-    --vis-graph-panel-side-icon-shape-fill-color: #ffffff;
+  --vis-graph-panel-side-icon-symbol-color: #9ea7b8;
+  --vis-graph-panel-side-icon-shape-fill-color: #ffffff;
 
-    // Dark Theme
-    --vis-dark-graph-panel-border-color: var(--vis-color-grey);
-    --vis-dark-graph-panel-fill-color: #292b34;
-    --vis-dark-graph-panel-label-color: #E6E9F3;
-    --vis-dark-graph-panel-label-background: var(--vis-color-grey);
-    --vis-dark-graph-panel-side-icon-symbol-color: #ffffff;
-    --vis-dark-graph-panel-side-icon-shape-fill-color: #6c778c;
-    --vis-dark-graph-panel-border-color: #a0a6ad;
+  /* Dark Theme */
+  --vis-dark-graph-panel-border-color: var(--vis-color-grey);
+  --vis-dark-graph-panel-fill-color: #292b34;
+  --vis-dark-graph-panel-label-color: #E6E9F3;
+  --vis-dark-graph-panel-label-background: var(--vis-color-grey);
+  --vis-dark-graph-panel-side-icon-symbol-color: #ffffff;
+  --vis-dark-graph-panel-side-icon-shape-fill-color: #6c778c;
+  --vis-dark-graph-panel-border-color: #a0a6ad;
 ```
 
 The side icon font family can be set with the `--vis-graph-icon-font-family` CSS variable.
@@ -664,9 +667,21 @@ const events = {
 By default, you can pan / zoom the graph and drag its nodes around. That behavior can be disabled by setting the
 `disableZoom` and `disableDrag` properties to `false` respectively.
 
-The maximum and minimum zoom levels can be set with the `zoomScaleExtent` property (default is [0.35, 1.25]).
+The maximum and minimum zoom levels can be set with the `zoomScaleExtent` property (default is `[0.35, 1.25]`).
+
 You can also provide a callback function to `onZoom` if you want to have some custom reaction when the graph is being
 panned or zoomed.
+
+_Graph_ implements a set of public methods to allow you controlling the view externally:
+```ts
+public zoomIn (increment: number)
+public zoomOut (increment: number)
+public setZoom (zoomLevel: number)
+public fitView ()
+```
+If you use React or Angular, you can access the component instance for calling these methods by using [`useRef`](https://react.dev/reference/react/useRef) or
+[`ViewChild`](https://angular.io/api/core/ViewChild) respectively.
+
 
 ```ts
 onZoom: (zoomScale: number, zoomScaleExtent: number) => void;


### PR DESCRIPTION
This PR contains a bunch of small fixes and tweaks that:

* `FIX`: React | LeafletMap, LeafletFlowMap: Removing CSS `style` support since it overlaps with the `style` config property of LeafletMap and cases errors (broken by https://github.com/f5/unovis/pull/162);
* Component | Bullet Legend: Updating description for `items` to provide better code editor experience;
* Component | Axis: Allowing `tickTextAlign` to accept `string`-type values;
* Dev | Examples | Chord Diagram Hierarchy, Graph ELK: Setting size to full page;
* Angular | Components | ChordDiagram, Graph: Wrappers update;
* Website | Docs | Axis: Updating headers for better searchability;
* Website | Docs | Graph: Adding information about Graph's public methods.

