### PR TITLE
Scatter: Configuration property to hide / show overlapping labels; Doc tweaks

### DIFF
--- a/packages/angular/src/components/nested-donut/nested-donut.component.ts
+++ b/packages/angular/src/components/nested-donut/nested-donut.component.ts
@@ -8,11 +8,11 @@ import {
   VisEventCallback,
   NestedDonutDirection,
   NumericAccessor,
+  NestedDonutSegment,
   StringAccessor,
   GenericAccessor,
   NestedDonutLayerSettings,
   ColorAccessor,
-  NestedDonutSegment,
 } from '@unovis/ts'
 import { VisCoreComponent } from '../../core'
 
@@ -99,6 +99,9 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
    * Default: `false` */
   @Input() showBackground?: boolean
 
+  /** Sort function for segments. Default `undefined` */
+  @Input() sort?: (a: NestedDonutSegment<Datum>, b: NestedDonutSegment<Datum>) => number
+
   /** Array of accessor functions to defined the nested groups */
   @Input() layers: StringAccessor<Datum>[]
 
@@ -150,8 +153,8 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
   }
 
   private getConfig (): NestedDonutConfigInterface<Datum> {
-    const { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments } = this
-    const config = { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments }
+    const { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments } = this
+    const config = { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments }
     const keys = Object.keys(config) as (keyof NestedDonutConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/scatter/scatter.component.ts
+++ b/packages/angular/src/components/scatter/scatter.component.ts
@@ -124,6 +124,9 @@ export class VisScatterComponent<Datum> implements ScatterConfigInterface<Datum>
   /** Label color. Default: `undefined` */
   @Input() labelColor?: ColorAccessor<Datum>
 
+  /** Hide overlapping labels. Default: `true` */
+  @Input() labelHideOverlapping?: boolean
+
   /** Optional point cursor. Default: `null` */
   @Input() cursor?: StringAccessor<Datum>
 
@@ -159,8 +162,8 @@ export class VisScatterComponent<Datum> implements ScatterConfigInterface<Datum>
   }
 
   private getConfig (): ScatterConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, size, sizeScale, sizeRange, shape, label, labelColor, cursor, labelTextBrightnessRatio, labelPosition, strokeColor, strokeWidth } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, size, sizeScale, sizeRange, shape, label, labelColor, cursor, labelTextBrightnessRatio, labelPosition, strokeColor, strokeWidth }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, size, sizeScale, sizeRange, shape, label, labelColor, labelHideOverlapping, cursor, labelTextBrightnessRatio, labelPosition, strokeColor, strokeWidth } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, size, sizeScale, sizeRange, shape, label, labelColor, labelHideOverlapping, cursor, labelTextBrightnessRatio, labelPosition, strokeColor, strokeWidth }
     const keys = Object.keys(config) as (keyof ScatterConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/scatter/scatter-point-label/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-point-label/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { VisXYContainer, VisScatter, VisAxis } from '@unovis/react'
+
+import { generateXYDataRecords, XYDataRecord } from '@src/utils/data'
+
+export const title = 'Points with labels'
+export const subTitle = 'Multi-accessor'
+export const component = (): JSX.Element => {
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  const data = generateXYDataRecords(35)
+  const size = (d: XYDataRecord): number => (d.x % 2 === 0 ? 25 : 10)
+  return (
+    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }}>
+      <VisScatter x={d => d.x} y={accessors} size={size} label={(d, i) => `${accessors[i](d)?.toFixed(2)}`} />
+      <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}`}/>
+    </VisXYContainer>
+  )
+}

--- a/packages/ts/src/components/scatter/config.ts
+++ b/packages/ts/src/components/scatter/config.ts
@@ -28,6 +28,8 @@ export interface ScatterConfigInterface<Datum> extends XYComponentConfigInterfac
   label?: StringAccessor<Datum>;
   /** Label color. Default: `undefined` */
   labelColor?: ColorAccessor<Datum>;
+  /** Hide overlapping labels. Default: `true` */
+  labelHideOverlapping?: boolean;
   /** Optional point cursor. Default: `null` */
   cursor?: StringAccessor<Datum>;
   /** Point color brightness ratio for switching between dark and light text label color. Default: `0.65` */
@@ -48,6 +50,7 @@ export class ScatterConfig<Datum> extends XYComponentConfig<Datum> implements Sc
   label = undefined
   labelColor = undefined
   labelPosition = Position.Bottom
+  labelHideOverlapping = true
   cursor = null
   labelTextBrightnessRatio = 0.65
   strokeColor: ScatterConfigInterface<Datum>['strokeColor'] = undefined

--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -135,10 +135,16 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfig<Datum>,
     removePoints(points.exit<ScatterPoint<Datum>>(), this.xScale, this.yScale, duration)
 
     // Take care of overlapping labels
-    this._collideLabels()
+    this._resolveLabelOverlap()
   }
 
-  private _collideLabels (): void {
+  private _resolveLabelOverlap (): void {
+    if (!this.config.labelHideOverlapping) {
+      const label = this._points.selectAll<SVGTextElement, ScatterPoint<Datum>>('text')
+      label.attr('opacity', null)
+      return
+    }
+
     cancelAnimationFrame(this._collideLabelsAnimFrameId)
     this._collideLabelsAnimFrameId = requestAnimationFrame(() => {
       collideLabels(this._points, this.config, this.xScale, this.yScale)
@@ -210,13 +216,13 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfig<Datum>,
     if (pointNode) pointNode._forceShowLabel = true
 
     point.raise()
-    this._collideLabels()
+    this._resolveLabelOverlap()
   }
 
   private _onPointMouseOut (d: ScatterPoint<Datum>, event: MouseEvent): void {
     const pointNode = select(event.target as SVGGElement).node() as ScatterPointGroupNode | null
     if (pointNode) delete pointNode._forceShowLabel
 
-    this._collideLabels()
+    this._resolveLabelOverlap()
   }
 }

--- a/packages/website/docs/xy-charts/Scatter.mdx
+++ b/packages/website/docs/xy-charts/Scatter.mdx
@@ -53,25 +53,30 @@ Fox example, if `sizeRange` is set to `[10,50]`, that will make the default size
 You can also place labels on _Scatter's_ points by passing a string accessor function to the `label` property.
 <XYWrapper {...defaultProps(15, true)} size={20} label={d => d.label}/>
 
-### Label Text Brightness Ratio
-By default, the _Scatter_ component will assign label color based on the point's shade with the `labelTextBrightnessRatio` property.
-It accepts any value between `0` and `1` (inclusive).
-
-The default setting `0.65` creates darker text on light backgrounds and light text on dark backgrounds.
-See how the contrast differs in the following examples, when we assign more extreme values to the `labelTextBrightnessRatio` property:
-<XYWrapperWithInput {...defaultProps(10, true)} size={20} color={d => d.color} label={d => d.label} property="labelTextBrightnessRatio" inputType="range" inputProps={{ min: 0.5, max: 0.7, step: 0.01}} defaultValue={0.65}/>
-
 ### Label Color
 You can also configure a custom color for your labels by providing the `labelColor` attribute with a color accessor method or string.
 Note that setting this property overrides `labelTextBrightnessRatio`.
 
-<XYWrapper {...defaultProps(15, true)} size={20} label={d => d.label} labelColor={'yellow'}/>
+<XYWrapper {...defaultProps(15, true)} size={20} label={d => d.label} labelColor={'red'}/>
 
 ### Label Position
 You can change a point's label position with the `labelPosition` property, which accepts a  _Position_ or _Position_ accessor
 function. Supported values are `Position.Center`, `Position.Bottom` (default), `Position.Left`, `Position.Right` and `Position.Top`
 
 <XYWrapperWithInput {...defaultProps(15, true)} hiddenProps={{ size: d => d.size, label: d => d.label}} property='labelPosition' inputType="select" options={['bottom', 'center', 'left', 'right', 'top']}/>
+
+### Label Text Brightness Ratio
+By default, labels with `Position.Center` will be assigned a color based on the point's shade with the `labelTextBrightnessRatio` property.
+It accepts any value between `0` and `1` (inclusive).
+
+The default setting `0.65` creates darker text on light backgrounds and light text on dark backgrounds.
+See how the contrast differs in the following examples, when we assign more extreme values to the `labelTextBrightnessRatio` property:
+<XYWrapperWithInput {...defaultProps(10, true)} size={20} color={d => d.color} label={d => d.label} labelPosition="center" property="labelTextBrightnessRatio" inputType="range" inputProps={{ min: 0.5, max: 0.7, step: 0.01}} defaultValue={0.65}/>
+
+### Overlapping Labels
+When there're overlapping labels, _Scatter_ will hide some of them to avoid cluttering. You can see hidden labels by hobvering over the points.
+If you want to disable hiding overlapping labels, you can set the `labelHideOverlapping` property to `false`.
+<XYWrapperWithInput {...defaultProps(45, true)} size={10} color={d => d.color} label={d => `Point ${d.label}`} property="labelHideOverlapping" inputType="checkbox" defaultValue={true}/>
 
 ### Custom Cursor
 _Scatter_ also allows to set a [custom](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) `cursor` when hovering


### PR DESCRIPTION
Updated Docs:
![Screen Recording 2023-08-08 at 11 43 58 AM](https://github.com/f5/unovis/assets/755708/7e28166c-1825-4664-b1ea-f59cefae36fa)

New Dev examples:
<img width="1154" alt="SCR-20230808-klnr" src="https://github.com/f5/unovis/assets/755708/7a662869-b78c-451c-8728-a134108ab9ec">
