### PR TITLE
Component | Leaflet Map: Custom attributes support, config initialization fix, handling expanded cluster on `setData`

### DIFF
--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-colorMap/data.ts
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-colorMap/data.ts
@@ -1,0 +1,214 @@
+import type { MapLibreStyleSpecs } from '@unovis/ts'
+
+export type MapPointDataRecord = {
+  name: string;
+  longitude: number;
+  latitude: number;
+  normal: number;
+  blocked: number;
+}
+
+export const points: MapPointDataRecord[] = [
+  { latitude: 52.35598, longitude: 4.95035, name: 'ams9', normal: 948, blocked: 4 },
+  { latitude: 33.64989, longitude: 130.12389, name: 'ap-0', normal: 980, blocked: 5 },
+  { latitude: 35.66822, longitude: 139.67082, name: 'ap-1', normal: 105, blocked: 0 },
+  { latitude: 34.67764, longitude: 135.45105, name: 'ap-2', normal: 783, blocked: 7 },
+  { latitude: 22.16182, longitude: 113.53505, name: 'ap-3', normal: 361, blocked: 82 },
+  { latitude: 37.56508, longitude: 126.91934, name: 'ap-4', normal: 446, blocked: 5 },
+  { latitude: 38.31359, longitude: 140.69612, name: 'ap-5', normal: 220, blocked: 6 },
+  { latitude: 51.50986, longitude: -0.118092, name: 'astral-azure', normal: 878, blocked: 4 },
+  { latitude: 1.35208, longitude: 103.81984, name: 'astral-gcp', normal: 716, blocked: 1 },
+  { latitude: 37.49858, longitude: -122.29465, name: 'corp-branch-1', normal: 143, blocked: 8 },
+  { latitude: 48.90162, longitude: 2.4153903, name: 'dc-eu-west', normal: 684, blocked: 0 },
+  { latitude: 40.74135, longitude: -74.005394, name: 'dc-us-east', normal: 874, blocked: 2 },
+  { latitude: 37.44582, longitude: -122.163, name: 'dc-us-west', normal: 974, blocked: 8 },
+  { latitude: 51.52857, longitude: -0.2420208, name: 'eu-0', normal: 24289, blocked: 6672 },
+  { latitude: 48.85883, longitude: 2.2768495, name: 'eu-1', normal: 554, blocked: 155 },
+  { latitude: 38.74362, longitude: -9.195309, name: 'eu-2', normal: 841, blocked: 655 },
+  { latitude: 50.12119, longitude: 8.566354, name: 'eu-3', normal: 452, blocked: 0 },
+  { latitude: 40.43793, longitude: -3.749747, name: 'eu-4', normal: 343, blocked: 0 },
+  { latitude: 41.91005, longitude: 12.465787, name: 'eu-5', normal: 444, blocked: 222 },
+  { latitude: 50.05958, longitude: 14.325202, name: 'eu-6', normal: 287, blocked: 5 },
+  { latitude: 40.71772, longitude: -74.0083, name: 'nyc', normal: 41, blocked: 8 },
+  { latitude: 48.92716, longitude: 2.350664, name: 'par', normal: 498, blocked: 4 },
+  { latitude: 48.90105, longitude: 2.423093, name: 'par-2', normal: 626, blocked: 0 },
+  { latitude: 1.29594, longitude: 103.788376, name: 'sin', normal: 992, blocked: 0 },
+  { latitude: 37.24117, longitude: -121.77938, name: 'sjc', normal: 637, blocked: 3 },
+  { latitude: 51.51139, longitude: -0.001787, name: 'lon', normal: 979, blocked: 6 },
+  { latitude: 35.62267, longitude: 139.77003, name: 'tky', normal: 174, blocked: 6 },
+  { latitude: 40.72916, longitude: -74.00558, name: 'usa-0', normal: 631, blocked: 1 },
+  { latitude: 38.90632, longitude: -77.04191, name: 'usa-1', normal: 21, blocked: 0 },
+  { latitude: 25.79083, longitude: -80.14021, name: 'usa-2', normal: 487, blocked: 0 },
+  { latitude: 30.00407, longitude: -90.15977, name: 'usa-3', normal: 751, blocked: 3 },
+  { latitude: 41.89261, longitude: -87.62556, name: 'usa-4', normal: 764, blocked: 3 },
+  { latitude: 32.78868, longitude: -97.34767, name: 'usa-5', normal: 0, blocked: 530 },
+  { latitude: 36.10304, longitude: -115.17369, name: 'usa-6', normal: 609, blocked: 5 },
+  { latitude: 34.10182, longitude: -118.32421, name: 'usa-7', normal: 543, blocked: 0 },
+  { latitude: 37.44428, longitude: -122.17108, name: 'usa-8', normal: 1920, blocked: 0 },
+  { latitude: 47.61698, longitude: -122.33839, name: 'usa-9', normal: 513, blocked: 2 },
+]
+
+export const totalEvents = points.reduce((sum, d) => sum + d.normal, 0) / points.length
+
+export const generateStyle = (
+  backgroundColor: string,
+  countryFillColor: string,
+  countryBoundaryColor: string,
+  coastlineColor: string
+): MapLibreStyleSpecs => ({
+  name: 'MapLibre-Unovis',
+  sources: {
+    maplibre: {
+      url: 'https://demotiles.maplibre.org/tiles/tiles.json',
+      type: 'vector',
+    },
+  },
+  glyphs: 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf',
+  layers: [{
+    id: 'background',
+    type: 'background',
+    paint: {
+      'background-color': backgroundColor,
+    },
+    // filter: ['all'],
+    layout: {
+      visibility: 'visible',
+    },
+    maxzoom: 24,
+  },
+  {
+    id: 'coastline',
+    type: 'line',
+    paint: {
+      'line-blur': 0.5,
+      'line-color': coastlineColor,
+      'line-width': {
+        type: 'interval',
+        stops: [
+          [0, 2],
+          [6, 6],
+          [14, 9],
+          [22, 18],
+        ],
+      },
+    },
+    filter: ['all'],
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+      visibility: 'visible',
+    },
+    source: 'maplibre',
+    maxzoom: 24,
+    minzoom: 0,
+    'source-layer': 'countries',
+  },
+  {
+    id: 'countries-fill',
+    type: 'fill',
+    paint: {
+      'fill-color': countryFillColor,
+    },
+    filter: ['all'],
+    layout: {
+      visibility: 'visible',
+    },
+    source: 'maplibre',
+    maxzoom: 24,
+    'source-layer': 'countries',
+  },
+  {
+    id: 'countries-boundary',
+    type: 'line',
+    paint: {
+      'line-color': countryBoundaryColor,
+      'line-width': {
+        type: 'interval',
+        stops: [[1, 1], [6, 2], [14, 6],
+          [22, 12],
+        ],
+      },
+      'line-opacity': {
+        type: 'interval',
+        stops: [
+          [3, 0.5],
+          [6, 1],
+        ],
+      },
+    },
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+      visibility: 'visible',
+    },
+    source: 'maplibre',
+    maxzoom: 24,
+    'source-layer': 'countries',
+  },
+  {
+    id: 'countries-label',
+    type: 'symbol',
+    paint: {
+      'text-color': 'rgba(177, 177, 177, 1)',
+      'text-halo-blur': {
+        type: 'interval',
+        stops: [
+          [2, 0.2],
+          [6, 0],
+        ],
+      },
+      'text-halo-color': 'rgba(255, 255, 255, 1)',
+      'text-halo-width': {
+        type: 'interval',
+        stops: [
+          [2, 1],
+          [6, 1.6],
+        ],
+      },
+    },
+    filter: ['all'],
+    layout: {
+      'text-font': [
+        'Open Sans Semibold',
+      ],
+      'text-size': {
+        type: 'interval',
+        stops: [
+          [2, 10],
+          [4, 12],
+          [6, 16],
+        ],
+      },
+      'text-field': {
+        type: 'interval',
+        stops: [
+          [4, '{NAME}'],
+        ],
+      },
+      visibility: 'visible',
+      'text-max-width': 10,
+      'text-transform': {
+        type: 'interval',
+        stops: [
+          [0, 'uppercase'],
+          [2, 'none'],
+        ],
+      },
+    },
+    source: 'maplibre',
+    maxzoom: 24,
+    minzoom: 2,
+    'source-layer': 'centroids',
+  },
+  ],
+  bearing: 0,
+  version: 8,
+  metadata: {
+    'maptiler:copyright': 'This style was generated on MapTiler Cloud.',
+    'openmaptiles:version': '3.x',
+  },
+})
+
+export const mapStyleLight = generateStyle('#DFE5EB', '#FEFEFE', '#DFE5EB', '#D3D8DE')
+
+export const mapStyleDark = generateStyle('#292b34', '#5b5f6d', '#2a2a2a', '#2a2a2a')

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-colorMap/index.tsx
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-colorMap/index.tsx
@@ -1,0 +1,74 @@
+import React, { useRef, useCallback, useState, useEffect } from 'react'
+import { VisLeafletMap, VisLeafletMapRef } from '@unovis/react'
+import { LeafletMap, LeafletMapClusterDatum, LeafletMapPoint, LeafletMapPointStyles } from '@unovis/ts'
+
+
+// Data
+import { MapPointDataRecord, points, totalEvents, mapStyleLight, mapStyleDark } from './data'
+
+// Style
+
+export const title = 'Color Map'
+export const subTitle = 'Updating color map and data'
+export const category = 'Leaflet Map'
+
+
+export const component = (): JSX.Element => {
+  const mapRef = useRef<VisLeafletMapRef<MapPointDataRecord>>(null)
+  const [data, setData] = useState(points)
+  const [colorMap, setColorMap] = useState<LeafletMapPointStyles<MapPointDataRecord>>({
+    normal: { color: '#4c7afc' },
+    blocked: { color: '#f8442d' },
+  })
+
+  const pointId = (d: MapPointDataRecord): string => d.name
+  const pointLatitude = (d: MapPointDataRecord): number => d.latitude
+  const pointLongitude = (d: MapPointDataRecord): number => d.longitude
+  const pointBottomLabel = (d: MapPointDataRecord): string => d.name
+  const pointRadius = (d: MapPointDataRecord | LeafletMapClusterDatum<MapPointDataRecord>): number =>
+    10 + 4 * Math.sqrt(((d.normal || 0) + (d.blocked || 0)) / totalEvents)
+  const pointLabel = (d: MapPointDataRecord | LeafletMapClusterDatum<MapPointDataRecord>): string =>
+    `${(((d.blocked || 0) + (d.normal || 0)) / 1000).toFixed(1)}K`
+  const clusterBottomLabel = (d: LeafletMapClusterDatum<MapPointDataRecord>): string => `${d.point_count} sites`
+
+  // Update color map and data to make sure the map re-renders accordingly
+  useEffect(() => {
+    // Will be called twice under the dev mode
+    setTimeout(() => {
+      points.push({ latitude: 51.53857, longitude: -0.2520208, name: 'lon-test', normal: 2758, blocked: 642 })
+
+      setData(points)
+      setColorMap({
+        normal: { color: '#26BDA4' },
+        blocked: { color: '#9876AA' },
+      })
+    }, 5000)
+  }, [])
+
+
+  return (<>
+    <VisLeafletMap<MapPointDataRecord>
+      ref={mapRef}
+      data={data}
+      style={mapStyleLight}
+      styleDarkTheme={mapStyleDark}
+      pointId={useCallback(pointId, [])}
+      pointLatitude={useCallback(pointLatitude, [])}
+      pointLongitude={useCallback(pointLongitude, [])}
+      pointLabel={useCallback(pointLabel, [])}
+      pointBottomLabel={useCallback(pointBottomLabel, [])}
+      pointRadius={useCallback(pointRadius, [])}
+      colorMap={colorMap}
+      clusterRadius={useCallback(pointRadius, [])}
+      clusterLabel={useCallback(pointLabel, [])}
+      clusterBottomLabel={useCallback(clusterBottomLabel, [])}
+      clusteringDistance={85}
+      clusterExpandOnClick={true}
+      attributes={{
+        [LeafletMap.selectors.point]: {
+          cluster: (p: LeafletMapPoint<MapPointDataRecord>) => p.isCluster,
+        },
+      }}
+    />
+  </>)
+}

