### PR TITLE
Container | XY: Render right after initialization if there are axes or components with data

### DIFF
--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -81,8 +81,12 @@ export class XYContainer<Datum> extends ContainerCore {
       this.setData(data, true)
     }
 
-    // Render if components are present and have data
-    if (this.components?.some(c => c.datamodel.data)) {
+    // Render if there are axes or components with data
+    if (
+      this.config.xAxis ||
+      this.config.yAxis ||
+      this.components?.some(c => c.datamodel.data)
+    ) {
       this.render()
     }
 


### PR DESCRIPTION
Previously, rendering was not happening if XY Container had only axes configured and no components, i.e. in our Axis docs:
<img width="1049" alt="image" src="https://github.com/f5/unovis/assets/755708/daedadee-9745-468d-881b-3cb1ea4cbbc5">

The issue was there for a long time but it became visible after my recent rendering optimizations.