### PR TITLE
Component | Graph: Autofit the layout if it was recalculated

### DIFF
--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -154,8 +154,8 @@ export class Graph<
   }
 
   setConfig (config: GraphConfigInterface<N, L>): void {
-    this._shouldFitLayout = this._shouldFitLayout || this.config.layoutType !== config.layoutType
     this._shouldRecalculateLayout = this._shouldRecalculateLayout || this._shouldLayoutRecalculate(config)
+    this._shouldFitLayout = this._shouldFitLayout || this._shouldRecalculateLayout
 
     super.setConfig(config)
     this._shouldSetPanels = true


### PR DESCRIPTION
Previously, there were situations where the view (translate / scale transform) and graph layout were out of sync after a container resize, causing the graph to be off-centered.