### PR TITLE
Component | Axis: Setting label and tick text color via config; Dual-axis chart dev example

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -120,6 +120,9 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Distance between the axis and the label in pixels. Default: `8` */
   @Input() labelMargin?: number
 
+  /** Font color of the axis label as CSS string. Default: `null` */
+  @Input() labelColor?: string | null
+
   /** Sets whether to draw the grid lines or not. Default: `true` */
   @Input() gridLine?: boolean
 
@@ -162,6 +165,9 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
   @Input() tickTextAlign?: TextAlign | string
 
+  /** Font color of the tick text as CSS string. Default: `null` */
+  @Input() tickTextColor?: string | null
+
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   @Input() tickPadding?: number
   @Input() data: Datum[]
@@ -185,8 +191,8 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   }
 
   private getConfig (): AxisConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, position, type, fullSize, label, labelFontSize, labelMargin, gridLine, tickLine, domainLine, minMaxTicksOnly, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickPadding } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, position, type, fullSize, label, labelFontSize, labelMargin, gridLine, tickLine, domainLine, minMaxTicksOnly, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickPadding }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, position, type, fullSize, label, labelFontSize, labelMargin, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickPadding } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, position, type, fullSize, label, labelFontSize, labelMargin, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickPadding }
     const keys = Object.keys(config) as (keyof AxisConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/dual-axis/index.tsx
+++ b/packages/dev/src/examples/xy-components/dual-axis/index.tsx
@@ -1,0 +1,48 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisArea, VisLine, VisAxis } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+
+export const title = 'Dual Axis Chart'
+export const subTitle = 'Generated Data'
+export const component = (): JSX.Element => {
+  const margin = { left: 100, right: 100, top: 40, bottom: 60 }
+  const style: React.CSSProperties = { position: 'absolute', top: 0, left: 0, width: '100%', height: '40vh' }
+  return (<>
+    <VisXYContainer
+      data={generateXYDataRecords(150)}
+      margin={margin}
+      autoMargin={false}
+      style={style}
+    >
+      <VisArea<XYDataRecord> x={d => d.x} y={(d: XYDataRecord, i: number) => i * (d.y || 0)} opacity={0.9} color='#FF6B7E'/>
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} label='Time'/>
+      <VisAxis type='y'
+        tickFormat={(y: number) => `${y}bps`}
+        tickTextWidth={60}
+        tickTextColor='#FF6B7E'
+        labelColor='#FF6B7E'
+        label='Traffic'
+      />
+    </VisXYContainer>
+    <VisXYContainer
+      data={generateXYDataRecords(150)}
+      yDomain={[0, 150]}
+      margin={margin}
+      autoMargin={false}
+      style={style}
+    >
+      <VisLine<XYDataRecord> x={d => d.x} y={d => 20 + 10 * (d.y2 || 0)}/>
+      <VisAxis
+        type='y'
+        position={'right'}
+        tickFormat={(y: number) => `${y}db`}
+        gridLine={false}
+        tickTextColor='#4D8CFD'
+        labelColor='#4D8CFD'
+        label='Signal Strength'
+      />
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -19,6 +19,8 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   labelFontSize?: string | null;
   /** Distance between the axis and the label in pixels. Default: `8` */
   labelMargin?: number;
+  /** Font color of the axis label as CSS string. Default: `null` */
+  labelColor?: string | null;
   /** Sets whether to draw the grid lines or not. Default: `true` */
   gridLine?: boolean;
   /** Sets whether to draw the tick lines or not. Default: `true` */
@@ -47,6 +49,8 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickTextFontSize?: string | null;
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
   tickTextAlign?: TextAlign | string;
+  /** Font color of the tick text as CSS string. Default: `null` */
+  tickTextColor?: string | null;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   tickPadding?: number;
 }
@@ -68,7 +72,9 @@ export class AxisConfig<Datum> extends XYComponentConfig<Datum> implements AxisC
   tickTextFitMode = FitMode.Wrap
   tickTextFontSize = null
   tickTextAlign = undefined
