### PR TITLE
Container | XY: Extend only the X domain when `preventEmptyDomain` is `null`

### DIFF
--- a/packages/ts/src/containers/xy-container/config.ts
+++ b/packages/ts/src/containers/xy-container/config.ts
@@ -80,7 +80,7 @@ export interface XYContainerConfigInterface<Datum> extends ContainerConfigInterf
   /** Prevents the chart domain from being empty (when domain's min and max values are equal).
    *  That usually happens when all the data values are equal or when there's no data.
    *  Setting to `true` will automatically extend the domain by `+1` when the domain is empty (domain start equals domain end).
-   *  Setting to `null` will extend the empty domain, but only when there's no data.
+   *  Setting to `null` will extend the empty X domain, but only when there's no data.
    *  Setting to `false` will keep the domain as is.
    *  Default: `null` */
   preventEmptyDomain?: boolean | null;

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -306,10 +306,11 @@ export class XYContainer<Datum> extends ContainerCore {
         clamp(domainMax, configuredDomainMaxConstraint?.[0] ?? Number.NEGATIVE_INFINITY, configuredDomainMaxConstraint?.[1] ?? Number.POSITIVE_INFINITY),
       ]
 
-      // Extend the domain if there is no data provided or preventEmptyDomain was explicitly set to `true`
+      // Extend the X and Y domains if they're empty and `preventEmptyDomain` was explicitly set to `true`
+      // or just the X domain if there is no data provided and `preventEmptyDomain` set to `null`
       if (domain[0] === domain[1]) {
         const hasDataProvided = componentsWithDomain.some(c => c.datamodel.data?.length > 0)
-        if (config.preventEmptyDomain || (config.preventEmptyDomain === null && !hasDataProvided)) {
+        if (config.preventEmptyDomain || (config.preventEmptyDomain === null && (!hasDataProvided || dimension === ScaleDimension.Y))) {
           domain[1] = domain[0] + 1
         }
       }


### PR DESCRIPTION
@reb-dev A small visual tweak we've discussed