### PR TITLE
Website | Gallery: Fix expandable sankey data model

### DIFF
--- a/packages/website/src/examples/expandable-sankey/data.ts
+++ b/packages/website/src/examples/expandable-sankey/data.ts
@@ -1,260 +1,132 @@
-export type NodeDatum = {
+export type Node = {
   id: string;
   label: string;
-  subgroups: string[];
   value: number;
+  subgroups: Node[];
+  color?: string;
   expandable?: boolean;
   expanded?: boolean;
-  level?: number;
-};
+}
+export type Link = { source: string; target: string; value: number }
 
-export type LinkDatum = {
-  source: string;
-  target: string;
-  value: number;
-};
-
-export type SankeyData = {
-  nodes: NodeDatum[];
-  links: LinkDatum[];
-};
-
-export function getColor (n: NodeDatum): string | undefined {
-  const colorMap = Object.fromEntries([
-    ['1', '#1acb9a'],
-    ['3', '#6A9DFF'],
-    ['4', '#8ee422'],
-    ['5', '#a611a5'],
-    ['6', '#f88080'],
-  ])
-  return colorMap[n.id.charAt(0)]
+export type Sankey = {
+  readonly nodes: Node[];
+  readonly links: Link[];
+  collapse: (n: Node) => void;
+  expand: (n: Node) => void;
 }
 
-const expenditureData = [
+const categories = [
   {
-    id: '',
-    label: 'Average Weekly Expenditure',
-    value: 414.6,
-    color: '#d4d4d4',
-    subgroups: ['1', '2', '3', '4', '5', '6', '7', '8', '9'],
-  },
-  {
-    id: '1',
     label: 'Consumables',
+    color: '#1acb9a',
     value: 83.3,
-    subgroups: ['1A', '1B', '1C'],
+    subgroups: [
+      { label: 'Food', value: 63.3 },
+      {
+        label: 'Drinks',
+        value: 17.2,
+        subgroups: [
+          { label: 'Non-alcoholic', value: 5.9 },
+          { label: 'Alcoholic', value: 11.3 },
+        ],
+      },
+      { label: 'Tobacco/narcotics', value: 2.8 },
+    ],
   },
+  { label: 'Apparel', value: 14.5 },
   {
-    id: '1A',
-    label: 'Food',
-    value: 63.3,
-    subgroups: [],
-  },
-  {
-    id: '1B',
-    label: 'Drinks',
-    value: 17.2,
-    subgroups: ['1Ba', '1Bb'],
-  },
-  {
-    id: '1Ba',
-    label: 'Non-alcoholic',
-    value: 5.9,
-    subgroups: [],
-  },
-  {
-    id: '1Bb',
-    label: 'Alcoholic',
-    value: 11.3,
-    subgroups: [],
-  },
-  {
-    id: '1C',
-    label: 'Tobacco/narcotics',
-    value: 2.8,
-    subgroups: [],
-  },
-  {
-    id: '2',
-    label: 'Apparel',
-    value: 14.5,
-    subgroups: [],
-  },
-  {
-    id: '3',
     label: 'Household expenses',
+    color: '#6A9DFF',
     value: 131.4,
-    subgroups: ['3A', '3B', '3C', '3D', '3E'],
+    subgroups: [
+      { label: 'Rent', value: 51.2 },
+      {
+        label: 'Utilities',
+        value: 34.3,
+        subgroups: [
+          { label: 'Water', value: 9.9 },
+          { label: 'Power', value: 23.2 },
+          { label: 'Other', value: 1.2 },
+        ],
+      },
+      { label: 'Goods & Furninshings', value: 15.0 },
+      { label: 'Repair', value: 10 },
+      { label: 'Phone/Internet', value: 20.9 },
+    ],
   },
   {
-    id: '3A',
-    label: 'Rent',
-    value: 51.2,
-    subgroups: [],
-  },
-  {
-    id: '3B',
-    label: 'Utilities',
-    value: 34.3,
-    subgroups: ['3B1', '3B2', '3B3'],
-  },
-  {
-    id: '3B1',
-    label: 'Water',
-    value: 9.9,
-    subgroups: [],
-  },
-  {
-    id: '3B2',
-    label: 'Power',
-    value: 23.2,
-    subgroups: [],
-  },
-  {
-    id: '3B3',
-    label: 'Other',
-    value: 1.2,
-    subgroups: [],
-  },
-  {
-    id: '3C',
-    label: 'Goods & Furninshings',
-    value: 15.0,
-    subgroups: [],
-  },
-  {
-    id: '3D',
-    label: 'Repair',
-    value: 10,
-    subgroups: [],
-  },
-  {
-    id: '3E',
-    label: 'Phone/Internet',
-    value: 20.9,
-    subgroups: [],
-  },
-  {
-    id: '4',
     label: 'Transport',
+    color: '#8ee422',
     value: 60.8,
-    subgroups: ['4A', '4B'],
+    subgroups: [
+      { label: 'Personal transport', value: 51.2 },
+      { label: 'Public transport', value: 9.6 },
+    ],
   },
   {
-    id: '4A',
-    label: 'Personal transport',
-    value: 51.2,
-    subgroups: [],
-  },
-  {
-    id: '4B',
-    label: 'Public transport',
-    value: 9.6,
-    subgroups: [],
-  },
-  {
-    id: '5',
     label: 'Individual expenses',
+    color: '#a611a5',
     value: 37.0,
-    subgroups: ['5A', '5B', '5C'],
+    subgroups: [
+      { label: 'Insurance', value: 20.4 },
+      { label: 'Healthcare', value: 6.7 },
+      { label: 'Personal care', value: 9.9 },
+    ],
   },
   {
-    id: '5A',
-    label: 'Insurance',
-    value: 20.4,
-    subgroups: [],
-  },
-  {
-    id: '5B',
-    label: 'Healthcare',
-    value: 6.7,
-    subgroups: [],
-  },
-  {
-    id: '5C',
-    label: 'Personal care',
-    value: 9.9,
-    subgroups: [],
-  },
-  {
-    id: '6',
     label: 'Recreation & Culture',
+    color: '#f88080',
     value: 45.5,
-    subgroups: ['6A', '6B', '6C', '6D', '6E'],
+    subgroups: [
+      { label: 'Electronics', value: 5.0 },
+      { label: 'Events & Activities', value: 11.3 },
+      { label: 'Pets', value: 6.7 },
+      { label: 'Hobbies', value: 16.3 },
+      { label: 'Other', value: 6.2 },
+    ],
   },
-  {
-    id: '6A',
-    label: 'Electronics',
-    value: 5.0,
-    subgroups: [],
-  },
-  {
-    id: '6B',
-    label: 'Events & Activities',
-    value: 11.3,
-    subgroups: [],
-  },
-  {
-    id: '6C',
-    label: 'Pets',
-    value: 6.7,
-    subgroups: [],
-  },
-  {
-    id: '6D',
-    label: 'Hobbies',
-    value: 16.3,
-    subgroups: [],
-  },
-  {
-    id: '6E',
-    label: 'Other',
-    value: 6.2,
-    subgroups: [],
-  },
-  {
-    id: '7',
-    label: 'Education',
-    value: 8.3,
-    subgroups: [],
-  },
-  {
-    id: '8',
-    label: 'Restaurant & Hotels',
-    value: 18.8,
-    subgroups: [],
-  },
-  {
-    id: '9',
-    label: 'Miscellaneous',
-    value: 15.0,
-    subgroups: [],
-  },
+  { label: 'Education', value: 8.3 },
+  { label: 'Restaurant & Hotels', value: 18.8 },
+  { label: 'Miscellaneous', value: 15.0 },
 ]
 
-const getNode = (id: string): NodeDatum => expenditureData.find((d) => d.id === id)
 
-export const sankeyData: SankeyData = {
-  nodes: expenditureData.map(d => ({
-    ...d,
-    level: d.id.length,
-    expandable: d.subgroups.length !== 0,
-    expanded: false,
-  })),
-  links: expenditureData.flatMap((d) =>
-    d.subgroups.map((id) => ({
-      source: d.id,
-      target: id,
-      value: getNode(id).value,
-    }))
-  ),
-}
+const getNodes = (n: Node): Node[] => n.subgroups?.map((child, i) => ({
+  ...child,
+  id: [n.id, i].join(''),
+  color: child.color ?? n.color,
+  expanded: false,
+  expandable: child.subgroups?.length > 0,
+}))
 
-export const sourceNode = {
-  ...sankeyData.nodes[0],
-  expandable: false,
-}
+const getLinks = (n: Node): Link[] => n.subgroups.map(target => ({
+  source: n.id,
+  target: target.id,
+  value: target.value,
+}))
 
-export function getChildren (n: NodeDatum): NodeDatum[] {
-  return sankeyData.nodes.filter(d => n.subgroups?.includes(d.id))
+const generate = (n: Node): Node => ({ ...n, subgroups: getNodes(n) })
+
+export const root: Node = generate({
+  id: 'root',
+  label: 'Average Weekly Expenditure',
+  value: 414.7,
+  expanded: true,
+  expandable: true,
+  subgroups: categories as Node[],
+})
+
+export const sankeyData: Sankey = {
+  nodes: [root, ...root.subgroups],
+  links: getLinks(root),
+  expand: function (n: Node): void {
+    n.subgroups = getNodes(n)
+    this.nodes = this.nodes.concat(n.subgroups)
+    this.links = this.links.concat(getLinks(n))
+  },
+  collapse: function (n: Node): void {
+    this.nodes = this.nodes.filter(d => d.id === n.id || !d.id.startsWith(n.id))
+    this.links = this.links.filter(d => !d.source.id.startsWith(n.id))
+  },
 }

--- a/packages/website/src/examples/expandable-sankey/expandable-sankey.component.html
+++ b/packages/website/src/examples/expandable-sankey/expandable-sankey.component.html
@@ -1,14 +1,13 @@
-<vis-single-container [data]="data" [height]="'60vh'">
+<vis-single-container #vis [data]="data" [height]="'60vh'">
   <vis-sankey
     labelFit="wrap"
     labelVerticalAlign="middle"
     subLabelPlacement="inline"
-    [nodeCursor]="nodeCursor"
     [events]="events"
     [labelForceWordBreak]="false"
     [labelMaxWidth]="150"
     [linkColor]="linkColor"
-    [nodeColor]="nodeColor"
+    [nodeCursor]="nodeCursor"
     [nodeIcon]="nodeIcon"
     [nodePadding]="20"
     [subLabel]="subLabel"

--- a/packages/website/src/examples/expandable-sankey/expandable-sankey.component.ts
+++ b/packages/website/src/examples/expandable-sankey/expandable-sankey.component.ts
@@ -1,27 +1,17 @@
-import { Component } from '@angular/core'
+import { Component, ViewChild } from '@angular/core'
+import { VisSingleContainerComponent } from '@unovis/angular'
 import { Sankey, SankeyLink, SankeyNode } from '@unovis/ts'
 
-import { getColor, getChildren, LinkDatum, NodeDatum, sankeyData, sourceNode } from './data'
+import { sankeyData, root, Node, Link } from './data'
 
 @Component({
   selector: 'expandable-sankey',
   templateUrl: './expandable-sankey.component.html',
 })
 export class ExpandableSankeyComponent {
-  data = {
-    nodes: [sourceNode, ...getChildren(sourceNode)],
-    links: sankeyData.links,
-  }
+  @ViewChild('vis') vis: VisSingleContainerComponent<{ nodes: Node[]; links: Link[] }>
 
-  nodeColor = getColor
-  nodeIcon = (d: NodeDatum): string => !d.expandable ? '' : (d.expanded ? '-' : '+')
-  nodeCursor = (d: SankeyNode<NodeDatum, LinkDatum>): string => d.expandable ? 'pointer' : null
-  subLabel = (d: SankeyNode<NodeDatum, LinkDatum>): string => {
-    if (d.expanded || d.depth === 0) return ''
-    return `${((d.value / sourceNode.value) * 100).toFixed(1)}%`
-  }
-
-  linkColor = (d: SankeyLink<NodeDatum, LinkDatum>): string => getColor(d.source)
+  data = { nodes: sankeyData.nodes, links: sankeyData.links }
 
   events = {
     [Sankey.selectors.node]: {
@@ -29,19 +19,23 @@ export class ExpandableSankeyComponent {
     },
   }
 
-  toggleGroup (n: SankeyNode<NodeDatum, LinkDatum>): void {
-    if (!n.expandable) return
-    const nodes = [...this.data.nodes]
-    nodes[n.index].expanded = !nodes[n.index].expanded
-    n.sourceLinks.forEach(d => {
-      nodes[d.index].expanded = false
-    })
+  linkColor = (d: SankeyLink<Node, Link>): string => d.source.color ?? null
+  nodeCursor = (d: Node): string => d.expandable ? 'pointer' : null
+  nodeIcon = (d: Node): string => !d.expandable ? '' : (d.expanded ? '-' : '+')
+  subLabel = (d: SankeyNode<Node, Link>): string => {
+    if (d.expanded || d.depth === 0) return ''
+    return `${((d.value / root.value) * 100).toFixed(1)}%`
+  }
 
-    this.data = {
-      nodes: n.expanded
-        ? nodes.filter(d => !d.id.startsWith(n.id) || d.level <= n.layer)
-        : [...nodes, ...getChildren(n)],
-      links: this.data.links,
+  toggleGroup (n: Node): void {
+    if (n.expandable) {
+      if (n.expanded) {
+        sankeyData.collapse(n)
+      } else {
+        sankeyData.expand(n)
+      }
+      n.expanded = !n.expanded
+      this.vis.chart.setData(sankeyData)
     }
   }
 }

--- a/packages/website/src/examples/expandable-sankey/expandable-sankey.svelte
+++ b/packages/website/src/examples/expandable-sankey/expandable-sankey.svelte
@@ -1,35 +1,29 @@
 <script lang='ts'>
-  import { FitMode, Sankey, SankeyNode, SankeySubLabelPlacement, VerticalAlign } from '@unovis/ts'
+  import { FitMode, Sankey, SankeyLink, SankeyNode, SankeySubLabelPlacement, VerticalAlign } from '@unovis/ts'
   import { VisSingleContainer, VisSankey } from '@unovis/svelte'
-  import { getColor, getChildren, LinkDatum, NodeDatum, sankeyData, sourceNode } from './data'
+  import { sankeyData, root, Node, Link } from './data'
 
-  let data = {
-    nodes: [sourceNode, ...sankeyData.nodes.filter(d => sourceNode.subgroups.includes(d.id))],
-    links: sankeyData.links,
-  }
+  let data = { nodes: sankeyData.nodes, links: sankeyData.links }
 
-  function toggleGroup (n: SankeyNode<NodeDatum, LinkDatum>): void {
-    if (!n.expandable) return
-    const nodes = [...data.nodes]
-    nodes[n.index].expanded = !nodes[n.index].expanded
-    n.sourceLinks.forEach(d => {
-      nodes[d.index].expanded = false
-    })
-
-    data = {
-      nodes: n.expanded
-        ? nodes.filter(d => !d.id.startsWith(n.id) || d.level <= n.layer)
-        : [...nodes, ...sankeyData.nodes.filter(d => n.subgroups.includes(d.id))],
-      links: data.links,
+  function toggleGroup (n: Node): void {
+    if (n.expandable) {
+      if (n.expanded) {
+        sankeyData.collapse(n)
+      } else {
+        sankeyData.expand(n)
+      }
+      n.expanded = !n.expanded
+      data = sankeyData
     }
   }
 
   const callbacks = {
-    linkColor: (d: LinkDatum): string => d.source,
-    nodeColor: getColor,
-    nodeIcon: (d: NodeDatum): string => d.expandable ? (d.expanded ? '-' : '+') : '',
-    nodeCursor: (d: SankeyNode<NodeDatum, LinkDatum>) => d.expandable ? 'pointer' : null,
-    subLabel: (d: SankeyNode<NodeDatum, LinkDatum>): string => ((d.depth === 0) || d.expanded) ? '' : `${((d.value / sourceNode.value) * 100).toFixed(1)}%`,
+    linkColor: (d: SankeyLink<Node, Link>): string => d.source.color ?? null,
+    nodeCursor: (d: Node) => d.expandable ? 'pointer' : null,
+    nodeIcon: (d: Node): string => d.expandable ? (d.expanded ? '-' : '+') : '',
+    subLabel: (d: SankeyNode<Node, Link>): string => (d.depth === 0 || d.expanded)
+      ? ''
+      : `${((d.value / root.value) * 100).toFixed(1)}%`,
     events: {
       [Sankey.selectors.node]: {
         click: toggleGroup,
@@ -38,7 +32,7 @@
   }
 </script>
 
-<VisSingleContainer {data} height={'60vh'}>
+<VisSingleContainer {data} height={'min(60vh,75vw)'}>
   <VisSankey
     {...callbacks}
     labelFit={FitMode.Wrap}


### PR DESCRIPTION
#180

**Background:**
The error was occurring because `data.nodes` and `data.links` weren't in sync. Previously, only the `node` objects were updated when setting a node's `expanded` property, while `links` remained unchanged, resulting in links with unrecognized source and target values when _Sankey_ wasn't fully expanded. (I suspect changes from [Datamodel | Graph: Fix link data logic (8b4416d) ](https://github.com/f5/unovis/commit/8b4416d218106340c6b3dcb998fcf7cc6ffeb8e6#diff-b4e9556c6675215c7be1e5f1db3804a7450e0e341c40e2d4dfcd11c908fa5333) are what ultimately broke it)

 **Changes** :
This PR:
- Updates both nodes and links whenever a node's subtree is toggled
- Extracts expand/collapse logic to `data.ts` file to maintain clarity in the component code
- Changes the data shape and type defs a bit to be more readable
- Includes minor tweaks to increase consistency across example files
