### PR TITLE
Component | Chord Diagram | Fixes, enhancements, and refactoring

### DIFF
--- a/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
+++ b/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
@@ -105,8 +105,8 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
   /** Node label alignment. Default: `ChordLabelAlignment.Along` */
   @Input() nodeLabelAlignment?: GenericAccessor<ChordLabelAlignment | string, ChordNodeDatum<N>>
 
-  /** Pad angle in radians. Constant value or accessor function. Default: `0.02` */
-  @Input() padAngle?: NumericAccessor<ChordNodeDatum<N>>
+  /** Pad angle in radians. Default: `0.02` */
+  @Input() padAngle?: number
 
   /** Corner radius constant value or accessor function. Default: `2` */
   @Input() cornerRadius?: NumericAccessor<ChordNodeDatum<N>>

--- a/packages/ts/src/components/chord-diagram/config.ts
+++ b/packages/ts/src/components/chord-diagram/config.ts
@@ -8,6 +8,10 @@ import { ColorAccessor, GenericAccessor, NumericAccessor, StringAccessor } from 
 import { ChordInputLink, ChordInputNode, ChordLabelAlignment, ChordLinkDatum, ChordNodeDatum } from './types'
 
 export interface ChordDiagramConfigInterface<N extends ChordInputNode, L extends ChordInputLink> extends ComponentConfigInterface {
+  /** Angular range of the diagram. Default: `[0, 2 * Math.PI]` */
+  angleRange?: [number, number];
+  /** Corner radius constant value or accessor function. Default: `2` */
+  cornerRadius?: NumericAccessor<ChordNodeDatum<N>>;
   /** Node id or index to highlight. Overrides default hover behavior if supplied. Default: `undefined` */
   highlightedNodeId?: number | string;
   /** Link ids or index values to highlight. Overrides default hover behavior if supplied. Default: [] */
@@ -28,12 +32,8 @@ export interface ChordDiagramConfigInterface<N extends ChordInputNode, L extends
   nodeLabelColor?: StringAccessor<ChordNodeDatum<N>>;
   /** Node label alignment. Default: `ChordLabelAlignment.Along` */
   nodeLabelAlignment?: GenericAccessor<ChordLabelAlignment | string, ChordNodeDatum<N>>;
-  /** Pad angle in radians. Constant value or accessor function. Default: `0.02` */
-  padAngle?: NumericAccessor<ChordNodeDatum<N>>;
-  /** Corner radius constant value or accessor function. Default: `2` */
-  cornerRadius?: NumericAccessor<ChordNodeDatum<N>>;
-  /** Angular range of the diagram. Default: `[0, 2 * Math.PI]` */
-  angleRange?: [number, number];
+  /** Pad angle in radians. Default: `0.02` */
+  padAngle?: number;
   /** The exponent property of the radius scale. Default: `2` */
   radiusScaleExponent?: number;
 }

--- a/packages/ts/src/components/chord-diagram/index.ts
+++ b/packages/ts/src/components/chord-diagram/index.ts
@@ -52,9 +52,11 @@ export class ChordDiagram<
   public config: ChordDiagramConfigInterface<N, L> = this._defaultConfig
   datamodel: GraphDataModel<N, L> = new GraphDataModel()
 
+  background: Selection<SVGRectElement, unknown, SVGGElement, unknown>
   nodeGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
   linkGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
   labelGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
+
   arcGen = arc<ChordNode<N>>()
   radiusScale: ScalePower<number, number> = scalePow()
 
