### PR TITLE
Utils | Text: Adding configurable force word break option

### DIFF
--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -58,6 +58,8 @@ export type UnovisTextOptions = {
   textAlign?: TextAlign | string;
   // Whether to use a fast estimation method or a more accurate one for text calculations.
   fastMode?: boolean;
+  // Force word break if they don't fit into the width
+  wordBreak?: boolean;
 }
 
 export type UnovisTextFrameOptions = UnovisTextOptions & {


### PR DESCRIPTION
This code change updates the `breakTextIntoLines` and `getWrappedText` functions to add support for breaking words when they exceed the specified width of a text container. The main changes in this update include:

1. Adding an optional `wordBreak` parameter to both `breakTextIntoLines` and `getWrappedText` functions. The default value for this parameter is set to `false`.
2. Implementing the word break functionality in the `breakTextIntoLines` function. This is done by checking the `wordBreak` parameter and, if `true`, iteratively breaking the line into smaller parts and inserting a hyphen at the break point to create sub-lines with the appropriate width.
3. Modifying the `getWrappedText` function to pass the `wordBreak` parameter to the `breakTextIntoLines` function.
4. Updating the `renderTextToSvgTextElement` and `renderTextIntoFrame` functions to pass the `wordBreak` option from their respective options objects to the `getWrappedText` function.

These changes will provide us with more control over text wrapping behavior when dealing with long words in the text containers.