### PR TITLE
Website | Gallery | Fix: gallery examples not styled correctly

### DIFF
--- a/packages/website/src/components/GalleryViewer/index.tsx
+++ b/packages/website/src/components/GalleryViewer/index.tsx
@@ -19,6 +19,7 @@ export function GalleryViewer ({ example, useTypescriptCode }: GalleryViewerProp
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     if (useTypescriptCode) require(`../../../../shared/examples/${example.pathname}/${example.pathname}.ts`)
+    if (example.styles) require(`../../../../shared/examples/${example.pathname}/styles.css`)
   })
 
   return (<div className={s.root}>


### PR DESCRIPTION
This PR fixes the following gallery examples noted in #282:
- ELK Layered Graph Layout
- Parallel Layout Graph
- Sunburst Nested Donut
- Scatter Plot with Free Brush