### PR TITLE
Component | Axis: Fixing `tickFormat` calling when `tickValues` are set explicitly

### DIFF
--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -190,7 +190,8 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfig<Datum>, AxisC
     const { config } = this
 
     const axisGen = this._buildAxis()
-    axisGen.tickValues(this._getConfiguredTickValues())
+    const tickValues: (number | Date)[] = this._getConfiguredTickValues() || axisGen.scale<ContinuousScale>().ticks(this._getNumTicks())
+    axisGen.tickValues(tickValues)
 
     // Interrupting all active transitions first to prevent them from being stuck.
     // Somehow we see it happening in Angular apps.
@@ -205,7 +206,6 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfig<Datum>, AxisC
 
     // Selecting the <text> elements of the ticks to apply formatting. By default, this selection
     // will include exiting elements, so we're filtering them out.
-    const tickValues: (number | Date)[] = axisGen.scale<ContinuousScale>().ticks(this._getNumTicks())
     const tickText = selection.selectAll<SVGTextElement, number | Date>('g.tick > text')
       .filter(tickValue => tickValues.some(t => isEqual(tickValue, t))) // We use isEqual to compare Dates
 

--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -35,6 +35,10 @@ export const isEqual = (a?: unknown | null, b?: unknown | null, visited: Set<any
     return true
   }
 
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime()
+  }
+
   if (typeof a === 'object' && a !== null && b !== null) {
     if (!(typeof b === 'object')) return false
     if (a === b) return true


### PR DESCRIPTION
#184