### PR TITLE
Website | Gallery: Example tweaks

### DIFF
--- a/packages/shared/examples/expandable-sankey/data.ts
+++ b/packages/shared/examples/expandable-sankey/data.ts
@@ -1,3 +1,5 @@
+import { SankeyNode } from '@unovis/ts'
+
 export type Node = {
   id: string;
   label: string;
@@ -7,13 +9,14 @@ export type Node = {
   expandable?: boolean;
   expanded?: boolean;
 }
+
 export type Link = { source: string; target: string; value: number }
 
-export type Sankey = {
-  readonly nodes: Node[];
-  readonly links: Link[];
-  collapse: (n: Node) => void;
-  expand: (n: Node) => void;
+export type Sankey<N, L extends Link> = {
+  nodes: N[];
+  links: L[];
+  expand: (n: SankeyNode<N, L>) => void;
+  collapse: (n: SankeyNode<N, L>) => void;
 }
 
 const categories = [
@@ -117,16 +120,18 @@ export const root: Node = generate({
   subgroups: categories as Node[],
 })
 
-export const sankeyData: Sankey = {
+export const sankeyData: Sankey<Node, Link> = {
   nodes: [root, ...root.subgroups],
   links: getLinks(root),
-  expand: function (n: Node): void {
+  expand: function (n: SankeyNode<Node, Link>): void {
     n.subgroups = getNodes(n)
+    this.nodes[n.index].expanded = true
     this.nodes = this.nodes.concat(n.subgroups)
     this.links = this.links.concat(getLinks(n))
   },
-  collapse: function (n: Node): void {
+  collapse: function (n: SankeyNode<Node, Link>): void {
+    this.nodes[n.index].expanded = false
     this.nodes = this.nodes.filter(d => d.id === n.id || !d.id.startsWith(n.id))
-    this.links = this.links.filter(d => !d.source.id.startsWith(n.id))
+    this.links = this.links.filter(d => !d.source.startsWith(n.id))
   },
 }

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.component.ts
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.component.ts
@@ -34,7 +34,6 @@ export class ExpandableSankeyComponent {
       } else {
         sankeyData.expand(n)
       }
-      n.expanded = !n.expanded
       this.vis.chart.setData(sankeyData)
     }
   }

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
@@ -12,7 +12,6 @@
       } else {
         sankeyData.expand(n)
       }
-      n.expanded = !n.expanded
       data = sankeyData
     }
   }

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.ts
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.ts
@@ -6,14 +6,13 @@ const container = document.getElementById('vis-container')
 const chart = new SingleContainer(container)
 
 // node click event listener
-function toggleGroup (n: Node): void {
+function toggleGroup (n: SankeyNode<Node, Link>): void {
   if (n.expandable) {
     if (n.expanded) {
       sankeyData.collapse(n)
     } else {
       sankeyData.expand(n)
     }
-    n.expanded = !n.expanded
     chart.setData({ nodes: sankeyData.nodes, links: sankeyData.links })
   }
 }

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.tsx
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.tsx
@@ -11,14 +11,13 @@ export default function ExpandableSankey (): JSX.Element {
 
   const [data, setData] = useState<{ nodes: Node[]; links: Link[] }>(sankeyData)
 
-  const toggleGroup = useCallback((n: Node): void => {
+  const toggleGroup = useCallback((n: SankeyNode<Node, Link>): void => {
     if (n.expandable) {
       if (n.expanded) {
         sankeyData.collapse(n)
       } else {
         sankeyData.expand(n)
       }
-      n.expanded = !n.expanded
       setData({ nodes: sankeyData.nodes, links: sankeyData.links })
     }
   }, [data])

--- a/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.tsx
+++ b/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { VisAxis, VisBulletLegend, VisStackedBar, VisTooltip, VisXYContainer } from '@unovis/react'
 import { Direction, FitMode, Orientation, StackedBar } from '@unovis/ts'
 import { data, EducationDatum, labels } from './data'

--- a/packages/shared/examples/topojson-map/styles.css
+++ b/packages/shared/examples/topojson-map/styles.css
@@ -5,10 +5,6 @@
   align-items: center;
 }
 
-vis-single-container {
-  width: 100%;
-}
-
 .topojson-map > header {
   width: max-content;
   position: relative;

--- a/packages/shared/examples/topojson-map/topojson-map.component.html
+++ b/packages/shared/examples/topojson-map/topojson-map.component.html
@@ -9,8 +9,8 @@
     <vis-tooltip [triggers]="tooltipTriggers"></vis-tooltip>
   </vis-single-container>
 
-  <vis-xy-container [data]="[{}]" [height]="70" [width]="500" [xDomain]="colorDomain">
-    <vis-axis type="x" position="top" label="Life expectancy (years)" [numTicks]="numLabels" [tickPadding]="0"></vis-axis>
-    <vis-stacked-bar [x]="0.5" orientation="horizontal" [y]="gradientSteps" [color]="getGradientColor"></vis-stacked-bar>
+  <vis-xy-container [data]="[{}]" [height]="70" [width]="500">
+    <vis-axis type="x" position="top" label="Life expectancy (years)" [numTicks]="numLabels" [tickFormat]="tickFormat"></vis-axis>
+    <vis-stacked-bar [x]="0" orientation="horizontal" [y]="gradientSteps" [color]="getGradientColor"></vis-stacked-bar>
   </vis-xy-container>
 </div>

--- a/packages/shared/examples/topojson-map/topojson-map.component.ts
+++ b/packages/shared/examples/topojson-map/topojson-map.component.ts
@@ -40,7 +40,8 @@ export class TopojsonMapComponent {
   }
 
   // legend config
-  getGradientColor = (_, i: number): string => this.color(i)
-  gradientSteps: number[] = Array(100).fill(1)
+  getGradientColor = (_, i: number): string => this.color(i + ageRange[0])
+  gradientSteps: number[] = Array(ageRange[1] - ageRange[0]).fill(1)
   numLabels: number = (ageRange[1] - ageRange[0]) / 5
+  tickFormat = (i: number): number => ageRange[0] + i
 }

--- a/packages/shared/examples/topojson-map/topojson-map.svelte
+++ b/packages/shared/examples/topojson-map/topojson-map.svelte
@@ -17,7 +17,7 @@
   let year = 2019
 
   // accessor functions
-  const color = (_, i: number) => colorScale(i)
+  const color = (_, i: number) => colorScale(i + ageRange[0])
   $: getExpectancy = (d: AreaDatum) => d.age[yearScale(year)]
   $: getAreaColor = (d: AreaDatum) => colorScale(getExpectancy(d))
 
@@ -25,7 +25,8 @@
     [TopoJSONMap.selectors.feature]: d => `${d.properties.name}: ${d.data ? getExpectancy(d.data) : 'no data'}`,
   }
 
-  const gradientSteps = Array(100).fill(1)
+  const gradientSteps = Array(ageRange[1] - ageRange[0]).fill(1)
+  const tickFormat = (i: number) => `${i + ageRange[0]}`
 </script>
 
 <div class="topojson-map">
@@ -41,8 +42,14 @@
   </VisSingleContainer>
   <!-- gradient legend-->
   <VisXYContainer data={[0]} height={70} width={500}>
-    <VisStackedBar x={0.5} y={gradientSteps} {color} orientation={Orientation.Horizontal}/>
-    <VisAxis type="x" position="top" numTicks={range / 5} label='Life Expectancy (years)' tickPadding={0}/>
+    <VisStackedBar x={0} y={gradientSteps} {color} orientation={Orientation.Horizontal}/>
+    <VisAxis
+      type="x"
+      position="top"
+      label='Life Expectancy (years)'
+      numTicks={gradientSteps.length / 5}
+      {tickFormat}
+    />
   </VisXYContainer>
 </div>
 

--- a/packages/shared/examples/topojson-map/topojson-map.ts
+++ b/packages/shared/examples/topojson-map/topojson-map.ts
@@ -64,17 +64,16 @@ yearSlider.addEventListener('change', function () {
 const gradientLegend = new XYContainer(legend, {
   height: 70,
   width: 500,
-  xDomain: ageRange,
   components: [new StackedBar({
-    x: 0.5,
-    y: Array(100).fill(1),
-    color: (_, i: number) => colorScale(i),
+    x: 0,
+    y: Array(ageRange[1] - ageRange[0]).fill(1),
+    color: (_, i: number) => colorScale(ageRange[0] + i),
     orientation: Orientation.Horizontal,
   })],
   xAxis: new Axis({
     position: 'top',
     numTicks: (ageRange[1] - ageRange[0]) / 5,
+    tickFormat: (i: number) => `${ageRange[0] + i}`,
     label: 'Life expectancy (years)',
-    tickPadding: 0,
   }),
 }, [{}])

--- a/packages/shared/examples/topojson-map/topojson-map.tsx
+++ b/packages/shared/examples/topojson-map/topojson-map.tsx
@@ -29,15 +29,18 @@ type GradientLegendProps = {
 }
 
 export function GradientLegend ({ colors, range, title }: GradientLegendProps): JSX.Element {
-  const y = useMemo(() => Array(100).fill(1), [])
+  const y = Array(range[1] - range[0]).fill(1)
+  const color = useCallback((_: number, i: number): string => colors(i + range[0]), [])
   return (
-    <VisXYContainer data={[{}]} height={70} width={500} xDomain={range}>
-      <VisStackedBar
-        orientation={Orientation.Horizontal}
-        x={0.5}
-        y={y}
-        color={useCallback((_, i: number) => colors(i), [])}/>
-      <VisAxis type="x" position="top" numTicks={(range[1] - range[0]) / 5} label={title} tickPadding={0}/>
+    <VisXYContainer data={[{}]} height={70} width={500}>
+      <VisStackedBar orientation={Orientation.Horizontal} x={0} y={y} color={color}/>
+      <VisAxis
+        type="x"
+        label={title}
+        position="top"
+        numTicks={(range[1] - range[0]) / 5}
+        tickFormat={useCallback((i: number) => `${range[0] + i}`, [])}
+      />
     </VisXYContainer>
   )
 }
@@ -46,7 +49,7 @@ export default function TopojsonMap (): JSX.Element {
   const mapData = useMemo(() => ({ areas: data }), [])
 
   // current year being viewed
-  const [year, setYear] = React.useState(2019)
+  const [year, setYear] = useState(2019)
 
   // scale functions
   const colorScale = Scale.scaleSequential(palette).domain(ageRange)


### PR DESCRIPTION
Closes #282

The following examples were configured incorrectly:
- Expandable Sankey - data wasn't updating properly when toggling expanded/collapsed state. Not sure why it was working before
- TopoJSON Map - Gradient legend didn't reflect the true data range, adjusted the other properties accordingly. (Hopefully in the near future we can substitute this section of the example with a new Legend component)
- Horizontal Stacked Bar - React isn't imported into the `.tsx` file