### PR TITLE
Container | Core, Single: Setting SVG size in `render()`

### DIFF
--- a/packages/ts/src/components/sankey/index.ts
+++ b/packages/ts/src/components/sankey/index.ts
@@ -219,7 +219,7 @@ export class Sankey<
 
     const height = max(values) || config.nodeMinHeight
     this._extendedHeight = height + bleed.top + bleed.bottom
-    this._extendedWidth = (config.nodeWidth + config.nodeHorizontalSpacing) * Object.keys(groupedByColumn).length - config.nodeHorizontalSpacing + bleed.left + bleed.right
+    this._extendedWidth = Math.max(0, (config.nodeWidth + config.nodeHorizontalSpacing) * Object.keys(groupedByColumn).length - config.nodeHorizontalSpacing + bleed.left + bleed.right)
   }
 
   private _prepareLayout (): void {

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -23,13 +23,16 @@ export class SingleContainer<Data> extends ContainerCore {
     super(element)
 
     if (config) {
-      this.updateContainer(config)
+      this.updateContainer(config, true)
       this.component = config.component
     }
 
     if (data) {
-      this.setData(data)
+      this.setData(data, true)
     }
+
+    // Render if component exists and has data
+    if (this.component?.datamodel.data) this.render()
   }
 
   public setData (data: Data, preventRender?: boolean): void {

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -74,11 +74,16 @@ export class XYContainer<Datum> extends ContainerCore {
       .html('<feColorMatrix type="saturate" in="SourceGraphic" values="1.35"/>')
 
     if (config) {
-      this.updateContainer(config)
+      this.updateContainer(config, true)
     }
 
     if (data) {
-      this.setData(data)
+      this.setData(data, true)
+    }
+
+    // Render if components are present and have data
+    if (this.components?.some(c => c.datamodel.data)) {
+      this.render()
     }
 
     // Force re-render axes when fonts are loaded

--- a/packages/ts/src/core/container/config.ts
+++ b/packages/ts/src/core/container/config.ts
@@ -15,11 +15,15 @@ export interface ContainerConfigInterface {
   /** Defines whether components should fit into the container or the container should expand to fit to the component's size. Default: `Sizing.Fit` */
   sizing?: Sizing | string;
   /** Width in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `width` as a percentage, do it via `style`
+   * of the corresponding DOM element.
    * By default, Container automatically fits to the size of the parent element.
    * Default: `undefined`
   */
   width?: number | string;
   /** Height in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `height` as a percentage, do it via `style`
+   * of the corresponding DOM element.
    * By default, Container automatically fits to the size of the parent element.
    * Default: `undefined`
   */

--- a/packages/ts/src/data-models/graph.ts
+++ b/packages/ts/src/data-models/graph.ts
@@ -6,13 +6,17 @@ import { GraphInputLink, GraphInputNode, GraphLinkCore, GraphNodeCore } from 'ty
 // Core Data Model
 import { CoreDataModel } from './core'
 
+export type GraphData<N extends GraphInputNode, L extends GraphInputLink> = {
+  nodes: N[];
+  links?: L[];
+}
 
 export class GraphDataModel<
   N extends GraphInputNode,
   L extends GraphInputLink,
   OutNode extends GraphNodeCore<N, L> = GraphNodeCore<N, L>,
   OutLink extends GraphLinkCore<N, L> = GraphLinkCore<N, L>,
-> extends CoreDataModel<{nodes: N[]; links?: L[]}> {
+> extends CoreDataModel<GraphData<N, L>> {
   private _nonConnectedNodes: OutNode[]
   private _connectedNodes: OutNode[]
   private _nodes: OutNode[] = []
@@ -24,9 +28,13 @@ export class GraphDataModel<
   public linkId: ((n: L) => string | undefined) = l => (isString(l.id) || isFinite(l.id as number)) ? `${l.id}` : undefined
   public nodeSort: ((a: N, b: N) => number)
 
-  // eslint-disable-next-line accessor-pairs
-  set data (inputData: { nodes: N[]; links?: L[]}) {
+  get data (): GraphData<N, L> {
+    return this._data
+  }
+
+  set data (inputData: GraphData<N, L>) {
     if (!inputData) return
+    this._data = inputData
     const prevNodes = this.nodes
     const prevLinks = this.links
 

--- a/packages/ts/src/data-models/map-graph.ts
+++ b/packages/ts/src/data-models/map-graph.ts
@@ -7,7 +7,13 @@ import { CoreDataModel } from 'data-models/core'
 // Types
 import { MapLink } from 'types/map'
 
-export class MapGraphDataModel<AreaDatum, PointDatum, LinkDatum> extends CoreDataModel<{ areas?: AreaDatum[]; points?: PointDatum[]; links?: LinkDatum[] }> {
+export type MapGraphData<AreaDatum, PointDatum, LinkDatum> = {
+  areas?: AreaDatum[];
+  points?: PointDatum[];
+  links?: LinkDatum[];
+}
+
+export class MapGraphDataModel<AreaDatum, PointDatum, LinkDatum> extends CoreDataModel<MapGraphData<AreaDatum, PointDatum, LinkDatum>> {
   private _areas: AreaDatum[] = []
   private _points: PointDatum[] = []
   private _links: MapLink<PointDatum, LinkDatum>[] = []
@@ -20,9 +26,13 @@ export class MapGraphDataModel<AreaDatum, PointDatum, LinkDatum> extends CoreDat
   /* eslint-disable-next-line dot-notation */
   public linkTarget: ((l: LinkDatum) => number | string | PointDatum) = l => l['target']
 
-  // eslint-disable-next-line accessor-pairs
-  set data (data: { areas?: AreaDatum[]; points?: PointDatum[]; links?: LinkDatum[] }) {
+  get data (): MapGraphData<AreaDatum, PointDatum, LinkDatum> {
+    return this._data
+  }
+
+  set data (data: MapGraphData<AreaDatum, PointDatum, LinkDatum>) {
     if (!data) return
+    this._data = data
 
     this._areas = cloneDeep(data?.areas ?? [])
     this._points = cloneDeep(data?.points ?? [])

--- a/packages/ts/src/utils/misc.ts
+++ b/packages/ts/src/utils/misc.ts
@@ -3,12 +3,6 @@ import { Rect } from 'types/misc'
 import { getString, isString } from 'utils/data'
 import toPx from 'to-px'
 
-export const getBoundingClientRectObject = (element: HTMLElement):
-{ top: number; right: number; bottom: number; left: number; width: number; height: number; x: number; y: number } => {
-  const { top, right, bottom, left, width, height, x, y } = element.getBoundingClientRect()
-  return { top, right, bottom, left, width, height, x, y }
-}
-
 export function guid (): string {
   const s4 = (): string =>
     Math.floor((1 + Math.random()) * 0x10000)


### PR DESCRIPTION
Setting SVG size in `render()` to avoid unnecessary rendering caused by ResizedObserve, that also interrupted active transitions causing some of the components look "stuck".

### Before
<img width="842" alt="image" src="https://user-images.githubusercontent.com/755708/229563090-a604d3d6-559f-478a-b82b-297963c6a259.png">
<img width="825" alt="image" src="https://user-images.githubusercontent.com/755708/229563322-7309aa8a-0ca7-412f-a445-18f268eb6fa7.png">

### After
<img width="832" alt="image" src="https://user-images.githubusercontent.com/755708/229563847-57185187-d2e2-4b02-8f19-7a6f4da42185.png">
<img width="618" alt="image" src="https://user-images.githubusercontent.com/755708/229563528-ea64c4c8-4a71-453e-9fd1-3ccd970909a7.png">

#173