### PR TITLE
Utils | Text: Preventing empty first line when the first word is too long

### DIFF
--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -283,7 +283,7 @@ function breakTextIntoLines (
       const textLengthPx = fastMode
         ? estimateStringPixelLength(line + words[i], textBlock.fontSize, textBlock.fontWidthToHeightRatio)
         : getPreciseStringLengthPx(line + words[i], textBlock.fontFamily, textBlock.fontSize)
-      if (textLengthPx < width) {
+      if (textLengthPx < width || i === 0) {
         line += words[i]
       } else {
         lines.push(line.trim())


### PR DESCRIPTION
### Before
<img width="226" alt="SCR-20230501-msou" src="https://user-images.githubusercontent.com/755708/235533994-6af1aad2-4a95-41a3-a337-7496e0649115.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/755708/235534145-759450c0-6996-4ffb-9f9f-07b861ef4367.png">

### After
<img width="231" alt="SCR-20230501-msrm" src="https://user-images.githubusercontent.com/755708/235533976-97d86c7f-19c2-44cc-8f80-a939a8c54ff0.png">
<img width="386" alt="image" src="https://user-images.githubusercontent.com/755708/235534207-2086c34b-4e88-425a-85af-084aa2efd928.png">
