### PR TITLE
@unovis/svelte: Fixing SingleContainer props and adding support for `class` property

### DIFF
--- a/packages/shared/examples/expandable-sankey/data.ts
+++ b/packages/shared/examples/expandable-sankey/data.ts
@@ -1,4 +1,4 @@
-import { SankeyNode } from '@unovis/ts'
+import type { SankeyNode } from '@unovis/ts'
 
 export type Node = {
   id: string;

--- a/packages/shared/examples/non-stacked-area-chart/data.ts
+++ b/packages/shared/examples/non-stacked-area-chart/data.ts
@@ -1,4 +1,4 @@
-import { BulletLegendItemInterface } from '@unovis/ts'
+import type { BulletLegendItemInterface } from '@unovis/ts'
 
 export enum Country {
   UnitedStates = 'us',

--- a/packages/svelte/.eslintrc.cjs
+++ b/packages/svelte/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     rules: {
       'svelte/indent': ['error'],
       'no-use-before-define': 'off',
+      'no-undef-init': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/packages/svelte/src/containers/single-container/single-container.svelte
+++ b/packages/svelte/src/containers/single-container/single-container.svelte
@@ -5,6 +5,9 @@
 
   // Generics
   type Data = $$Generic
+  interface $$Props extends SingleContainerConfigInterface<Data> {
+    data?: Data;
+  }
 
   // Internal variables
   let chart: SingleContainer<Data> | undefined
@@ -14,6 +17,22 @@
 
   // Props
   export let data: Data
+  export let className = ''
+  /**
+   * CSS class string. Requires `:global` modifier to take effect. _i.e._
+   * ```css
+   * div :global(.chart) { }
+   * ```
+   * @example
+   * <div>
+   *     <VisSingleContainer class='chart'>
+   *        ...
+   *     </VisSingleContainer>
+   * </div>
+   *
+   * @see {@link https://svelte.dev/docs/svelte-components#styles}
+  */
+  export { className as class }
   let config: SingleContainerConfigInterface<Data>
   $: props = $$restProps as SingleContainerConfigInterface<Data>
   $: config = { component, tooltip, ...props }
@@ -48,7 +67,7 @@
   onDestroy(() => chart?.destroy())
 </script>
 
-<vis-single-container bind:this={ref} class='unovis-single-container'>
+<vis-single-container bind:this={ref} class={`unovis-single-container ${className}`}>
   <slot/>
 </vis-single-container>
 

--- a/packages/svelte/src/containers/single-container/single-container.svelte
+++ b/packages/svelte/src/containers/single-container/single-container.svelte
@@ -16,7 +16,7 @@
   let tooltip: Tooltip
 
   // Props
-  export let data: Data
+  export let data: Data = undefined
   export let className = ''
   /**
    * CSS class string. Requires `:global` modifier to take effect. _i.e._

--- a/packages/svelte/src/containers/xy-container/xy-container.svelte
+++ b/packages/svelte/src/containers/xy-container/xy-container.svelte
@@ -8,7 +8,7 @@
   }
 
   // Props
-  export let data: Datum[]
+  export let data: Datum[] = undefined
   export let className = ''
   /**
    * CSS class string. Requires `:global` modifier to take effect. _i.e._

--- a/packages/svelte/src/containers/xy-container/xy-container.svelte
+++ b/packages/svelte/src/containers/xy-container/xy-container.svelte
@@ -3,8 +3,28 @@
   import { onMount, setContext } from 'svelte'
 
   type Datum = $$Generic
+  interface $$Props extends XYContainerConfigInterface<Datum> {
+    data?: Datum[];
+  }
 
+  // Props
   export let data: Datum[]
+  export let className = ''
+  /**
+   * CSS class string. Requires `:global` modifier to take effect. _i.e._
+   * ```css
+   * div :global(.chart) { }
+   * ```
+   * @example
+   * <div>
+   *     <VisXYContainer class='chart'>
+   *        ...
+   *     <VisXYContainer>
+   * </div>
+   *
+   * @see {@link https://svelte.dev/docs/svelte-components#styles}
+  */
+  export { className as class }
 
   let chart: XYContainer<Datum>
   const config: XYContainerConfigInterface<Datum> = {
@@ -45,7 +65,7 @@
   }))
 </script>
 
-<vis-xy-container bind:this={ref} class='unovis-xy-container'>
+<vis-xy-container bind:this={ref} class={`unovis-xy-container ${className}`}>
   <slot />
 </vis-xy-container>
 


### PR DESCRIPTION
closes: #291 

Previously, `$$restProps` object was ignored in the `initChart` call, resulting in missing props. I fixed the logic and did some minor refactoring to ensure update calls weren't being called unnecessarily.

Additionally, users can now add the `class` property for containers.

Note: Due to the way [svelte component styles](https://svelte.dev/docs/svelte-components#style) are scoped, the `:global` modifier is required for it to take effect. It is recommended to combine local and global to avoid conflicts and keep the scope as limited as possible. For example:

```html
<div>
    <VisSingleContainer class='chart'>...</VisSingleContainer>
</div>
<style>
    div :global(.chart) {
        /* Applies to elements in any component inside a <div>
        element belonging to this component. ✅ Recommended */
    }

    :global(.chart) {
        /* Applies to all elements in any component in the document
        where class="chart". ⛔ Works, but not recommended */
     }

    .chart {
        /* Strictly applies to elements (not components) that belong to this
        component. ❌ Doesn't work for `@unovis/svelte` containers */
    }
</style>
```