--- a/packages/ts/src/components/leaflet-map/modules/utils.ts
+++ b/packages/ts/src/components/leaflet-map/modules/utils.ts
@@ -51,7 +51,10 @@ export function bBoxMerge (
 
 export const getNextZoomLevelOnClusterClick = (level: number): number => clamp(1 + level * 1.5, level, 12)
 
-export function projectPoint (geoJSONPoint, leafletMap: L.Map): { x: number; y: number } {
+export function projectPoint<D extends GenericDataRecord> (
+  geoJSONPoint: LeafletMapPoint<D> | ClusterFeature<LeafletMapClusterDatum<D>> | PointFeature<LeafletMapPointDatum<D>>,
+  leafletMap: L.Map
+): { x: number; y: number } {
   const lat = geoJSONPoint.geometry.coordinates[1]
   const lon = geoJSONPoint.geometry.coordinates[0]
   const projected = leafletMap.latLngToLayerPoint([lat, lon])
@@ -214,15 +217,14 @@ export function shouldClusterExpand<D extends GenericDataRecord> (
   cluster: LeafletMapPoint<D>,
   zoomLevel: number,
   midLevel = 4,
-  maxLevel = 11,
+  maxLevel = 8,
   maxClusterZoomLevel = 23
 ): boolean {
   if (!cluster) return false
 
-  const clusterExpansionZoomLevel: number = cluster.clusterIndex.getClusterExpansionZoom(cluster.id as number)
-  return clusterExpansionZoomLevel >= maxClusterZoomLevel ||
-    zoomLevel >= maxLevel ||
-    (zoomLevel >= midLevel && cluster && (cluster.properties as LeafletMapClusterDatum<D>).point_count < 20)
+  const clusterExpansionZoomLevel = cluster.clusterIndex.getClusterExpansionZoom(cluster.properties.cluster_id as number)
+  return zoomLevel >= maxLevel ||
+        (zoomLevel >= midLevel && (cluster.properties.point_count < 20 || clusterExpansionZoomLevel >= maxClusterZoomLevel))
 }
 
 export function findPointAndClusterByPointId<D extends GenericDataRecord> (


### PR DESCRIPTION
Takes care of [#186](https://github.com/f5/unovis/issues/186) and [#187](https://github.com/f5/unovis/issues/187)

* Re-initialize config on `setConfig` (fixes `colorMap` update);
* Redraw expanded cluster on data update;
* Supporting setting custom point attributes via `config.attributes`;

![Screen Recording 2023-04-24 at 4 21 34 PM](https://user-images.githubusercontent.com/755708/234137034-904e8693-d673-4dc7-abe1-34d58535dbef.gif)
