### PR TITLE
CI/CD: Update the website only when the `publish` branch gets updated

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: main
+    branches: publish
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Currently our website gets updated form the main branch so it contains all in-progress work that has not been released yet. This PR switches the deployment branch from `main` to `publish` to solve that issue.