### PR TITLE
Svelte: Adding Svelte 4 to the supported `peerDependencies` list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20131,7 +20131,7 @@
       },
       "peerDependencies": {
         "@unovis/ts": "1.1.1",
-        "svelte": "^3.48.0"
+        "svelte": "^3.48.0 || ^4.0.0"
       }
     },
     "packages/svelte/node_modules/tslib": {

--- a/packages/svelte/licences.txt
+++ b/packages/svelte/licences.txt
@@ -13,3 +13,4 @@ tslib                         perpetual       0BSD          2.4.1              M
 ttypescript                   perpetual       MIT           1.5.13             cevek
 typescript                    perpetual       Apache-2.0    4.2.4              Microsoft Corp.
 @unovis/ts                    perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+svelte                        perpetual       MIT           3.50.1             Rich Harris

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@unovis/ts": "1.1.1",
-    "svelte": "^3.48.0"
+    "svelte": "^3.48.0 || ^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.4",


### PR DESCRIPTION
Adding Svelte 4 support in advance. We'll do actual tests after the new version gets released, and for now we'll just hope that everything is going to work out of the box. #236