### PR TITLE
Theme | New theme: Patterns

### DIFF
--- a/packages/dev/src/App.module.css
+++ b/packages/dev/src/App.module.css
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap');
-@import url('https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css');
 
 * {
   box-sizing: border-box;
@@ -14,6 +14,17 @@
 
 body {
   margin: 0;
+  color: var(--color-black);
+}
+
+body.theme-dark {
+  background-color: var(--color-black);
+  color: var(--color-light-grey);
+  color-scheme: dark;
+}
+
+body.theme-dark select, body.theme-dark input {
+  background-color: var(--color-grey);
 }
 
 textarea:focus, input:focus, input[type]:focus, .uneditable-input:focus {
@@ -28,6 +39,5 @@ textarea:focus, input:focus, input[type]:focus, .uneditable-input:focus {
   height: 100%;
   display: flex;
   flex-direction: row;
-  color: var(--color-black);
   padding: 8px 8px 8px 8px;
 }

--- a/packages/dev/src/App.tsx
+++ b/packages/dev/src/App.tsx
@@ -3,12 +3,14 @@ import { Outlet } from 'react-router-dom'
 
 // Internal Components
 import { NavigationSideBar } from '@src/components/NavigationSideBar'
+import { ThemeSelector } from '@src/components/ThemeSelector'
 
 // Examples
 import { examples } from '@src/examples'
 
 // Styles
 import s from './App.module.css'
+
 
 // Unovis base styles (using require to avoid tree-shaking)
 // eslint-disable-next-line import/no-unresolved
@@ -17,6 +19,7 @@ require('@unovis/ts/styles')
 const App = (): JSX.Element => {
   return (
     <div className={s.root}>
+      <ThemeSelector/>
       <NavigationSideBar exampleGroups={examples} />
       <Outlet />
     </div>

--- a/packages/dev/src/components/ThemeSelector/index.tsx
+++ b/packages/dev/src/components/ThemeSelector/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+// Styles
+import s from './style.module.css'
+
+export function ThemeSelector (): JSX.Element {
+  const toggleTheme = (e: React.FormEvent): void => {
+    document.body.classList.toggle((e.target as Element).id)
+  }
+
+  return (
+    <div onChange={toggleTheme} className={s.themeSelector}>
+      <label className={s.colorTheme}>
+        <input type='checkbox' id='theme-dark'/>
+        <div className='slider'>
+          <span className='fa-solid fa-sun'/>
+          <span className='fa-solid fa-moon'/>
+        </div>
+      </label>
+      <label className={s.patternTheme}>
+        <input type='checkbox' id='theme-patterns'/>
+        <span className='fa-solid fa-magic-wand-sparkles'/>
+      </label>
+    </div>
+  )
+}

--- a/packages/dev/src/components/ThemeSelector/style.module.css
+++ b/packages/dev/src/components/ThemeSelector/style.module.css
@@ -1,0 +1,68 @@
+:root {
+  --color-active: #2299ff;
+  --color-slider-bg: var(--color-grey);
+  --color-slider-icon: #fff;
+}
+
+body.theme-dark {
+  --color-slider-bg: #eee;
+  --color-slider-icon: var(--color-grey);
+}
+
+.themeSelector {
+  position: absolute;
+  right: 8px;
+  z-index: 999;
+  border-radius: 10px;
+  display: flex;
+}
+
+.themeSelector label {
+  cursor: pointer;
+  margin: 0 2px;
+}
+
+.themeSelector input[type='checkbox'] {
+  display: none;
+}
+
+.colorTheme {
+  border-radius: 20px;
+  position: relative;
+}
+
+.slider {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--color-slider-bg);
+  color: var(--color-slider-icon);
+  border-radius: 90px;
+  min-width: 2.5em;
+  height: 100%;
+  padding: 2px 0.25em;
+}
+
+
+.slider::after {
+  position: absolute;
+  content: '';
+  left: 0;
+  width: 1.3em;
+  height: 1.3em;
+  background: var(--color-active);
+  border-radius: 90px;
+  transition: 0.3s;
+}
+
+input:checked + .slider::after {
+  transform: translateX(100%);
+}
+
+.patternTheme > input:not(:checked) + span {
+  opacity: 0.6;
+}
+
+.patternTheme > input:checked + span {
+  color: var(--color-active);
+}

--- a/packages/dev/src/components/TransitionComponent/index.tsx
+++ b/packages/dev/src/components/TransitionComponent/index.tsx
@@ -44,10 +44,10 @@ export function TransitionComponent<T> (props: TransitionComponentProps<T>): JSX
     </div>
     {Object.keys(dataSeries).map((key) => (
       <div key={key}>
-        <p>
-          <span className={usingDefaultData ? s.focus : ''}>Default</span>
-          ⇔
-          <span className={!usingDefaultData ? s.focus : ''}>{
+        <p className='label'>
+          <span className={usingDefaultData ? s.inactive : ''}>Default</span>
+          <span className='fa fa-arrows-left-right'></span>
+          <span className={!usingDefaultData ? s.inactive : ''}>{
             key.replace(/([A-Z])/g, ' $1').replace(/^./, (match) => match.toUpperCase())
           }</span>
         </p>

--- a/packages/dev/src/components/TransitionComponent/style.module.css
+++ b/packages/dev/src/components/TransitionComponent/style.module.css
@@ -1,21 +1,18 @@
 .controller {
-  position: absolute;
-  right: 0;
   cursor: pointer;
   font-size: larger;
   font-family: 'Font Awesome';
-}
-
-.controller > i {
-  margin: 10px;
   color: lightslategray;
 }
 
-.controller span {
-  margin-inline: 5px;
-  position: relative;
+.controller > i {
+  margin: 0 0.25em;
 }
 
-.controller span:not(.focus) {
+.label > span {
+  margin-inline: 0 0.5em;
+}
+
+.label > .inactive {
   color: lightgrey;
 }

--- a/packages/dev/src/examples/auxiliary/bullet-legend/legend-stacked-bar-donut/index.tsx
+++ b/packages/dev/src/examples/auxiliary/bullet-legend/legend-stacked-bar-donut/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { sum } from 'd3-array'
+import { VisBulletLegend, VisSingleContainer, VisDonut, VisXYContainer, VisStackedBar } from '@unovis/react'
+
+import s from './styles.module.css'
+
+export const title = 'Basic Bullet Legend'
+export const subTitle = 'with Stacked Bar and Donut'
+
+type DataRecord = {
+  x: number;
+  ys: number[];
+}
+
+export const component = (): JSX.Element => {
+  const items = Array(6).fill(0).map((_, i) => ({ name: `y${i}` }))
+  const data = Array(10).fill(0).map((_, i) => ({
+    x: i,
+    ys: items.map(() => Math.random()),
+  }))
+  const accessors = items.map((_, i) => (d: DataRecord) => d.ys[i])
+
+  return (
+    <div className={s.legendExample}>
+      <VisBulletLegend items={items} bulletSize='20px'/>
+      <div className={s.components}>
+        <VisSingleContainer width={300}>
+          <VisDonut data={items} value={(_, i) => sum(data.map(accessors[i]))} centralLabel='Total'/>
+        </VisSingleContainer>
+        <VisXYContainer>
+          <VisStackedBar
+            data={data}
+            x={d => d.x}
+            y={accessors}
+          />
+        </VisXYContainer>
+      </div>
+    </div>
+  )
+}

--- a/packages/dev/src/examples/auxiliary/bullet-legend/legend-stacked-bar-donut/styles.module.css
+++ b/packages/dev/src/examples/auxiliary/bullet-legend/legend-stacked-bar-donut/styles.module.css
@@ -1,0 +1,16 @@
+.legendExample {
+  margin: 0 auto;
+}
+
+.legendExample > div {
+  margin: 10px;
+}
+
+.components {
+  display: flex;
+}
+
+.components > div:last-child {
+  flex: 1;
+  margin-left: 20px;
+}

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/index.tsx
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/index.tsx
@@ -15,19 +15,8 @@ type MapPointDatum = typeof cities[0]
 export const component = (): JSX.Element => {
   const mapKey = 'LNln6dGJDxyBa7F3c7Gd'
   const mapRef = useRef<VisLeafletMapRef<MapPointDatum> | null>(null)
-  const [isDarkTheme, toggleTheme] = useState(false)
-
-  useEffect(() => {
-    return () => document.body.classList.remove('theme-dark')
-  }, [])
-
-  const handleClick = (): void => {
-    toggleTheme(!isDarkTheme)
-    document.body.classList.toggle('theme-dark')
-  }
 
   return (<>
-    <button className={s.toggleThemeButton} onClick={handleClick}>{isDarkTheme ? 'Light' : 'Dark'} Theme</button>
     <div className={s.map}>
       <VisLeafletMap<MapPointDatum>
         ref={mapRef}

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/style.module.css
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-css-vars/style.module.css
@@ -1,10 +1,3 @@
-.toggleThemeButton {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  z-index: 999;
-}
-
 .map {
   --vis-map-cluster-inner-label-text-color-dark: orange;
   --vis-map-cluster-inner-label-text-color-light: yellow;

--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/style.module.css
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-vector/style.module.css
@@ -1,6 +1,5 @@
 .showHideButton {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  left: 0px;
   z-index: 999;
 }

--- a/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
+++ b/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
@@ -1,0 +1,28 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisAxis, VisTooltip, VisCrosshair, VisBulletLegend, VisLine } from '@unovis/react'
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+
+export const title = 'Multi Line Chart'
+export const subTitle = 'Generated Data'
+
+export const component = (): JSX.Element => {
+  const tooltipRef = useRef(null)
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+    () => Math.random(),
+    () => Math.random(),
+  ]
+  return (
+    <>
+      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}>
+        <VisLine x={d => d.x} y={accessors}/>
+        <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} />
+        <VisAxis type='y' tickFormat={(y: number) => `${y}`} />
+        <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
+        <VisTooltip ref={tooltipRef} />
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/ts/src/components/bullet-legend/modules/shape.ts
+++ b/packages/ts/src/components/bullet-legend/modules/shape.ts
@@ -7,18 +7,21 @@ import { ColorAccessor } from 'types/accessor'
 import { getColor } from 'utils/color'
 import { circlePath } from 'utils/path'
 
+// Constants
+import { PATTERN_SIZE_PX } from 'styles/patterns'
+
 // Local types
 import { BulletLegendConfigInterface } from '../config'
 import { BulletShape, BulletLegendItemInterface } from '../types'
 
 // Size with respect to the viewBox. We use this to compute path data which is independent of the
 // the configured size.
-const BULLET_SIZE = 20
+const BULLET_SIZE = PATTERN_SIZE_PX * 3
 
-function getWidth (shape: BulletShape): number {
+function getHeight (shape: BulletShape): number {
   switch (shape) {
     case BulletShape.Line:
-      return BULLET_SIZE * 2.5
+      return BULLET_SIZE / 2.5
     default:
       return BULLET_SIZE
   }
@@ -43,7 +46,7 @@ export function createBullets (
     .attr('width', '100%')
     .attr('height', '100%')
     .append('path')
-    .attr('d', getPath(config.bulletShape, getWidth(config.bulletShape), BULLET_SIZE))
+    .attr('d', getPath(config.bulletShape, BULLET_SIZE, getHeight(config.bulletShape)))
 }
 
 export function updateBullets (
@@ -51,8 +54,8 @@ export function updateBullets (
   config: BulletLegendConfigInterface,
   colorAccessor: ColorAccessor<BulletLegendItemInterface>
 ): void {
-  const height = BULLET_SIZE
-  const width = getWidth(config.bulletShape)
+  const width = BULLET_SIZE
+  const height = getHeight(config.bulletShape)
 
   const getOpacity = (d: BulletLegendItemInterface): number => d.inactive ? 0.4 : 1
 

--- a/packages/ts/src/components/bullet-legend/style.ts
+++ b/packages/ts/src/components/bullet-legend/style.ts
@@ -25,6 +25,10 @@ export const variables = injectGlobal`
     --vis-legend-label-color: var(--vis-dark-legend-label-color);
     --vis-legend-bullet-inactive-color: var(--vis-dark-legend-bullet-inactive-color);
   }
+
+  body.theme-patterns {
+    --vis-legend-bullet-size: 14px;
+  }
 `
 
 export const item = css`

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -57,6 +57,9 @@ export class SingleContainer<Data> extends ContainerCore {
       tooltip.setComponents([this.component])
     }
 
+    // Defs
+    this.element.appendChild(this._svgDefs.node())
+
     if (!preventRender) this.render()
   }
 

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -45,7 +45,6 @@ export type XYConfigInterface<Datum> = XYComponentConfigInterface<Datum>
 export class XYContainer<Datum> extends ContainerCore {
   config: XYContainerConfig<Datum> = new XYContainerConfig()
   datamodel: CoreDataModel<Datum[]> = new CoreDataModel()
-  private _svgDefs: Selection<SVGDefsElement, unknown, null, undefined>
   private _clipPath: Selection<SVGClipPathElement, unknown, null, undefined>
   private _clipPathId = guid()
   private _axisMargin: Spacing = { top: 0, bottom: 0, left: 0, right: 0 }
@@ -67,7 +66,6 @@ export class XYContainer<Datum> extends ContainerCore {
       --highlight-filter-id: url(${baseUrl}#${highlightFilterId}); // defining a css variable
     `)
 
-    this._svgDefs = this.svg.append('defs')
     this._svgDefs.append('filter')
       .attr('id', highlightFilterId)
       .attr('filterUnits', 'objectBoundingBox')

--- a/packages/ts/src/core/container/index.ts
+++ b/packages/ts/src/core/container/index.ts
@@ -20,6 +20,7 @@ export class ContainerCore {
   protected _requestedAnimationFrame: number
   protected _isFirstRender = true
   protected _resizeObserver: ResizeObserver | undefined
+  protected _svgDefs: Selection<SVGDefsElement, unknown, null, undefined>
   private _containerSize: { width: number; height: number }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -42,6 +43,7 @@ export class ContainerCore {
       .attr('height', ContainerCore.DEFAULT_CONTAINER_HEIGHT) // Overriding default SVG height of 150
       .attr('aria-hidden', true)
 
+    this._svgDefs = this.svg.append('defs')
     this.element = this.svg.node()
   }
 

--- a/packages/ts/src/styles/index.ts
+++ b/packages/ts/src/styles/index.ts
@@ -2,6 +2,7 @@ import { injectGlobal } from '@emotion/css'
 import { getCSSVariableValue } from 'utils/misc'
 import { UnovisText } from 'types/text'
 import { colors, colorsDark, getCSSColorVariable, getLighterColor, getDarkerColor } from './colors'
+import { fills, lines, getPatternVariable } from './patterns'
 
 export const UNOVIS_ICON_FONT_FAMILY_DEFAULT = globalThis?.UNOVIS_ICON_FONT_FAMILY || 'FontAwesome'
 export const UNOVIS_FONT_WH_RATIO_DEFAULT: number = globalThis?.UNOVIS_FONT_W2H_RATIO_DEFAULT || 0.5
@@ -27,11 +28,32 @@ export const variables = injectGlobal`
     --vis-color-grey: #2a2a2a;
     ${colors.map((c, i) => `${getCSSColorVariable(i)}: ${c};`)}
     ${colorsDark.map((c, i) => `--vis-dark-color${i}: ${c};`)}
+    ${fills.map((p, i) => `
+      --${getPatternVariable(p)}: url(#${getPatternVariable(p)});
+      --vis-pattern-fill${i}: var(--${getPatternVariable(p)});
+    `)}
+    ${lines.map((p, i) => `
+      --${getPatternVariable(p)}: url(#${getPatternVariable(p)});
+      --vis-pattern-marker${i}: var(--${getPatternVariable(p)});
+      --vis-pattern-dasharray${i}: ${p.dashArray?.join(' ')};
+    `)}
 
     body.theme-dark {
       ${colors.map((c, i) => `${getCSSColorVariable(i)}: var(--vis-dark-color${i});`)}
     }
-  }
+
+    body.theme-patterns {
+      ${fills.map((_, i) => `path[style*="fill: var(${getCSSColorVariable(i)})"]  {
+        mask: var(--vis-pattern-fill${i});
+      }`)}
+      ${lines.map((_, i) => `
+      path[stroke="var(${getCSSColorVariable(i)})"]:not([style*="fill"]),
+      path[style*="stroke: var(${getCSSColorVariable(i)})"]:not([style*="fill"]) {
+        marker: var(--vis-pattern-marker${i});
+        stroke-dasharray: var(--vis-pattern-dasharray${i});
+      }
+    `)}
+}
 `
 
 export function getFontWidthToHeightRatio (context: HTMLElement | SVGGElement | undefined = window?.document.body): number {

--- a/packages/ts/src/styles/patterns.ts
+++ b/packages/ts/src/styles/patterns.ts
@@ -1,0 +1,72 @@
+import { getCSSColorVariable } from './colors'
+
+type Pattern = {
+  id: string;
+  width?: number;
+  height?: number;
+}
+
+type FillPattern = Pattern & {
+  svg: string;
+}
+
+type LinePattern = Pattern & {
+  marker: string;
+  dashArray: number[];
+}
+
+export const PATTERN_SIZE_PX = 10
+
+export const fills: FillPattern[] = [
+  { id: 'stripes-diagonal', svg: '<path d="M-1,1 l2,-2 M0,10 l10,-10 M9,11 l2,-2" stroke="#000"/>' },
+  { id: 'dots', svg: '<path d="m0-1.5a1 1 0 010 3m10-3a1 1 0 000 3M5 3.5a1 1 0 010 3 1 1 0 010-3M0 8.5 a1 1 0 010 3m10-3a1 1 0 000 3" fill"#000"/>' },
+  { id: 'stripes-vertical', svg: '<path d="M 5,-1 L5,11" stroke="#000"/>' },
+  { id: 'crosshatch', svg: '<path d="M0 0L10 10ZM10 0L0 10Z" stroke="#000"/>' },
+  { id: 'waves', svg: '<path d="M0 4Q2.5 1 5 4 7.5 7 10 4v2Q7.5 9 5 6 2.5 3 0 6Z" fill="#000"/>' },
+  { id: 'circles', svg: '<circle cx="5" cy="5" r="3" stroke="#000" fill="#fff"/>' },
+]
+export const lines: LinePattern[] = [
+  { id: 'circle', marker: '<circle cx="5" cy="5" r="5"/>', dashArray: [] },
+  { id: 'triangle', marker: '<path d="M5,0 L10,9 L0,9Z">', dashArray: [9, 1] },
+  { id: 'diamond', marker: '<path d="M 0 5 L5 0 L 10 5 L 5 10 L 0 5Z">', dashArray: [2] },
+  { id: 'arrow', marker: '<path d="M4 0 0 0 6 5 0 10 4 10 10 5Z">', dashArray: [2, 3, 8, 3] },
+  { id: 'square', marker: '<rect x="1" y="1" width="8" height="8"/>', dashArray: [6] },
+  { id: 'star', marker: '<path d="m2 9 3-9 3 9L0 3h10Z"/>', dashArray: [1, 6] },
+]
+
+export function getPatternVariable (p: Pattern): string {
+  return `vis-${`pattern-${(p as FillPattern).svg ? 'fill' : 'marker'}`}-${p.id}`
+}
+
+const maskDef = (p: FillPattern): string =>
+  `<mask id="${getPatternVariable(p)}">
+    <pattern id="${p.id}" viewBox="0 0 10 10" width="${PATTERN_SIZE_PX}" height="${PATTERN_SIZE_PX}" patternUnits="userSpaceOnUse">
+      <rect width="100%" height="100%" fill="#fff"/>
+      ${p.svg}
+    </pattern>
+    <rect x="-50%" y="-50%" width="200%" height="200%" fill="url(#${p.id})"/>
+  </mask>`
+
+const markerDef = (p: LinePattern, i: number): string =>
+  `<marker id="${getPatternVariable(p)}"
+    fill="var(${getCSSColorVariable(i)})"
+    markerUnits="userSpaceOnUse"
+    refX="5"
+    refY="5"
+    markerWidth="${PATTERN_SIZE_PX}"
+    markerHeight="${PATTERN_SIZE_PX}">
+    ${p.marker}
+  </marker>`
+
+// // Injecting SVG defs as a single SVG element on the page
+function injectSVGDefs (): void {
+  const svgDefs = fills.map(maskDef).concat(lines.map(markerDef)).join('')
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  svg.setAttribute('height', '100%')
+  svg.setAttribute('width', '100%')
+  svg.setAttribute('position', 'absolute')
+  svg.innerHTML = `<defs>${svgDefs}</defs>`
+  document.body.appendChild(svg)
+}
+
+if (typeof window !== 'undefined') injectSVGDefs()

--- a/packages/website/docs/guides/theming.mdx
+++ b/packages/website/docs/guides/theming.mdx
@@ -61,7 +61,8 @@ export function SizedScatter (props) {
   )
 }
 
-## Overview
+## CSS Variables
+### Overview
 In addition to configuration properties, our components also rely on
 [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
 to supply the values of various SVG attributes such as `fill`, `stroke`, `opacity`, etc. You can override
@@ -74,7 +75,7 @@ Note that while our variables follow this convention, it does not guarantee that
 to override is available. Be sure to check the corresponding doc page of the component you want to customize
 to see the available CSS variables.
 
-## Basic Example
+### Basic Example
 Variables can be overridden in your CSS style declarations. Consider the default configuration for sankey, which looks like this:
 
 <DocWrapper {...sankeyProps()} subLabel={d => Math.random()} excludeTabs/>
@@ -95,7 +96,7 @@ _Sankey_ component, we will see the following result:
    <DocWrapper {...sankeyProps()} subLabel={d => Math.random()} excludeTabs/>
 </div>
 
-## Dark Theme
+### Dark Theme Usage
 Our library offers dark theme support which takes effect when the class `theme-dark` is added to the
 document's `body` element. Every component has a dark version of each color variable labeled with the
 prefix `--vis-dark`. You can opt not to override these if you want to use our default dark theme values,
@@ -109,13 +110,46 @@ or override them like so:
   '--vis-dark-sankey-link-color',
 ]}/>
 
-## Label Sizing
+## Global Variables
+The majority of our variables exist on a component level,  but there are a few global CSS variables:
+
+<CSSVariables selector=':root' vars={[
+  '--vis-font-family',
+  '--vis-color-main',
+  '--vis-color-main-light',
+  '--vis-color-main-dark',
+  '--vis-color-grey',
+]}/>
+
+:::note
+Unless overridden explicitly, `--vis-color-main` corresponds to the first color in the default [color palette](#color-palette)
+:::
+
+## Label Styling
+### Font
+The font for labels across all of our components is defined by the `--vis-font-family` variable. The default font,
+[Inter](https://rsms.me/inter/), is not imported by default, but you can easily import it yourself from
+[Google Fonts](https://fonts.google.com/specimen/Inter).
+
+To use a different font, simply redefine the `--vis-font-family` CSS variable:
+
+<div className='custom-font'>
+  <CSSVariables vars={['--vis-font-family']} selector='.custom-font'/>
+  <XYWrapper
+    {...scatterProps}
+    labelPosition='center'
+    data={generateScatterDataRecords(10)}
+    sizeRange={[40,60]}
+  />
+</div>
+
+### Large Sizing
 A common theming scenario is the "large size" theme, for when you want larger font sizes for the
 labels in your charts. We offer two variations in the form of css classes that you can import directly
 from `@unovis/ts`:
 
 ```ts
-import { styleLargeTheme } from '@unovis/ts' // ~1.3x larger
+import { styleLargeSize } from '@unovis/ts' // ~1.3x larger
 import { styleExtraLargeSize } from '@unovis/ts' // 2x larger
 ```
 
@@ -142,39 +176,6 @@ point labels will try fit to the point's size. In this case, you will instead ne
 Additionally, you may need to adjust the [`rowHeight`](../xy-charts/Timeline#row-height) property to
 accommodate larger labels.
 :::
-
-## Global Variables
-The majority of our variables exist on a component level,  but there are a few global CSS variables:
-
-<CSSVariables selector=':root' vars={[
-  '--vis-font-family',
-  '--vis-color-main',
-  '--vis-color-main-light',
-  '--vis-color-main-dark',
-  '--vis-color-grey',
-]}/>
-
-:::note
-Unless overridden explicitly, `--vis-color-main` corresponds to the first color in the default [color palette](#color-palette)
-:::
-
-## Font
-The font for labels across all of our components is defined by the `--vis-font-family` variable. The default font,
-[Inter](https://rsms.me/inter/), is not imported by default, but you can easily import it yourself from
-[Google Fonts](https://fonts.google.com/specimen/Inter).
-
-To use a different font, simply redefine the `--vis-font-family` CSS variable:
-
-<div className='custom-font'>
-  <CSSVariables vars={['--vis-font-family']} selector='.custom-font'/>
-  <XYWrapper
-    {...scatterProps}
-    labelPosition='center'
-    data={generateScatterDataRecords(10)}
-    sizeRange={[40,60]}
-  />
-</div>
-
 
 ## Color Palette
 Many of our components use the default color palette for visualizations. You can import the array of hex values directly
@@ -248,6 +249,98 @@ globalThis.UNOVIS_COLORS = [...]
 ```
 This needs to be done before the library is imported, i.e. in your top level JS file or HTML.
 :::
+
+## Applying Patterns
+When `document.body` has the class `theme-patterns` we automatically apply patterns of two types:
+
+### Fill Patterns
+For solid shapes (most cases). You can customize fill patterns by assigning the corresponding CSS
+to a SVG [`mask`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask) reference.
+
+The fill pattern palette looks like:
+
+<body class='theme-patterns' style={{ marginBottom: '20px'}}>
+  <XYWrapper
+    name='StackedBar'
+    data={Array(6).fill(0).map((_, i) => ({ x: i, y: 1 + Math.random(), color: `var(--vis-color${i})` }))}
+    x={d => d.x}
+    y={d => d.y}
+    color={d => d.color}
+    height={100}
+    components={[axis('x', { numTicks: 6, tickFormat: i => `Fill Pattern #${i}`})]}
+    excludeTabs
+  />
+</body>
+
+<details open>
+<summary>Default CSS Variables:</summary>
+
+```css
+--vis-pattern-fill0: var(--vis-pattern-fill-stripes-diagonal);
+--vis-pattern-fill1: var(--vis-pattern-fill-dots);
+--vis-pattern-fill2: var(--vis-pattern-fill-stripes-vertical);
+--vis-pattern-fill3: var(--vis-pattern-fill-crosshatch);
+--vis-pattern-fill4: var(--vis-pattern-fill-waves);
+--vis-pattern-fill5: var(--vis-pattern-fill-circles);
+```
+
+</details>
+
+### Line Patterns
+For the _Line_ component and when _BulletLegend_'s `bulletShape` property is set to `"line"`.
+You can customize these patterns by assigning any combination of the following variable types:
+- Prefixed `--vis-pattern-marker`: accepts SVG defs containings
+[`marker`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker) elements
+- Variables with the prefix `--vis-pattern-dasharray` to a valid value for the
+[stroke-dasharray](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray) property. The default palette looks like:
+  
+<body class='theme-patterns' style={{ marginBottom: '20px'}}>
+  <XYWrapper
+    name='Line'
+    {...xyProps(6)}
+    y={Array(6).fill(0).map((_, i) => (d, j) => i + (j === 0 ? 0.5 : d.values[i]))}
+    components={[axis('y', {
+      tickValues: Array(6).fill(0).map((_, i) => i + 0.5),
+      tickFormat: i => `Line Pattern #${Math.floor(i)}`
+    })]}
+    excludeTabs
+  />
+</body>
+
+  
+<details>
+<summary>Default CSS Variables:</summary>
+
+```css
+--vis-pattern-marker0: var(--vis-pattern-marker-circle);
+
+--vis-pattern-marker1: var(--vis-pattern-marker-triangle);
+--vis-pattern-dasharray1: 9 1;
+
+--vis-pattern-marker2: var(--vis-pattern-marker-diamond);
+--vis-pattern-dasharray2: 2;
+
+--vis-pattern-marker3: var(--vis-pattern-marker-arrow);
+--vis-pattern-dasharray3: 2 3 8 3;
+
+--vis-pattern-marker4: var(--vis-pattern-marker-square);
+--vis-pattern-dasharray4: 6;
+
+--vis-pattern-marker5: var(--vis-pattern-marker-star);
+--vis-pattern-dasharray5: 1 6;
+```
+
+</details>
+
+### Summary
+To override default patterns use the following table for reference.
+
+| CSS Variable Prefix       | Type | Accepted Value | Example |
+| ------------------------- | -----| ----------- | --------------- |
+| `--vis-pattern-fill`      | Fill | SVG [`mask`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/mask) from a `<defs>` element | `url(#my-pattern-fill)` |
+| `--vis-pattern-marker`    | Line | SVG [`marker`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker) from a `<defs>` element | `url(#my-line-marker)` |
+| `--vis-pattern-dasharray` | Line | CSS [stroke-dasharray](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray) property | `5 10` |
+
 
 ## Bordered Segments
 For charts with multiple data layers, it might be preferable to have a visual separation of elements.


### PR DESCRIPTION
The PR adds a new theme to the library.

#### Pattern Theme
When `document.body` has the class `theme-patterns` we automatically apply patterns of two types:
- **Fill patterns** for solid shapes (most cases). Users can customize fill patterns by assigning `--vis-pattern${i}` to a valid SVG def of a `mask` element. The default palette looks like:
<img width="708" alt="Screen Shot 2023-10-03 at 2 56 27 PM" src="https://github.com/f5/unovis/assets/52078477/6450b1ac-f95d-4fcf-bf30-fe87a8a375e8">

with the corresponding css variables:

```
--vis-pattern-fill0: var(--vis-pattern-fill-stripes-diagonal);
--vis-pattern-fill1: var(--vis-pattern-fill-dots);
--vis-pattern-fill2: var(--vis-pattern-fill-stripes-vertical);
--vis-pattern-fill3: var(--vis-pattern-fill-crosshatch);
--vis-pattern-fill4: var(--vis-pattern-fill-waves);
--vis-pattern-fill5: var(--vis-pattern-fill-circles);
```

- **Line patterns** for the _Line_ component and when _BulletLegend_'s `bulletShape` property is set to `"line"`. Users can customize these patterns by assigning `--vis-pattern-marker${i}` to a valid SVG def of a `marker` element or `--vis-pattern-dasharray${i}` to a valid value for the [stroke-dasharray](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray) property. The default palette looks like:
  
<img width="606" alt="Screen Shot 2023-10-03 at 2 56 48 PM" src="https://github.com/f5/unovis/assets/52078477/8a0b8f8d-9a28-4352-8b3b-918928241841">

with the corresponding css variables:

```
--vis-pattern-marker0: var(--vis-pattern-marker-circle);

--vis-pattern-marker1: var(--vis-pattern-marker-triangle);
--vis-pattern-dasharray1: 9 1;

--vis-pattern-marker2: var(--vis-pattern-marker-diamond);
--vis-pattern-dasharray2: 2;

--vis-pattern-marker3: var(--vis-pattern-marker-arrow);
--vis-pattern-dasharray3: 2 3 8 3;

--vis-pattern-marker4: var(--vis-pattern-marker-square);
--vis-pattern-dasharray4: 6;

--vis-pattern-marker5: var(--vis-pattern-marker-star);
--vis-pattern-dasharray5: 1 6;
```

Other changes:
- Added a theme selector to the dev demo app (toggle switch for dark/light theme, wand button toggles pattern theme)
- Tweaked Bullet Legend's viewBox sizing method to accommodate the patterns (tweaking the viewBox height instead of the width gives the best results for both types)