### PR TITLE
Utils | Clone Deep: Fixing cloning of arrays

### DIFF
--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -72,7 +72,7 @@ export const cloneDeep = <T>(obj: T, stack: Map<any, any> = new Map()): T => {
     for (const item of obj) {
       clone.push(stack.has(item) ? stack.get(item) : cloneDeep(item, stack))
     }
-    return obj
+    return clone as unknown as T
   }
 
   // Class instances will be copied without cloning


### PR DESCRIPTION
Fixes #190. Our `cloneDeep` implementation was not handling arrays properly.