### PR TITLE
Release 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unovis",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unovis",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -20005,7 +20005,7 @@
     },
     "packages/angular": {
       "name": "@unovis/angular",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -20034,7 +20034,7 @@
         "@angular/common": "12 - 16",
         "@angular/compiler": "12 - 16",
         "@angular/core": "12 - 16",
-        "@unovis/ts": "1.1.1"
+        "@unovis/ts": "1.2.0"
       }
     },
     "packages/angular/node_modules/@types/node": {
@@ -20079,7 +20079,7 @@
     },
     "packages/react": {
       "name": "@unovis/react",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.0.4",
@@ -20100,7 +20100,7 @@
         "typescript": "~4.2.4"
       },
       "peerDependencies": {
-        "@unovis/ts": "1.1.1",
+        "@unovis/ts": "1.2.0",
         "react": ">=16.8.0 || ^17 || ^18",
         "react-dom": ">=16.8.0 || ^17 || ^18"
       }
@@ -20113,7 +20113,7 @@
     },
     "packages/svelte": {
       "name": "@unovis/svelte",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.0.4",
@@ -20130,7 +20130,7 @@
         "typescript": "~4.2.4"
       },
       "peerDependencies": {
-        "@unovis/ts": "1.1.1",
+        "@unovis/ts": "1.2.0",
         "svelte": "^3.48.0 || ^4.0.0"
       }
     },
@@ -20142,7 +20142,7 @@
     },
     "packages/ts": {
       "name": "@unovis/ts",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unovis",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": [

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unovis/angular",
   "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/f5/unovis.git",
@@ -46,7 +46,7 @@
     "@angular/common": "12 - 16",
     "@angular/compiler": "12 - 16",
     "@angular/core": "12 - 16",
-    "@unovis/ts": "1.1.1"
+    "@unovis/ts": "1.2.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^12.0.3",

--- a/packages/dev/licences.txt
+++ b/packages/dev/licences.txt
@@ -19,4 +19,4 @@ typescript-plugin-css-modules         perpetual       MIT           4.1.1       
 webpack                               perpetual       MIT           5.75.0             Tobias Koppers @sokra
 webpack-cli                           perpetual       MIT           5.0.1              n/a
 webpack-dev-server                    perpetual       MIT           4.11.1             Tobias Koppers @sokra
-@unovis/ts                            perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/ts                            perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)

--- a/packages/react/licences.txt
+++ b/packages/react/licences.txt
@@ -16,6 +16,6 @@ tsconfig-paths-webpack-plugin      perpetual       MIT           3.5.2          
 tslib                              perpetual       0BSD          2.4.1              Microsoft Corp.
 ttypescript                        perpetual       MIT           1.5.13             cevek
 typescript                         perpetual       Apache-2.0    4.2.4              Microsoft Corp.
-@unovis/ts                         perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/ts                         perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 react                              perpetual       MIT           16.14.0            n/a
 react-dom                          perpetual       MIT           16.14.0            n/a

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unovis/react",
   "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/f5/unovis.git",
@@ -35,7 +35,7 @@
     "publish:dist": "rm -rf dist/.cache; cp ./{LICENSE,README.md,package.json} ./dist; cd ./dist; npm publish"
   },
   "peerDependencies": {
-    "@unovis/ts": "1.1.1",
+    "@unovis/ts": "1.2.0",
     "react": ">=16.8.0 || ^17 || ^18",
     "react-dom": ">=16.8.0 || ^17 || ^18"
   },

--- a/packages/svelte/licences.txt
+++ b/packages/svelte/licences.txt
@@ -12,5 +12,5 @@ svelte-preprocess             perpetual       MIT           4.10.7             C
 tslib                         perpetual       0BSD          2.4.1              Microsoft Corp.
 ttypescript                   perpetual       MIT           1.5.13             cevek
 typescript                    perpetual       Apache-2.0    4.2.4              Microsoft Corp.
-@unovis/ts                    perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/ts                    perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 svelte                        perpetual       MIT           3.50.1             Rich Harris

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unovis/svelte",
   "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/f5/unovis.git",
