### PR TITLE
Fix | Nested Donut alignment issue

### DIFF
--- a/packages/angular/src/containers/single-container/single-container.component.ts
+++ b/packages/angular/src/containers/single-container/single-container.component.ts
@@ -23,7 +23,7 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
   @Input() height?: number
 
   /** Margins. Default: `{ top: 0, bottom: 0, left: 0, right: 0 }` */
-  @Input() margin?: Spacing = { top: 10, bottom: 10, left: 10, right: 10 }
+  @Input() margin?: Spacing = { top: 0, bottom: 0, left: 0, right: 0 }
   /** Animation duration of all the components within the container. Default: `undefined` */
   @Input() duration?: number
   /** Alternative text description of the chart for accessibility purposes. It will be applied as an

--- a/packages/angular/src/containers/xy-container/xy-container.component.ts
+++ b/packages/angular/src/containers/xy-container/xy-container.component.ts
@@ -83,7 +83,7 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
   /** Animation duration of all the components within the container. Default: `undefined` */
   @Input() duration?: number = undefined
   /** Margins. Default: `{ top: 0, bottom: 0, left: 0, right: 0 }` */
-  @Input() margin?: Spacing = { top: 10, bottom: 10, left: 10, right: 10 }
+  @Input() margin?: Spacing = { top: 0, bottom: 0, left: 0, right: 0 }
   /** Padding. Default: `{ top: 0, bottom: 0, left: 0, right: 0 }` */
   @Input() padding?: Spacing = {}
   /** Sets the Y scale domain based on the current X scale domain (not the whole dataset). Default: `false` */

--- a/packages/ts/src/components/nested-donut/index.ts
+++ b/packages/ts/src/components/nested-donut/index.ts
@@ -78,7 +78,10 @@ NestedDonutConfigInterface<Datum>
       .outerRadius(d => d.y1)
       .cornerRadius(config.cornerRadius)
 
-    this.g.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.arcGroup.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.arcBackground.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.centralLabel.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.centralSubLabel.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
 
     // Layer backgrounds
     const backgrounds = this.arcBackground


### PR DESCRIPTION
<img width="685" alt="image (1)" src="https://github.com/f5/unovis/assets/52078477/d63badd9-a80b-4706-9f45-4106ed7a2161">

Changes:
- Nested Donut: No longer transforms `g` directly because it was overriding the transform applied by the container for `margin` property
- `@unovis/angular`: Updating the default values for `margin` to align with the rest of the wrappers.