+  tickTextColor = null
   labelMargin = 8
+  labelColor = null
   tickFormat = undefined
   tickValues = undefined
   fullSize = true

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -209,6 +209,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfig<Datum>, AxisC
     const tickText = selection.selectAll<SVGTextElement, number | Date>('g.tick > text')
       .filter(tickValue => tickValues.some(t => isEqual(tickValue, t))) // We use isEqual to compare Dates
       .classed(s.tickLabel, true)
+      .style('fill', config.tickTextColor)
 
     // We interrupt the transition on tick's <text> to make it 'wrappable'
     tickText.nodes().forEach(node => interrupt(node))
@@ -316,9 +317,10 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfig<Datum>, AxisC
       .append('text')
       .attr('class', s.label)
       .text(label)
-      .style('font-size', labelFontSize)
       .attr('dy', `${this._getLabelDY()}em`)
       .attr('transform', `translate(${offsetX + marginX},${offsetY + marginY}) rotate(${rotation})`)
+      .style('font-size', labelFontSize)
+      .style('fill', this.config.labelColor)
   }
 
   _getLabelDY (): number {

--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -92,13 +92,14 @@ export const tick = css`
     stroke-width: var(--vis-axis-tick-line-width);
   }
 
-  text, tspan {
+  text {
     fill: var(--vis-axis-tick-label-color);
-    font-family: var(--vis-axis-font-family, var(--vis-font-family));
     cursor: var(--vis-axis-tick-label-cursor);
+    font-family: var(--vis-axis-font-family, var(--vis-font-family));
     text-decoration: var(--vis-axis-tick-label-text-decoration);
     stroke: none;
   }
+
 `
 
 export const label = css`

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -60,6 +60,10 @@ You can provide a string to label your axes with the `label` property:
 Change the label size (in pixels) with the `labelFontSize` property.
 <XYWrapperWithInput {...defaultProps()} inputType="range" label="Label" defaultValue={30} property="labelFontSize"/>
 
+### Label Color
+Change the label color with the `labelColor` property.
+<XYWrapperWithInput {...defaultProps()} inputType="color" label="Label" defaultValue={'#1acb9a'} property="labelColor"/>
+
 ### Label Margin
 The spacing between the label and the axis itself can be set with the `labelMargin` property:
 <XYWrapperWithInput {...defaultProps()} label="Label" inputType="range" inputProps={{ min: 0, max: 50, step: 1}} defaultValue={5} property="labelMargin"/>
@@ -100,6 +104,10 @@ You can remove tick labels from your axis by setting the `tickLine` property to 
 ### Tick Label Font Size
 To change the font size for the tick labels, you provide the `tickTextFontSize` property with a CSS string.
 <XYWrapperWithInput {...defaultProps()} inputType="text" defaultValue={'50px'} property="tickTextFontSize"/>
+
+### Tick Label Color
+You can change the color of the tick labels with the `tickTextColor` property.
+<XYWrapperWithInput {...defaultProps()} inputType="color" defaultValue={'#1acb9a'} property="tickTextColor"/>
 
 ### Tick Label Format
 You can customize how ticks are formatted using the `tickFormat` property and a label formatter function.


### PR DESCRIPTION
This PR will allow users to configure axis label and tick text color via the config object. Also adding a dev example of a dual-axis chart.

<img width="736" alt="image" src="https://github.com/f5/unovis/assets/755708/c30e759e-c0d5-4521-951a-c886044906a8">
<img width="936" alt="SCR-20230825-kzmf" src="https://github.com/f5/unovis/assets/755708/a6b32eb7-bd63-4134-9a16-cece2d6b7b84">
<img width="935" alt="SCR-20230825-kzon" src="https://github.com/f5/unovis/assets/755708/2d34198c-533c-4ed6-abc0-ca11b2629b94">
