### PR TITLE
Component | Nested Donut | Use `fill-opacity` for segment shading

### DIFF
--- a/packages/ts/src/components/nested-donut/modules/arc.ts
+++ b/packages/ts/src/components/nested-donut/modules/arc.ts
@@ -46,7 +46,8 @@ export function updateArc<Datum> (
 ): void {
   selection
     .style('transition', `fill ${duration}ms`) // Animate color with CSS because we're using CSS-variables
-    .style('fill', d => getColor(d, config.segmentColor) ?? d._state?.fill)
+    .style('fill', d => d._state.fill)
+    .style('fill-opacity', d => d._state.fillOpacity)
 
   if (duration) {
     const transition = smartTransition(selection, duration)

--- a/packages/ts/src/components/nested-donut/types.ts
+++ b/packages/ts/src/components/nested-donut/types.ts
@@ -12,6 +12,7 @@ export type NestedDonutSegment<Datum> = HierarchyRectangularNode<NestedDonutSegm
   _index?: number;
   _state?: {
     fill?: string;
+    fillOpacity?: number | null;
   };
 }
 

--- a/packages/ts/src/utils/color.ts
+++ b/packages/ts/src/utils/color.ts
@@ -8,6 +8,8 @@ import { ColorAccessor, StringAccessor } from 'types/accessor'
 import { getString, isNumber } from 'utils/data'
 import { isStringCSSVariable, getCSSVariableValue } from 'utils/misc'
 
+type RGBColor = { r: number; g: number; b: number }
+
 /** Retrieves color from the data if provided, fallbacks to CSS variables if the index was passed */
 export function getColor<T> (
   d: T,
@@ -21,7 +23,7 @@ export function getColor<T> (
   return (value || ((isNumber(index) && !dontFallbackToCssVar) ? `var(${getCSSColorVariable(index)})` : null))
 }
 
-export function hexToRgb (hex: string): { r: number; g: number; b: number } {
+export function hexToRgb (hex: string): RGBColor {
   const parsed = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
   return parsed ? {
     r: parseInt(parsed[1], 16),
@@ -30,12 +32,28 @@ export function hexToRgb (hex: string): { r: number; g: number; b: number } {
   } : { r: 0, g: 0, b: 0 }
 }
 
+export function rgbToBrightness (rgb: RGBColor): number {
+  return (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255
+}
+
 export function hexToBrightness (hex: string): number {
   const rgb = hexToRgb(hex)
-  return (0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b) / 255
+  return rgbToBrightness(rgb)
 }
 
 export function getHexValue (s: string, context: HTMLElement | SVGElement): string {
   const hex = isStringCSSVariable(s) ? getCSSVariableValue(s, context) : s
   return color(hex)?.formatHex()
+}
+
+export function rgbaToRgb (rgba: string, backgroundColor?: string): RGBColor {
+  const rgb = color(rgba)?.rgb()
+  if (!rgb || rgb.opacity === 1) return rgb
+  const alpha = 1 - rgb.opacity
+  const bg = color(backgroundColor ?? '#fff').rgb()
+  return {
+    r: Math.round((rgb.opacity * (rgb.r / 255) + (alpha * (bg.r / 255))) * 255),
+    g: Math.round((rgb.opacity * (rgb.g / 255) + (alpha * (bg.g / 255))) * 255),
+    b: Math.round((rgb.opacity * (rgb.b / 255) + (alpha * (bg.b / 255))) * 255),
+  }
 }


### PR DESCRIPTION
In this PR, Nested Donut now uses `fill-opacity: <value>` CSS/SVG property to shade nodes instead of altering `fill` values. Segment label coloring logic is also updated to handle this change.

In light theme, the change produces identical results. For dark theme, the shading is darker, which makes sense.

### Light theme:
Before  | After
:-----------|:--------------
![localhost_9500_examples_Nested%20Donut_Nested%20Donut%20Layer%20Configuration](https://github.com/f5/unovis/assets/52078477/ff4b2c23-d0ca-47be-901d-1f4468dbad3d) | ![localhost_9500_examples_Nested%20Donut_Nested%20Donut%20Layer%20Configuration (1)](https://github.com/f5/unovis/assets/52078477/236a51d7-6f28-42c0-9d34-bedb86b1d3f7)

### Dark theme:
Before | After
:-----------|:--------------
![localhost_9500_examples_Nested%20Donut_Nested%20Donut%20Layer%20Configuration (2)](https://github.com/f5/unovis/assets/52078477/2792162c-8bc8-471a-b131-3f2ab82b5463) | ![localhost_9500_examples_Nested%20Donut_Nested%20Donut%20Layer%20Configuration (3)](https://github.com/f5/unovis/assets/52078477/e3c4f5fd-e328-4e74-9845-eca500ae95d7)

