### PR TITLE
Component | Stacked Bar, Groped Bar: Smarter bleed calculations

### DIFF
--- a/packages/dev/src/examples/xy-components/grouped-bar/basic-grouped-bar/index.tsx
+++ b/packages/dev/src/examples/xy-components/grouped-bar/basic-grouped-bar/index.tsx
@@ -1,0 +1,26 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisGroupedBar, VisAxis, VisTooltip, VisCrosshair } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+
+export const title = 'Basic Grouped Bar Chart'
+export const subTitle = 'Generated Data'
+export const category = 'Grouped Bar'
+export const component = (): JSX.Element => {
+  const tooltipRef = useRef(null)
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  return (
+    <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }} xDomain={[-1, 15]}>
+      <VisGroupedBar x={d => d.x} y={accessors} />
+      <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}`}/>
+      <VisCrosshair template={(d: XYDataRecord) => `${d.x}`}/>
+      <VisTooltip ref={tooltipRef}/>
+    </VisXYContainer>
+  )
+}

--- a/packages/ts/src/components/grouped-bar/config.ts
+++ b/packages/ts/src/components/grouped-bar/config.ts
@@ -24,7 +24,7 @@ export interface GroupedBarConfigInterface<Datum> extends XYComponentConfigInter
   /** Configurable bar cursor when hovering over. Default: `null` */
   cursor?: StringAccessor<Datum>;
   /** Chart orientation: `Orientation.Vertical` or `Orientation.Horizontal`. Default `Orientation.Vertical` */
-  orientation?: Orientation;
+  orientation?: Orientation | string;
 }
 
 export class GroupedBarConfig<Datum> extends XYComponentConfig<Datum> implements GroupedBarConfigInterface<Datum> {

--- a/packages/ts/src/components/grouped-bar/index.ts
+++ b/packages/ts/src/components/grouped-bar/index.ts
@@ -1,5 +1,5 @@
 import { scaleBand } from 'd3-scale'
-import { min, range } from 'd3-array'
+import { min, max, range } from 'd3-array'
 import { select } from 'd3'
 
 // Core
@@ -55,8 +55,9 @@ export class GroupedBar<Datum> extends XYComponentCore<Datum, GroupedBarConfig<D
     const dataDomain = this.dataScale.domain()
     const halfGroupWidth = this._getGroupWidth() / 2
 
-    const firstDataValue = getNumber(this._barData[0], this.config.x, 0)
-    const lastDataValue = getNumber(this._barData[this._barData.length - 1], this.config.x, this._barData.length - 1)
+    const dataScaleValues = this._barData.map((d, i) => getNumber(d, this.config.x, i))
+    const firstDataValue = min(dataScaleValues)
+    const lastDataValue = max(dataScaleValues)
     const firstValuePx = this.dataScale(firstDataValue)
     const lastValuePx = this.dataScale(lastDataValue)
 

--- a/packages/ts/src/components/stacked-bar/config.ts
+++ b/packages/ts/src/components/stacked-bar/config.ts
@@ -26,7 +26,7 @@ export interface StackedBarConfigInterface<Datum> extends XYComponentConfigInter
    * Default: `null` */
   barMinHeightZeroValue?: any;
   /** Chart orientation: `Orientation.Vertical` or `Orientation.Horizontal`. Default `Orientation.Vertical` */
-  orientation?: Orientation;
+  orientation?: Orientation | string;
 }
 
 export class StackedBarConfig<Datum> extends XYComponentConfig<Datum> implements StackedBarConfigInterface<Datum> {

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -1,4 +1,4 @@
-import { min } from 'd3-array'
+import { min, max } from 'd3-array'
 
 // Core
 import { XYComponentCore } from 'core/xy-component'
@@ -47,8 +47,9 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfig<D
     const dataDomain = this.dataScale.domain()
     const halfGroupWidth = this._getBarWidth() / 2
 
-    const firstDataValue = getNumber(this._barData[0], this.config.x, 0)
-    const lastDataValue = getNumber(this._barData[this._barData.length - 1], this.config.x, this._barData.length - 1)
+    const dataScaleValues = this._barData.map((d, i) => getNumber(d, this.config.x, i))
+    const firstDataValue = min(dataScaleValues)
+    const lastDataValue = max(dataScaleValues)
     const firstValuePx = this.dataScale(firstDataValue)
     const lastValuePx = this.dataScale(lastDataValue)
 

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -221,9 +221,13 @@ export class XYContainer<Datum> extends ContainerCore {
     this._renderAxes(this._firstRender ? 0 : customDuration)
 
     // Clip Rect
+    // Extending the clipping path to allow small overflow (e.g. Line will looks better that way when it touches the edges)
+    const clipPathExtension = 2
     this._clipPath.select('rect')
-      .attr('width', this.width)
-      .attr('height', this.height)
+      .attr('x', -clipPathExtension)
+      .attr('y', -clipPathExtension)
+      .attr('width', this.width + 2 * clipPathExtension)
+      .attr('height', this.height + 2 * clipPathExtension)
 
     // Tooltip
     config.tooltip?.update() // Re-bind events


### PR DESCRIPTION
Fixes #178 
> When xDomain is set to a range that fits all the bars, the bleed spacing is still being applied:

### Before
<img width="950" alt="image" src="https://user-images.githubusercontent.com/755708/229884071-c554689d-41c3-4845-8d97-03b9fec3fe1f.png">

### After
<img width="955" alt="image" src="https://user-images.githubusercontent.com/755708/229883310-a2ee8b0b-2317-4e1d-976c-add97c16b10d.png">
