### PR TITLE
Core: Using native ResizeObserver when available

### DIFF
--- a/packages/ts/src/components/leaflet-flow-map/index.ts
+++ b/packages/ts/src/components/leaflet-flow-map/index.ts
@@ -1,10 +1,10 @@
 import { select } from 'd3-selection'
-import { ResizeObserver } from '@juggle/resize-observer'
 
 import { ComponentCore } from 'core/component'
 import { ComponentType } from 'types/component'
 
 // Utils
+import { ResizeObserver } from 'utils/resize-observer'
 import { getNumber, throttle } from 'utils/data'
 import { getDataLatLngBounds } from 'utils/map'
 import { getColor } from 'utils/color'

--- a/packages/ts/src/components/leaflet-map/index.ts
+++ b/packages/ts/src/components/leaflet-map/index.ts
@@ -2,7 +2,6 @@ import { select, Selection } from 'd3-selection'
 import { packSiblings } from 'd3-hierarchy'
 import type L from 'leaflet'
 import Supercluster, { ClusterFeature, PointFeature } from 'supercluster'
-import { ResizeObserver } from '@juggle/resize-observer'
 import { StyleSpecification } from 'maplibre-gl'
 
 // Core
@@ -16,6 +15,7 @@ import { ComponentType } from 'types/component'
 import { GenericDataRecord } from 'types/data'
 
 // Utils
+import { ResizeObserver } from 'utils/resize-observer'
 import { clamp, isNil, getNumber, getString, isString } from 'utils/data'
 import { constraintMapViewThrottled } from './renderer/mapboxgl-utils'
 import {

--- a/packages/ts/src/core/container/index.ts
+++ b/packages/ts/src/core/container/index.ts
@@ -1,11 +1,11 @@
 import { select, Selection } from 'd3-selection'
-import { ResizeObserver } from '@juggle/resize-observer'
 
 // Types
 import { Sizing } from 'types/component'
 
 // Utils
 import { isEqual, clamp } from 'utils/data'
+import { ResizeObserver } from 'utils/resize-observer'
 
 // Config
 import { ContainerConfig, ContainerConfigInterface } from './config'

--- a/packages/ts/src/utils/resize-observer.ts
+++ b/packages/ts/src/utils/resize-observer.ts
@@ -1,0 +1,2 @@
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer'
+export const ResizeObserver = window.ResizeObserver || ResizeObserverPolyfill


### PR DESCRIPTION
When native ResizeObserver is available, use it instead of the polyfilled version #207