@@ -84,6 +86,7 @@ export class ChordDiagram<
   constructor (config?: ChordDiagramConfigInterface<N, L>) {
     super()
     if (config) this.setConfig(config)
+    this.background = this.g.append('rect').attr('class', s.background)
     this.linkGroup = this.g.append('g').attr('class', s.links)
     this.nodeGroup = this.g.append('g').attr('class', s.nodes)
     this.labelGroup = this.g.append('g').attr('class', s.labels)
@@ -170,9 +173,16 @@ export class ChordDiagram<
       .innerRadius(d => this.radiusScale(d.y1) - getNumber(d, config.nodeWidth))
       .outerRadius(d => this.radiusScale(d.y1))
 
-    // Center the view
-    this.g.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
     this.g.classed(s.transparent, this._forceHighlight)
+    this.background
+      .attr('width', this._width)
+      .attr('height', this._height)
+      .style('opacity', 0)
+
+    // Center the view
+    this.nodeGroup.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.labelGroup.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
+    this.linkGroup.attr('transform', `translate(${this._width / 2},${this._height / 2})`)
 
     // Links
     const linksSelection = this.linkGroup

--- a/packages/ts/src/components/chord-diagram/modules/layout.ts
+++ b/packages/ts/src/components/chord-diagram/modules/layout.ts
@@ -1,0 +1,118 @@
+import { group, index } from 'd3-array'
+import { HierarchyNode, hierarchy } from 'd3-hierarchy'
+import { pie } from 'd3-shape'
+
+// Utils
+import { getNumber, groupBy } from 'utils/data'
+
+// Types
+import { NumericAccessor } from 'types/accessor'
+
+// Local Types
+import { ChordNode, ChordRibbon, ChordLinkDatum, ChordHierarchyNode, ChordLeafNode } from '../types'
+
+function transformData <T> (node: HierarchyNode<T>): void {
+  const { height, depth } = node
+  if (height > 0) {
+    const d = node.data as unknown as [string, T[]]
+    const n = node as unknown as HierarchyNode<ChordHierarchyNode<T>>
+    n.data = { key: d[0], values: d[1], depth, height, ancestors: n.ancestors().map(d => d.data.key) }
+  }
+}
+
+export function getHierarchyNodes<N> (
+  data: N[],
+  value: NumericAccessor<N>,
+  levels: string[] = []
+): HierarchyNode<ChordHierarchyNode<N>> {
+  const nodeLevels = levels.map(level => (d: N) => d[level as keyof N]) as unknown as [(d: N) => string]
+  const nestedData = levels.length ? group<N, string>(data, ...nodeLevels) : { key: 'root', children: data }
+
+  const root = hierarchy(nestedData)
+    .sum(d => getNumber(d as unknown as N, value))
+    .each(transformData)
+
+  return root as unknown as HierarchyNode<ChordHierarchyNode<N>>
+}
+
+export function positionChildren<N> (node: ChordNode<N>, padding: number, scalingCoeff = 0.95): void {
+  if (!node.children) return
+
+  const length = node.x1 - node.x0
+  const scaledLength = length * scalingCoeff
+  const delta = length - scaledLength
+
+  const positions = pie<ChordNode<N>>()
+    .startAngle(node.x0 + delta / 2)
+    .endAngle(node.x1 - delta / 2)
+    .padAngle(padding)
+    .value(d => d.value)
+    .sort((a, b) => node.children.indexOf(a) - node.children.indexOf(b))(node.children)
+
+  node.children.forEach((child, i) => {
+    const x0 = positions[i].startAngle
+    const x1 = positions[i].endAngle
+    const childDelta = (x1 - x0) * (1 - scalingCoeff)
+    child.x0 = x0 + childDelta / 2
+    child.x1 = x1 - childDelta / 2
+  })
+}
+
+export function getRibbons<N> (data: ChordNode<N>, links: ChordLinkDatum<N>[], padding: number): ChordRibbon<N>[] {
+  type LinksArrayType = typeof links
+  const groupedBySource: Record<string, LinksArrayType> = groupBy(links, d => d.source._id)
+  const groupedByTarget: Record<string, LinksArrayType> = groupBy(links, d => d.target._id)
+
+  const leafNodes = data.leaves() as ChordLeafNode<N>[]
+  const leafNodesById: Map<string, ChordLeafNode<N>> = index(leafNodes, d => d.data._id)
+
+  const getNodesInRibbon = (
+    source: ChordLeafNode<N>,
+    target: ChordLeafNode<N>,
+    partitionHeight: number,
+    nodes: ChordNode<N>[] = []
+  ): ChordNode<N>[] => {
+    nodes[source.height] = source
+    nodes[partitionHeight * 2 - target.height] = target
+    if (source.parent && target.parent) getNodesInRibbon(source.parent, target.parent, partitionHeight, nodes)
+    return nodes
+  }
+  const calculatePoints = (links: LinksArrayType, type: 'in' | 'out', depth: number, maxDepth: number): void => {
+    links.forEach(link => {
+      if (!link._state.points) link._state.points = []
+
+      const sourceLeaf = leafNodesById.get(link.source._id)
+      const targetLeaf = leafNodesById.get(link.target._id)
+      const nodesInRibbon = getNodesInRibbon(
+        type === 'out' ? sourceLeaf : targetLeaf,
+        type === 'out' ? targetLeaf : sourceLeaf,
+        maxDepth
+      )
+      const currNode = nodesInRibbon[depth]
+      const len = currNode.x1 - currNode.x0 - padding
+      const x0 = currNode._prevX1 ?? (currNode.x0 + padding / 2)
+      const x1 = x0 + len * link._state.value / currNode.value
+      currNode._prevX1 = x1
+
+      const pointIdx = type === 'out' ? depth : maxDepth * 2 - 1 - depth
+      link._state.points[pointIdx] = { a0: x0, a1: x1, r: currNode.y1 }
+    })
+  }
+
+  leafNodes.forEach(leafNode => {
+    const outLinks = groupedBySource[leafNode.data._id] || []
+    const inLinks = groupedByTarget[leafNode.data._id] || []
+    for (let depth = 0; depth < leafNode.depth; depth += 1) {
+      calculatePoints(outLinks, 'out', depth, leafNode.depth)
+      calculatePoints(inLinks, 'in', depth, leafNode.depth)
+    }
+  })
+
+  return links.map(l => ({
+    source: leafNodesById.get(l.source._id),
+    target: leafNodesById.get(l.target._id),
+    data: l,
+    points: l._state.points,
+    _state: {},
+  }))
+}

--- a/packages/ts/src/components/chord-diagram/style.ts
+++ b/packages/ts/src/components/chord-diagram/style.ts
@@ -27,6 +27,10 @@ export const variables = injectGlobal`
   }
 `
 
+export const background = css`
+  label: background;
+`
+
 export const nodes = css`
   label: nodes;
 `

--- a/packages/ts/src/components/chord-diagram/style.ts
+++ b/packages/ts/src/components/chord-diagram/style.ts
@@ -63,12 +63,12 @@ export const label = css`
 `
 
 export const labelText = css`
-  label: label-text:
+  label: label-text;
 
   dominant-baseline: middle;
   user-select: none;
   font-size: var(--vis-chord-diagram-label-text-font-size);
-
+  
   > textPath {
     dominant-baseline: central;
   }

--- a/packages/ts/src/components/chord-diagram/style.ts
+++ b/packages/ts/src/components/chord-diagram/style.ts
@@ -18,6 +18,7 @@ export const variables = injectGlobal`
 
     --vis-chord-diagram-label-text-fill-color-bright: #ffffff;
     --vis-chord-diagram-label-text-fill-color-dark: #a5abb2;
+    --vis-chord-diagram-label-text-font-size: 16px;
 
     --vis-dark-chord-diagram-link-fill-color: #575c65;
   }
@@ -66,6 +67,7 @@ export const labelText = css`
 
   dominant-baseline: middle;
   user-select: none;
+  font-size: var(--vis-chord-diagram-label-text-font-size);
 
   > textPath {
     dominant-baseline: central;


### PR DESCRIPTION
### Additions
- Background selector for events
- CSS variable for node label font size

### Refactoring
- Extracted layout logic to new module
- Replaced `d3.nest` (deprecated) with `d3.group` for hierarchal data generation

 ### Fixes
- Overlapping "empty" nodes (nodes without any ingoing or outgoing links)
- Pad angle inconsistent behavior
- Empty nodes not highlighting on hover
- Changing config after initial render doesn't have any effect (except for `radiusScaleExponent`)

Closes: unovis/issues-only#13
Closes: unovis/issues-only#19
Closes: unovis/issues-only#20
Closes: unovis/issues-only#21