### PR TITLE
Component | Axis | Add `rotate` label fit mode

### DIFF
--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -232,6 +232,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         const textOptions: UnovisTextOptions = {
           verticalAlign: config.type === AxisType.X ? VerticalAlign.Top : VerticalAlign.Middle,
           width: textMaxWidth,
+          fitMode: config.tickTextFitMode,
           separator: config.tickTextSeparator,
           wordBreak: config.tickTextForceWordBreak,
         }

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -13,6 +13,7 @@ export enum VerticalAlign {
 export enum FitMode {
   Wrap = 'wrap',
   Trim = 'trim',
+  Rotate = 'rotate',
 }
 
 export enum TextAlign {
@@ -45,6 +46,8 @@ export type UnovisText = {
 export type UnovisWrappedText = UnovisText & {
   // An array of text lines, where each element represents a single line of text.
   _lines: string[];
+  // Maximum width of any line of text in this text block
+  _maxWidth: number;
   // Estimated height of this text block
   _estimatedHeight: number;
 }
@@ -62,6 +65,8 @@ export type UnovisTextOptions = {
   verticalAlign?: VerticalAlign | string;
   // The horizontal text alignment ('left', 'center', or 'right').
   textAlign?: TextAlign | string;
+  // The strategy for containing text within the available width.
+  fitMode?: FitMode | string;
   // Whether to use a fast estimation method or a more accurate one for text calculations.
   fastMode?: boolean;
   // Force word break if they don't fit into the width

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -124,7 +124,6 @@ Change the tick's label alignment with respect to the tick marker using `tickTex
   options={['right', 'center', 'left']}
   property="tickTextAlign"/>
 
-
 ### Label Width
 To limit the width of the tick labels (in pixels), you can use the `tickTextWidth` property.
 <XYWrapperWithInput
@@ -137,14 +136,14 @@ To limit the width of the tick labels (in pixels), you can use the `tickTextWidt
 />
 
 ### Label Fit Mode
-_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap` or `FitMode.Trim`. This determines how the axis will
+_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap`, `FitMode.Trim` or `FitMode.Rotate`. This determines how the axis will
 handle tick text overflow. The following example showcases the previous example using `"trim"` instead of `"wrap"`.
 <XYWrapperWithInput inputType="select"
   {...defaultProps()}
   tickTextWidth={10}
   data={generateTimeSeries(10)}
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString(), tickTextTrimType:"end"}}
-  options={['trim', 'wrap']}
+  options={['trim', 'wrap', 'rotate']}
   property="tickTextFitMode"/>
 
 ### Label Trim Type


### PR DESCRIPTION
![image](https://github.com/f5/unovis/assets/1331877/5540a81b-e4ca-4f31-a5d6-c43519e368ea)

Adds a new option `tickTextFitMode="rotate"` on the Axis component. Inspired by [d3fc/d3fc](https://github.com/d3fc/d3fc)'s `d3fc-axis`.