### PR TITLE
Component | BulletLegend: Adding support for bullet shapes

### DIFF
--- a/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
+++ b/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
@@ -1,5 +1,5 @@
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
-import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface } from '@unovis/ts'
+import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface, BulletShape } from '@unovis/ts'
 import { VisGenericComponent } from '../../core'
 
 @Component({
@@ -38,6 +38,9 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
 
   /** Bullet circle size, mapped to the width and height CSS properties. Default: `null` */
   @Input() bulletSize?: string | null
+
+  /** Bullet shape: `BulletShape.Circle`, `BulletShape.Line` or `BulletShape.Square`. Default: `BulletShape.Circle` */
+  @Input() bulletShape?: BulletShape
 
   component: BulletLegend | undefined
 

--- a/packages/dev/src/components/TransitionComponent/style.module.css
+++ b/packages/dev/src/components/TransitionComponent/style.module.css
@@ -11,11 +11,11 @@
   color: lightslategray;
 }
 
-span {
+.controller span {
   margin-inline: 5px;
   position: relative;
 }
 
-span:not(.focus) {
+.controller span:not(.focus) {
   color: lightgrey;
 }

--- a/packages/dev/src/examples/auxiliary/bullet-legend/legend-shapes/index.tsx
+++ b/packages/dev/src/examples/auxiliary/bullet-legend/legend-shapes/index.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useCallback, useEffect, ChangeEvent } from 'react'
+import { BulletLegendItemInterface, BulletShape } from '@unovis/ts'
+import { VisBulletLegend, VisXYContainer, VisScatter, VisGroupedBar, VisLine, VisAxis } from '@unovis/react'
+import { generateStackedDataRecords, StackedDataRecord } from '@src/utils/data'
+
+export const title = 'Bullet Shapes'
+export const subTitle = 'Select chart type'
+
+const data = generateStackedDataRecords(10)
+const items = Array(6).fill(0).map((_, i) => ({ name: `Y${i}`, inactive: false }))
+
+export const component = (): JSX.Element => {
+  const chartOptions = [
+    { type: 'Line', legendShape: BulletShape.Line },
+    { type: 'Scatter', legendShape: BulletShape.Circle },
+    { type: 'Bar', legendShape: BulletShape.Square },
+  ]
+
+  const x = (d: StackedDataRecord): number => d.x
+
+  const [accessors, setAccessors] = useState<(null | ((d: StackedDataRecord) => number))[]>()
+  const [chart, setChart] = useState(chartOptions[0])
+  const [legendItems, setLegendItems] = useState(items)
+
+  const toggleItem = useCallback((_: BulletLegendItemInterface, index: number) => {
+    const newItems = legendItems.map((l, i) => i === index ? ({ ...l, inactive: !l.inactive }) : l)
+    setLegendItems(newItems)
+  }, [legendItems])
+
+  useEffect(() =>
+    setAccessors(legendItems.map((l, i) => l.inactive ? null : (d: StackedDataRecord) => d.ys[i]))
+  , [legendItems])
+
+  return (<>
+    <select onChange={(e: ChangeEvent<HTMLSelectElement>) => setChart(chartOptions[Number(e.target.value)])}>
+      {chartOptions.map((o, i) => <option value={i}>{o.type}</option>)}
+    </select>
+    <VisBulletLegend
+      items={legendItems}
+      bulletShape={chart.legendShape}
+      onLegendItemClick={toggleItem}
+    />
+    <VisXYContainer>
+      {chart.type === 'Line' && <VisLine data={data} x={x} y={accessors}/>}
+      {chart.type === 'Scatter' && <VisScatter data={data} x={x} y={accessors}/>}
+      {chart.type === 'Bar' && <VisGroupedBar data={data} x={x} y={accessors} roundedCorners={0}/>}
+      <VisAxis type='x'/>
+      <VisAxis type='y'/>
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/dev/src/examples/auxiliary/bullet-legend/line-legend/index.tsx
+++ b/packages/dev/src/examples/auxiliary/bullet-legend/line-legend/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { VisBulletLegend, VisXYContainer, VisLine, VisAxis } from '@unovis/react'
+import { generateStackedDataRecords, StackedDataRecord } from '@src/utils/data'
+
+import s from './styles.module.css'
+
+export const title = 'Line Legend'
+export const subTitle = 'with markers and dashes'
+
+const data = generateStackedDataRecords(10)
+const legendItems = Array(data[0].ys.length).fill(0).map((_, i) => ({ name: `Y${i}` }))
+
+export const component = (): JSX.Element => {
+  const svgDefs = `
+    <marker id="circle-marker" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="5" markerHeight="5">
+      <circle cx="5" cy="5" r="4" stroke-width="1" stroke="var(--vis-color2)" fill="#fff"/>
+    </marker>
+    <marker id="square-marker" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="5" markerHeight="5">
+      <polygon points="5,0 10,5 5,10 0,5" stroke="none" fill="var(--vis-color4)"/>
+    </marker>
+    <marker id="arrow-marker" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="5" markerHeight="5">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--vis-color5)"/>
+    </marker>
+  `
+  return (
+    <div className={s.legends}>
+      <VisBulletLegend bulletShape='line' bulletSize='12px' items={legendItems}/>
+      <VisXYContainer data={data} svgDefs={svgDefs}>
+        <VisLine
+          x={(d: StackedDataRecord) => d.x}
+          y={legendItems.map((_, i) => (d: StackedDataRecord) => d.ys[i])}
+        />
+        <VisAxis type='x'/>
+        <VisAxis type='y'/>
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/dev/src/examples/auxiliary/bullet-legend/line-legend/styles.module.css
+++ b/packages/dev/src/examples/auxiliary/bullet-legend/line-legend/styles.module.css
@@ -1,0 +1,20 @@
+.legends *[stroke="var(--vis-color1)"]:not([style*="fill"]) {
+    stroke-dasharray: 5;
+}
+
+.legends *[stroke="var(--vis-color2)"]:not([style*="fill"]) {
+    marker: url('#circle-marker');
+  }
+  
+.legends *[stroke="var(--vis-color3)"]:not([style*="fill"]) {
+    stroke-dasharray: 2;
+  }
+  
+.legends *[stroke="var(--vis-color4)"]:not([style*="fill"]) {
+  marker: url('#square-marker');
+}
+
+.legends *[stroke="var(--vis-color5)"]:not([style*="fill"]) {
+  marker: url('#arrow-marker');
+  stroke-dasharray: 2 7;
+}

--- a/packages/dev/src/utils/data.ts
+++ b/packages/dev/src/utils/data.ts
@@ -6,6 +6,11 @@ export type XYDataRecord = {
   y1?: number;
   y2?: number;
 }
+
+export type StackedDataRecord = {
+  x: number;
+  ys: number[];
+}
 export interface TimeDataRecord {
   timestamp: number;
   value: number;
@@ -39,6 +44,13 @@ export function generateXYDataRecords (n = 10): XYDataRecord[] {
     y: 5 + 5 * Math.random(),
     y1: 1 + 3 * Math.random(),
     y2: 2 * Math.random(),
+  }))
+}
+
+export function generateStackedDataRecords (n = 10, count = 6): StackedDataRecord[] {
+  return Array(n).fill(0).map((_, i) => ({
+    x: i,
+    ys: Array(count).fill(0).map((_, i) => (i * count / 3) + (count * Math.random())),
   }))
 }
 

--- a/packages/ts/src/components/bullet-legend/config.ts
+++ b/packages/ts/src/components/bullet-legend/config.ts
@@ -1,7 +1,7 @@
 import { Config } from 'core/config'
 
 // Local Types
-import { BulletLegendItemInterface } from './types'
+import { BulletLegendItemInterface, BulletShape } from './types'
 
 export interface BulletLegendConfigInterface {
   /** Legend items. Array of `BulletLegendItemInterface`:
@@ -24,8 +24,10 @@ export interface BulletLegendConfigInterface {
   labelFontSize?: string | null;
   /** Label text (<span> element) max-width CSS property. Default: `null` */
   labelMaxWidth?: string | null;
-  /** Bullet circle size, mapped to the width and height CSS properties. Default: `null` */
+  /** Bullet shape size, mapped to the width and height CSS properties. Default: `null` */
   bulletSize?: string | null;
+  /** Bullet shape: `BulletShape.Circle`, `BulletShape.Line` or `BulletShape.Square`. Default: `BulletShape.Circle` */
+  bulletShape?: BulletShape;
 }
 
 export class BulletLegendConfig extends Config implements BulletLegendConfigInterface {
@@ -35,4 +37,5 @@ export class BulletLegendConfig extends Config implements BulletLegendConfigInte
   labelFontSize = null
   labelMaxWidth = null
   bulletSize = null
+  bulletShape = BulletShape.Circle
 }

--- a/packages/ts/src/components/bullet-legend/index.ts
+++ b/packages/ts/src/components/bullet-legend/index.ts
@@ -1,14 +1,13 @@
 import { select, Selection } from 'd3-selection'
-import { color } from 'd3-color'
-
-// Utils
-import { getColor } from 'utils/color'
 
 // Config
 import { BulletLegendConfig, BulletLegendConfigInterface } from './config'
 
 // Local Types
 import { BulletLegendItemInterface } from './types'
+
+// Modules
+import { createBullets, updateBullets } from './modules/shape'
 
 // Styles
 import * as s from './style'
@@ -54,8 +53,7 @@ export class BulletLegend {
 
     legendItemsEnter.append('span')
       .attr('class', s.bullet)
-      .style('width', config.bulletSize)
-      .style('height', config.bulletSize)
+      .call(createBullets, config)
 
     legendItemsEnter.append('span')
       .attr('class', s.label)
@@ -67,18 +65,11 @@ export class BulletLegend {
     legendItemsMerged
       .classed(s.clickable, d => !!config.onLegendItemClick && this._isItemClickable(d))
       .style('display', (d: BulletLegendItemInterface) => d.hidden ? 'none' : null)
-    const legendBulletsToUpdate = legendItemsMerged.select(`.${s.bullet}`)
-    legendBulletsToUpdate.style('background-color', (d: BulletLegendItemInterface, i) => getColor(d, this._colorAccessor, i))
-      .style('border-color', (d: BulletLegendItemInterface, i) => getColor(d, this._colorAccessor, i))
-    legendBulletsToUpdate.each((d, i, elements) => {
-      if (d.inactive) {
-        const bulletColor = window.getComputedStyle(elements[i] as Element).getPropertyValue('background-color')
-        const transparentColor = color(bulletColor)
-        transparentColor.opacity = 0.4
-        select(elements[i])
-          .style('background-color', transparentColor.toString())
-      }
-    })
+
+    legendItemsMerged.select<HTMLSpanElement>(`.${s.bullet}`)
+      .style('min-width', config.bulletSize)
+      .style('height', config.bulletSize)
+      .call(updateBullets, this.config, this._colorAccessor)
 
     legendItemsMerged.select(`.${s.label}`)
       .text((d: BulletLegendItemInterface) => d.name)

--- a/packages/ts/src/components/bullet-legend/modules/shape.ts
+++ b/packages/ts/src/components/bullet-legend/modules/shape.ts
@@ -1,0 +1,77 @@
+import { Selection } from 'd3-selection'
+
+// Types
+import { ColorAccessor } from 'types/accessor'
+
+// Utils
+import { getColor } from 'utils/color'
+import { circlePath } from 'utils/path'
+
+// Local types
+import { BulletLegendConfigInterface } from '../config'
+import { BulletShape, BulletLegendItemInterface } from '../types'
+
+// Size with respect to the viewBox. We use this to compute path data which is independent of the
+// the configured size.
+const BULLET_SIZE = 20
+
+function getWidth (shape: BulletShape): number {
+  switch (shape) {
+    case BulletShape.Line:
+      return BULLET_SIZE * 2.5
+    default:
+      return BULLET_SIZE
+  }
+}
+
+function getPath (shape: BulletShape, width: number, height: number): string {
+  switch (shape) {
+    case BulletShape.Line:
+      return `M0,${height / 2} L${width / 2},${height / 2} L${width},${height / 2}`
+    case BulletShape.Square:
+      return `M0,0 L${width},0 L${width},${height} L0,${height}Z`
+    case BulletShape.Circle:
+      return circlePath(height / 2, height / 2, height / 2 - 1)
+  }
+}
+
+export function createBullets (
+  container: Selection<HTMLSpanElement, BulletLegendItemInterface, HTMLDivElement, unknown>,
+  config: BulletLegendConfigInterface
+): void {
+  container.append('svg')
+    .attr('width', '100%')
+    .attr('height', '100%')
+    .append('path')
+    .attr('d', getPath(config.bulletShape, getWidth(config.bulletShape), BULLET_SIZE))
+}
+
+export function updateBullets (
+  container: Selection<HTMLSpanElement, BulletLegendItemInterface, HTMLDivElement, unknown>,
+  config: BulletLegendConfigInterface,
+  colorAccessor: ColorAccessor<BulletLegendItemInterface>
+): void {
+  const height = BULLET_SIZE
+  const width = getWidth(config.bulletShape)
+
+  const getOpacity = (d: BulletLegendItemInterface): number => d.inactive ? 0.4 : 1
+
+  const selection = container.select('svg')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .select('path')
+    .attr('d', getPath(config.bulletShape, width, height))
+    .attr('stroke', (d, i) => getColor(d, colorAccessor, i))
+    .style('stroke-width', '1px')
+    .style('fill', (d, i) => getColor(d, colorAccessor, i))
+    .style('fill-opacity', getOpacity)
+
+  if (config.bulletShape === BulletShape.Line) {
+    selection
+      .style('stroke-width', `${height / 5}px`)
+      .style('opacity', getOpacity)
+      .style('fill', null)
+      .style('fill-opacity', null)
+      .style('marker-start', 'none')
+      .style('marker-end', 'none')
+  }
+}

--- a/packages/ts/src/components/bullet-legend/style.ts
+++ b/packages/ts/src/components/bullet-legend/style.ts
@@ -29,7 +29,8 @@ export const variables = injectGlobal`
 
 export const item = css`
   label: legendItem;
-  display: inline;
+  display: inline-flex;
+  align-items: center;
   font-family: var(--vis-legend-font-family, var(--vis-font-family));
   margin-right: var(--vis-legend-item-spacing);
   white-space: nowrap;
@@ -55,16 +56,12 @@ export const label = css`
 
 export const bullet = css`
   label: legendItemBullet;
-  border-radius: 100%;
-  background-color: var(--vis-legend-bullet-inactive-color);
-  border: 1px solid;
-  display: inline-block;
   margin-right: var(--vis-legend-bullet-label-spacing);
-  width: var(--vis-legend-bullet-size);
+  min-width: var(--vis-legend-bullet-size);
   height: var(--vis-legend-bullet-size);
-  vertical-align: middle;
 
-  .inactive {
-
+  > svg {
+    display: block;
   }
+}
 `

--- a/packages/ts/src/components/bullet-legend/types.ts
+++ b/packages/ts/src/components/bullet-legend/types.ts
@@ -5,3 +5,9 @@ export interface BulletLegendItemInterface {
   hidden?: boolean;
   pointer?: boolean;
 }
+
+export enum BulletShape {
+  Circle = 'circle',
+  Line = 'line',
+  Square = 'square',
+}

--- a/packages/website/docs/auxiliary/BulletLegend.mdx
+++ b/packages/website/docs/auxiliary/BulletLegend.mdx
@@ -89,6 +89,13 @@ The `pointer` property in the _BulletLegendItemInterface_ refers to the [cursor 
 Note that there is no specified default value unless `onLegendItemCilck` property is provided, in which case the
 cursor will be `pointer`.
 
+## Bullet Shapes
+You can specify the bullet shapes with `bulletShape` property. The supported shapes are:
+
+`BulletShape.Circle` or  `"circle"`: <BulletLegendDoc excludeTabs/>
+`BulletShape.Line`   or   `"line"` : <BulletLegendDoc excludeTabs bulletShape='line'/>
+`BulletShape.Square` or `"square"` : <BulletLegendDoc excludeTabs bulletShape='square'/>
+
 ## Label Configuration
 ### Font Size
 The label's font size can be changed with a valid [font-size CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size)


### PR DESCRIPTION
This PR introduces three shape variations for BulletLegend bullets: Circle (default), Line and Square.

![Screen Shot 2023-09-29 at 11 17 07 AM](https://github.com/f5/unovis/assets/52078477/ad470d2e-dc3f-427f-a51e-fbde3a748cfd)

**Note**: In order to accommodate line dashes and markers for Line shaped legends, SVGs will be used in place of HTML span elements for all shapes. @rokotyan Please review thoroughly to ensure this change doesn't break anything.