### PR TITLE
Component | Nested Donut tweaks

### DIFF
--- a/packages/ts/src/components/nested-donut/modules/label.ts
+++ b/packages/ts/src/components/nested-donut/modules/label.ts
@@ -50,7 +50,7 @@ function getLabelBounds<Datum> (
 ): { width: number; height: number } {
   const arcWidth = d.y1 - d.y0
   const arcLength = d._layer._innerRadius * (d.x1 - d.x0)
-  const bandwidth = Math.max(Math.abs(Math.cos(d.x0 + (d.x1 - d.x0) / 2 - Math.PI / 2) * d._layer.width), arcWidth)
+  const bandwidth = Math.max(Math.abs(Math.cos(d.x0 + (d.x1 - d.x0) / 2 - Math.PI / 2) * arcWidth), arcWidth)
   switch (d._layer.labelAlignment) {
     case NestedDonutSegmentLabelAlignment.Perpendicular:
       return { width: arcWidth, height: arcLength }

--- a/packages/ts/src/components/nested-donut/modules/label.ts
+++ b/packages/ts/src/components/nested-donut/modules/label.ts
@@ -3,10 +3,10 @@ import { color } from 'd3-color'
 import { Arc } from 'd3-shape'
 
 // Utils
-import { UNOVIS_TEXT_DEFAULT } from 'styles'
 import { getColor, hexToBrightness } from 'utils/color'
 import { smartTransition } from 'utils/d3'
 import { getString } from 'utils/data'
+import { getCSSVariableValueInPixels } from 'utils/misc'
 import { cssvar } from 'utils/style'
 import { wrapSVGText } from 'utils/text'
 
@@ -85,11 +85,16 @@ export function updateLabel<Datum> (
     .each((d, i, els) => {
       const bounds = getLabelBounds(d)
       const label = select(els[i]).call(wrapSVGText, bounds.width)
-      const offset = label.selectChildren().size() - 1
+
       const { width, height } = label.node().getBBox()
 
-      label.attr('dy', -offset * UNOVIS_TEXT_DEFAULT.fontSize + (2 * offset))
-        .attr('visibility', config.hideOverflowingSegmentLabels && (width > bounds.width || height > bounds.height) && 'hidden')
+      if (config.hideOverflowingSegmentLabels && (width > bounds.width || height > bounds.height) && 'hidden') {
+        label.attr('visibility', 'hidden')
+      } else {
+        const fontSize = getCSSVariableValueInPixels(cssvar(variables.nestedDonutSegmentLabelFontSize), els[i])
+        const len = label.selectChildren().size() - 1
+        label.attr('dy', -fontSize / 2 * len)
+      }
     })
 
   smartTransition(selection, duration)

--- a/packages/ts/src/components/nested-donut/style.ts
+++ b/packages/ts/src/components/nested-donut/style.ts
@@ -25,6 +25,7 @@ const cssVarDefaults = {
   '--vis-nested-donut-segment-stroke-color': 'var(--vis-nested-donut-background-color)',
   '--vis-nested-donut-segment-label-text-color-light': '#5b5f6d',
   '--vis-nested-donut-segment-label-text-color-dark': '#fff',
+  '--vis-nested-donut-segment-label-font-size': '1em',
 
   /* Dark theme */
   '--vis-dark-nested-donut-background-color': '#18160C',
@@ -69,6 +70,7 @@ export const segmentLabel = css`
   text-anchor: middle;
   dominant-baseline: middle;
   user-select: none;
+  font-size: var(--vis-nested-donut-segment-label-font-size);
 `
 
 export const centralLabel = css`

--- a/packages/ts/src/components/nested-donut/types.ts
+++ b/packages/ts/src/components/nested-donut/types.ts
@@ -29,7 +29,7 @@ export enum NestedDonutSegmentLabelAlignment {
 export type NestedDonutLayerSettings = {
   backgroundColor?: string;
   labelAlignment?: NestedDonutSegmentLabelAlignment;
-  width?: number;
+  width?: number | string;
 }
 
 export type NestedDonutLayer = NestedDonutLayerSettings & {

--- a/packages/ts/src/utils/misc.ts
+++ b/packages/ts/src/utils/misc.ts
@@ -31,6 +31,10 @@ export function getCSSVariableValueInPixels (s: string, context: HTMLElement | S
   return toPx(val)
 }
 
+export function getPixelValue (v: string | number): number | null {
+  return typeof v === 'number' ? v : toPx(v)
+}
+
 export function rectIntersect (rect1: Rect, rect2: Rect, tolerancePx = 0): boolean {
   const [left1, top1, right1, bottom1] = [
     rect1.x + tolerancePx,

--- a/packages/website/docs/misc/NestedDonut.mdx
+++ b/packages/website/docs/misc/NestedDonut.mdx
@@ -256,27 +256,33 @@ Read Donut's [doc page](./donut) to learn more.
 _Nested Donut_ supports the following CSS variables:
 
 ```css
---vis-nested-donut-background-color: #e7e9f3
 /* Undefined by default to allow proper fallback to var(--vis-font-family) */
---vis-nested-donut-font-family: undefined
+--vis-nested-donut-font-family: undefined;
+
+/* Background */
+--vis-nested-donut-background-color: #e7e9f3
 
 /* Central label */
---vis-nested-donut-central-label-font-size: 16px
---vis-nested-donut-central-label-font-weight: 600
---vis-nested-donut-central-label-text-color: #5b5f6d
+--vis-nested-donut-central-label-font-size: 16px;
+--vis-nested-donut-central-label-font-weight: 600;
+--vis-nested-donut-central-label-text-color: #5b5f6d;
 
 /* Central sub-label */
---vis-nested-donut-central-sublabel-font-size: 12px
---vis-nested-donut-central-sublabel-font-weight: 500
---vis-nested-donut-central-sublabel-text-color: #5b5f6d
+--vis-nested-donut-central-sublabel-font-size: 12px;
+--vis-nested-donut-central-sublabel-font-weight: 500;
+--vis-nested-donut-central-sublabel-text-color: #5b5f6d;
 
 /* Segments */
---vis-nested-donut-segment-stroke-width: 1px
+--vis-nested-donut-segment-stroke-width: 1px;
+--vis-nested-donut-segment-stroke-color: var(--vis-nested-donut-background-color);
+--vis-nested-donut-segment-label-text-color-light: #5b5f6d;
+--vis-nested-donut-segment-label-text-color-dark: #fff;
+--vis-nested-donut-segment-label-font-size: 1em;
 
 /* Dark theme */
---vis-dark-nested-donut-background-color: #18160c
---vis-dark-nested-donut-central-label-text-color: #fff
---vis-dark-nested-donut-central-sublabel-text-color: #fff
+--vis-dark-nested-donut-background-color: #18160c;
+--vis-dark-nested-donut-central-label-text-color: #fff;
+--vis-dark-nested-donut-central-sublabel-text-color: #fff;
 ```
 
 ## Component Props

--- a/packages/website/docs/misc/NestedDonut.mdx
+++ b/packages/website/docs/misc/NestedDonut.mdx
@@ -101,7 +101,7 @@ which accepts an accessor that returns the following type based on the layer's d
 
 ```typescript
 type NestedDonutLayerSettings = {
-  width: number; // The layer's width in pixels
+  width: number | string; // The layer's width in pixels or css string to be converted to pixels
   labelAlignment: NestedDonutSegmentLabelAlignment; // Alignment of the layer's segment labels
 }
 ```

--- a/packages/website/src/examples/sunburst-nested-donut/data.ts
+++ b/packages/website/src/examples/sunburst-nested-donut/data.ts
@@ -56,7 +56,7 @@ export const colors = new Map([
   ['Resinous', 'rgb(126, 106, 158)'],
   ['Turpeny', 'rgb(126, 106, 158)'],
   ['Piney', '#72659d'],
-  ['Blackcurrant', '#8a6e9e'],
+  ['Black Currant', '#8a6e9e'],
   ['Medicinal', 'rgb(145, 84, 136)'],
   ['Camphoric', '#8f5c85'],
   ['Cineolic', '#934b8b'],
@@ -285,7 +285,7 @@ export const data = [
     group: 'Dry Distillation',
     subgroup: 'Resinous',
     description: 'Turpeny',
-    item: 'Blackcurrant',
+    item: 'Black Currant',
   },
   {
     type: 'Aromas',

--- a/packages/website/src/examples/sunburst-nested-donut/index.tsx
+++ b/packages/website/src/examples/sunburst-nested-donut/index.tsx
@@ -27,6 +27,7 @@ const example: Example = {
   data: require('!!raw-loader!./data').default,
   preview: require(`../_previews/${pathname}.png`).default,
   previewDark: require(`../_previews/${pathname}-dark.png`).default,
+  styles: require('!!raw-loader!./styles.css').default,
 }
 
 export default example

--- a/packages/website/src/examples/sunburst-nested-donut/styles.css
+++ b/packages/website/src/examples/sunburst-nested-donut/styles.css
@@ -1,0 +1,4 @@
+.sunburst {
+    height: 60vmin;
+    --vis-nested-donut-segment-label-font-size: 1vmin;
+}

--- a/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.component.html
+++ b/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.component.html
@@ -1,7 +1,7 @@
-<vis-single-container [data]="data" [height]="1000">
+<vis-single-container [data]="data" class="sunburst">
     <vis-nested-donut
         [direction]="direction"
-        [hideSegmentLabels]="true"
+        [hideOverflowingSegmentLabels]="false"
         [layers]="layers"
         [layerSettings]="layerSettings"
         [segmentColor]="segmentColor"

--- a/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.component.ts
+++ b/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.component.ts
@@ -5,6 +5,7 @@ import { colors, data, Datum } from './data'
 @Component({
   selector: 'sunburst-nested-donut',
   templateUrl: './sunburst-nested-donut.component.html',
+  styleUrls: ['./styles.css'],
 })
 export class SunburstChartComponent {
   data = data
@@ -17,10 +18,7 @@ export class SunburstChartComponent {
     (d: Datum) => d.item,
   ]
 
-  layerSettings = {
-    width: 100,
-    rotateLabels: true,
-  }
+  layerSettings = { width: '6vmin' }
 
   segmentColor = (d: NestedDonutSegment<Datum>): string => colors.get(d.data.key)
 }

--- a/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
+++ b/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
@@ -13,14 +13,18 @@
   const segmentColor = (d: NestedDonutSegment<Datum>) => colors.get(d.data.key)
 </script>
 
-<VisSingleContainer data={data} height={1000}>
+<VisSingleContainer data={data} class='sunburst'>
   <VisNestedDonut
     direction='outwards'
-    hideSegmentLabels={false}
-    layerSettings={{
-      width: 100,
-      rotateLabels: true,
-    }}
+    hideOverflowingSegmentLabels={false}
+    layerSettings={{ width: '6vmin' }}
     {layers}
     {segmentColor}/>
 </VisSingleContainer>
+
+<style>
+  .sunburst {
+    height: 60vmin;
+    --vis-nested-donut-segment-label-font-size: 1vmin;
+  }
+</style>

--- a/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.ts
+++ b/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.ts
@@ -1,11 +1,15 @@
 import { SingleContainer, NestedDonut, NestedDonutSegment } from '@unovis/ts'
 import { colors, data, Datum } from './data'
 
+import './styles.css'
+
 const container = document.getElementById('vis-container')
+container.classList.add('sunburst')
+
 const chart = new SingleContainer(container, {
   component: new NestedDonut<Datum>({
     direction: 'outwards',
-    hideSegmentLabels: false,
+    hideOverflowingSegmentLabels: false,
     layers: [
       (d: Datum) => d.type,
       (d: Datum) => d.group,
@@ -13,8 +17,7 @@ const chart = new SingleContainer(container, {
       (d: Datum) => d.description,
       (d: Datum) => d.item,
     ],
-    layerSettings: { width: 100, rotateLabels: true },
+    layerSettings: { width: '6vmin' },
     segmentColor: (d: NestedDonutSegment<Datum>) => colors.get(d.data.key),
   }),
-  height: 1000,
 }, data)

--- a/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.tsx
+++ b/packages/website/src/examples/sunburst-nested-donut/sunburst-nested-donut.tsx
@@ -3,11 +3,14 @@ import { VisSingleContainer, VisNestedDonut } from '@unovis/react'
 import { NestedDonutSegment } from '@unovis/ts'
 import { colors, data, Datum } from './data'
 
+import './styles.css'
+
 export default function SunburstChart (): JSX.Element {
   return (
-    <VisSingleContainer data={data} height={1000}>
+    <VisSingleContainer data={data} className='sunburst'>
       <VisNestedDonut
-        hideSegmentLabels={false}
+        direction='outwards'
+        hideOverflowingSegmentLabels={false}
         layers={useMemo(() => [
           (d: Datum) => d.type,
           (d: Datum) => d.group,
@@ -15,9 +18,9 @@ export default function SunburstChart (): JSX.Element {
           (d: Datum) => d.description,
           (d: Datum) => d.item,
         ], [])}
-        layerSettings={{ width: 100, rotateLabels: true }}
+        layerSettings={{ width: '6vmin' }}
         segmentColor={useCallback((d: NestedDonutSegment<Datum>) => colors.get(d.data.key), [])}
-        direction='outwards'/>
+      />
     </VisSingleContainer>
   )
 }


### PR DESCRIPTION
This PR adds the following changes to _Nested Donut_ component:
- Segment label font size is now configurable with the css variable `--vis-nested-donut-segment-label-font-size` (default: `1em`)
- The `width` property of `NetsedDonutLayerSettings` now accepts css units as strings like `10vh`, `1em`. (Note: Like with SingleContainer, percentages won't work)

Utilized above features to address the sizing issue for the gallery example (ref: #230) and updated the docs.