@@ -36,7 +36,7 @@
     "publish:dist": "rm -rf dist/.cache; cp ./{LICENSE,README.md,package.json} ./dist; cd ./dist; npm publish"
   },
   "peerDependencies": {
-    "@unovis/ts": "1.1.1",
+    "@unovis/ts": "1.2.0",
     "svelte": "^3.48.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/svelte/src/containers/single-container/single-container.svelte
+++ b/packages/svelte/src/containers/single-container/single-container.svelte
@@ -6,25 +6,31 @@
 
   export let data: Data
 
-  let chart: SingleContainer<Data>
+  let chart: SingleContainer<Data> | undefined
   const config: SingleContainerConfigInterface<Data> = {
     component: undefined,
     tooltip: undefined,
   }
   let ref: HTMLDivElement
 
-  $: chart?.setData(data, true)
-  $: chart?.updateContainer({ ...config, ...($$restProps as SingleContainerConfigInterface<Data>) })
+  const initChart = () => {
+    if (data && config.component && ref) {
+      chart = new SingleContainer<Data>(ref, config, data)
+    }
+  }
+  $: chart ? chart.setData(data, true) : initChart()
+  $: chart ? chart.updateContainer({ ...config, ...($$restProps as SingleContainerConfigInterface<Data>) }) : initChart()
 
   onMount(() => {
-    chart = new SingleContainer<Data>(ref, config, data)
-    return () => chart.destroy()
+    initChart()
+    return () => chart?.destroy()
   })
 
   setContext('tooltip', () => ({
     update: (t: Tooltip) => { config.tooltip = t },
     destroy: () => { config.tooltip = undefined },
   }))
+
   setContext('component', () => ({
     update: (c: ComponentCore<Data>) => { config.component = c },
     destroy: () => { config.component = undefined },

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@unovis/ts",
   "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/f5/unovis.git",

--- a/packages/website/licences.txt
+++ b/packages/website/licences.txt
@@ -32,7 +32,7 @@ rollup-plugin-terser                       perpetual       MIT           7.0.2  
 rollup-plugin-typescript2                  perpetual       MIT           0.31.2             @ezolenko
 svelte-preprocess                          perpetual       MIT           4.10.7             Christian Kaisermann <christian@kaisermann.me>
 typescript                                 perpetual       Apache-2.0    4.2.4              Microsoft Corp.
-@unovis/angular                            perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
-@unovis/react                              perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
-@unovis/svelte                             perpetual       Apache-2.0    1.1.1              Rebecca Bol, F5 Inc. <r.bol@f5.com>
-@unovis/ts                                 perpetual       Apache-2.0    1.1.1              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/angular                            perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/react                              perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
+@unovis/svelte                             perpetual       Apache-2.0    1.2.0              Rebecca Bol, F5 Inc. <r.bol@f5.com>
+@unovis/ts                                 perpetual       Apache-2.0    1.2.0              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)

--- a/packages/website/src/utils/stackblitz.ts
+++ b/packages/website/src/utils/stackblitz.ts
@@ -109,7 +109,8 @@ function getStarterFiles (framework: Framework, e: Example): ProjectFiles {
             "svelte-preprocess": "^4.10.7",
             "tslib": "^2.4.0",
             "typescript": "^4.6.4",
-            "vite": "^3.1.0"
+            "vite": "^3.1.0",
+            "web-worker": "^1.2.0"
           }
         }`),
         'vite.config.ts': trimMultiline(`


### PR DESCRIPTION
## Unovis 1.2.0
A new version of _Unovis_ is waiting for you on NPM! This update introduces a new component: Nested Donut (aka Sunburst). It also adds better support for accessibility features, allows you to apply additional styles to axes, and much more.

## Release highlights:
### 🍩  **New component: _Nested Donut_**
_Nested Donut_ is a captivating graphical representation that displays hierarchical data in a circular format. Its nested design allows for multiple concentric rings, each representing a different level of data, enabling users to explore relationships and proportions effortlessly.
<img  alt="SCR-20230616-iwvk" src="https://github.com/f5/unovis/assets/755708/4903488a-275a-4595-9dbf-de9d6ff918eb">
![248906133-5288af22-5811-457d-b04d-7135bbcb6b9d](https://github.com/f5/unovis/assets/755708/cd1d2119-e789-44a3-a673-d9fdc23f767d)

### 👓  **Accessibility: Supporting ARIA tags #214**
You can now set the `aria-label` attribute for your visualization by providing the `ariaLabel` config property to the container you use. Unovis will automatically apply `role="figure"` attribute to the container element, making it accessible to assistive technologies.
<img alt="Image showing aria-label support in Unovis" src="https://github.com/f5/unovis/assets/755708/028ea127-899c-455e-ad23-e02121019440">

https://github.com/f5/unovis/assets/755708/15c4dde8-7a87-469a-a0e8-8b1f82aaf869


### 🔠  **New CSS variables for styling Axis #203 #223**
If you want to customize the width of your tick and grid lines, you can do so using the new `--vis-axis-tick-line-width` and `--vis-axis-grid-line-width` variables. 

The color of the domain line by default equals the tick color (that can be specified with `--vis-axis-tick-color`), but _Unovis 1.2_ allows you to explicitly set it via `--vis-axis-domain-color`.

Additionally you can apply custom `cursor` and `text-decoration` to your tick labels with `--vis-axis-tick-label-cursor` and `--vis-axis-tick-label-text-decoration` variables.

<img  alt="image" src="https://github.com/f5/unovis/assets/755708/8bce43b1-d955-4683-a55a-6596da9b2bf0">


## Other changes
### Enhancements
* Component | LeafletMap: Adding `getExpandedCluster` public method #205
* Component | Line: Better enter transition for broken lines #227
* Component | Scatter: Fixing the missing points issue #227
* Component | Scatter: Stroke color and width support #232

### Bug Fixes:
* Container | XY: Calling render right after initialization if there are axes or components with data (#212)
* @unovis/svelte: Updating component lifecycles to prevent DOM related errors with SvelteKt (SSR) #216

### Other
* Core: Using native ResizeObserver when available #209
* Dependencies: Updating Dagre packages to work with Angular 16 #210
