### PR TITLE
React: Exporting component selectors to allow for easier import

### DIFF
--- a/packages/react/autogen/component.ts
+++ b/packages/react/autogen/component.ts
@@ -30,6 +30,8 @@ export type Vis${componentName}Props${genericsDefStr} = ${componentName}ConfigIn
   ref?: Ref<Vis${componentName}Ref${genericsStr}>
 }
 
+export const Vis${componentName}Selectors = ${componentName}.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function Vis${componentName}FC${genericsDefStr} (props: Vis${componentName}Props${genericsStr}, fRef: ForwardedRef<Vis${componentName}Ref${genericsStr}>): JSX.Element {
   const ref = useRef<VisComponentElement<${componentName}${genericsStr}>>(null)

--- a/packages/react/src/components/area/index.tsx
+++ b/packages/react/src/components/area/index.tsx
@@ -17,6 +17,8 @@ export type VisAreaProps<Datum> = AreaConfigInterface<Datum> & {
   ref?: Ref<VisAreaRef<Datum>>;
 }
 
+export const VisAreaSelectors = Area.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisAreaFC<Datum> (props: VisAreaProps<Datum>, fRef: ForwardedRef<VisAreaRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Area<Datum>>>(null)

--- a/packages/react/src/components/axis/index.tsx
+++ b/packages/react/src/components/axis/index.tsx
@@ -17,6 +17,8 @@ export type VisAxisProps<Datum> = AxisConfigInterface<Datum> & {
   ref?: Ref<VisAxisRef<Datum>>;
 }
 
+export const VisAxisSelectors = Axis.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisAxisFC<Datum> (props: VisAxisProps<Datum>, fRef: ForwardedRef<VisAxisRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Axis<Datum>>>(null)

--- a/packages/react/src/components/brush/index.tsx
+++ b/packages/react/src/components/brush/index.tsx
@@ -17,6 +17,8 @@ export type VisBrushProps<Datum> = BrushConfigInterface<Datum> & {
   ref?: Ref<VisBrushRef<Datum>>;
 }
 
+export const VisBrushSelectors = Brush.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisBrushFC<Datum> (props: VisBrushProps<Datum>, fRef: ForwardedRef<VisBrushRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Brush<Datum>>>(null)

--- a/packages/react/src/components/chord-diagram/index.tsx
+++ b/packages/react/src/components/chord-diagram/index.tsx
@@ -17,6 +17,8 @@ export type VisChordDiagramProps<N extends ChordInputNode, L extends ChordInputL
   ref?: Ref<VisChordDiagramRef<N, L>>;
 }
 
+export const VisChordDiagramSelectors = ChordDiagram.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisChordDiagramFC<N extends ChordInputNode, L extends ChordInputLink> (props: VisChordDiagramProps<N, L>, fRef: ForwardedRef<VisChordDiagramRef<N, L>>): JSX.Element {
   const ref = useRef<VisComponentElement<ChordDiagram<N, L>>>(null)

--- a/packages/react/src/components/crosshair/index.tsx
+++ b/packages/react/src/components/crosshair/index.tsx
@@ -17,6 +17,8 @@ export type VisCrosshairProps<Datum> = CrosshairConfigInterface<Datum> & {
   ref?: Ref<VisCrosshairRef<Datum>>;
 }
 
+export const VisCrosshairSelectors = Crosshair.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisCrosshairFC<Datum> (props: VisCrosshairProps<Datum>, fRef: ForwardedRef<VisCrosshairRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Crosshair<Datum>>>(null)

--- a/packages/react/src/components/donut/index.tsx
+++ b/packages/react/src/components/donut/index.tsx
@@ -17,6 +17,8 @@ export type VisDonutProps<Datum> = DonutConfigInterface<Datum> & {
   ref?: Ref<VisDonutRef<Datum>>;
 }
 
+export const VisDonutSelectors = Donut.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisDonutFC<Datum> (props: VisDonutProps<Datum>, fRef: ForwardedRef<VisDonutRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Donut<Datum>>>(null)

--- a/packages/react/src/components/free-brush/index.tsx
+++ b/packages/react/src/components/free-brush/index.tsx
@@ -17,6 +17,8 @@ export type VisFreeBrushProps<Datum> = FreeBrushConfigInterface<Datum> & {
   ref?: Ref<VisFreeBrushRef<Datum>>;
 }
 
+export const VisFreeBrushSelectors = FreeBrush.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisFreeBrushFC<Datum> (props: VisFreeBrushProps<Datum>, fRef: ForwardedRef<VisFreeBrushRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<FreeBrush<Datum>>>(null)

--- a/packages/react/src/components/graph/index.tsx
+++ b/packages/react/src/components/graph/index.tsx
@@ -17,6 +17,8 @@ export type VisGraphProps<N extends GraphInputNode, L extends GraphInputLink> = 
   ref?: Ref<VisGraphRef<N, L>>;
 }
 
+export const VisGraphSelectors = Graph.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisGraphFC<N extends GraphInputNode, L extends GraphInputLink> (props: VisGraphProps<N, L>, fRef: ForwardedRef<VisGraphRef<N, L>>): JSX.Element {
   const ref = useRef<VisComponentElement<Graph<N, L>>>(null)

--- a/packages/react/src/components/grouped-bar/index.tsx
+++ b/packages/react/src/components/grouped-bar/index.tsx
@@ -17,6 +17,8 @@ export type VisGroupedBarProps<Datum> = GroupedBarConfigInterface<Datum> & {
   ref?: Ref<VisGroupedBarRef<Datum>>;
 }
 
+export const VisGroupedBarSelectors = GroupedBar.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisGroupedBarFC<Datum> (props: VisGroupedBarProps<Datum>, fRef: ForwardedRef<VisGroupedBarRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<GroupedBar<Datum>>>(null)

--- a/packages/react/src/components/line/index.tsx
+++ b/packages/react/src/components/line/index.tsx
@@ -17,6 +17,8 @@ export type VisLineProps<Datum> = LineConfigInterface<Datum> & {
   ref?: Ref<VisLineRef<Datum>>;
 }
 
+export const VisLineSelectors = Line.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisLineFC<Datum> (props: VisLineProps<Datum>, fRef: ForwardedRef<VisLineRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Line<Datum>>>(null)

--- a/packages/react/src/components/nested-donut/index.tsx
+++ b/packages/react/src/components/nested-donut/index.tsx
@@ -17,6 +17,8 @@ export type VisNestedDonutProps<Datum> = NestedDonutConfigInterface<Datum> & {
   ref?: Ref<VisNestedDonutRef<Datum>>;
 }
 
+export const VisNestedDonutSelectors = NestedDonut.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisNestedDonutFC<Datum> (props: VisNestedDonutProps<Datum>, fRef: ForwardedRef<VisNestedDonutRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<NestedDonut<Datum>>>(null)

--- a/packages/react/src/components/sankey/index.tsx
+++ b/packages/react/src/components/sankey/index.tsx
@@ -17,6 +17,8 @@ export type VisSankeyProps<N extends SankeyInputNode, L extends SankeyInputLink>
   ref?: Ref<VisSankeyRef<N, L>>;
 }
 
+export const VisSankeySelectors = Sankey.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisSankeyFC<N extends SankeyInputNode, L extends SankeyInputLink> (props: VisSankeyProps<N, L>, fRef: ForwardedRef<VisSankeyRef<N, L>>): JSX.Element {
   const ref = useRef<VisComponentElement<Sankey<N, L>>>(null)

--- a/packages/react/src/components/scatter/index.tsx
+++ b/packages/react/src/components/scatter/index.tsx
@@ -17,6 +17,8 @@ export type VisScatterProps<Datum> = ScatterConfigInterface<Datum> & {
   ref?: Ref<VisScatterRef<Datum>>;
 }
 
+export const VisScatterSelectors = Scatter.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisScatterFC<Datum> (props: VisScatterProps<Datum>, fRef: ForwardedRef<VisScatterRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Scatter<Datum>>>(null)

--- a/packages/react/src/components/stacked-bar/index.tsx
+++ b/packages/react/src/components/stacked-bar/index.tsx
@@ -17,6 +17,8 @@ export type VisStackedBarProps<Datum> = StackedBarConfigInterface<Datum> & {
   ref?: Ref<VisStackedBarRef<Datum>>;
 }
 
+export const VisStackedBarSelectors = StackedBar.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisStackedBarFC<Datum> (props: VisStackedBarProps<Datum>, fRef: ForwardedRef<VisStackedBarRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<StackedBar<Datum>>>(null)

--- a/packages/react/src/components/timeline/index.tsx
+++ b/packages/react/src/components/timeline/index.tsx
@@ -17,6 +17,8 @@ export type VisTimelineProps<Datum> = TimelineConfigInterface<Datum> & {
   ref?: Ref<VisTimelineRef<Datum>>;
 }
 
+export const VisTimelineSelectors = Timeline.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisTimelineFC<Datum> (props: VisTimelineProps<Datum>, fRef: ForwardedRef<VisTimelineRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<Timeline<Datum>>>(null)

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -17,6 +17,8 @@ export type VisTooltipProps = TooltipConfigInterface & {
   ref?: Ref<VisTooltipRef>;
 }
 
+export const VisTooltipSelectors = Tooltip.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisTooltipFC (props: VisTooltipProps, fRef: ForwardedRef<VisTooltipRef>): JSX.Element {
   const ref = useRef<VisComponentElement<Tooltip>>(null)

--- a/packages/react/src/components/topojson-map/index.tsx
+++ b/packages/react/src/components/topojson-map/index.tsx
@@ -17,6 +17,8 @@ export type VisTopoJSONMapProps<AreaDatum, PointDatum, LinkDatum> = TopoJSONMapC
   ref?: Ref<VisTopoJSONMapRef<AreaDatum, PointDatum, LinkDatum>>;
 }
 
+export const VisTopoJSONMapSelectors = TopoJSONMap.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisTopoJSONMapFC<AreaDatum, PointDatum, LinkDatum> (props: VisTopoJSONMapProps<AreaDatum, PointDatum, LinkDatum>, fRef: ForwardedRef<VisTopoJSONMapRef<AreaDatum, PointDatum, LinkDatum>>): JSX.Element {
   const ref = useRef<VisComponentElement<TopoJSONMap<AreaDatum, PointDatum, LinkDatum>>>(null)

--- a/packages/react/src/components/xy-labels/index.tsx
+++ b/packages/react/src/components/xy-labels/index.tsx
@@ -17,6 +17,8 @@ export type VisXYLabelsProps<Datum> = XYLabelsConfigInterface<Datum> & {
   ref?: Ref<VisXYLabelsRef<Datum>>;
 }
 
+export const VisXYLabelsSelectors = XYLabels.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisXYLabelsFC<Datum> (props: VisXYLabelsProps<Datum>, fRef: ForwardedRef<VisXYLabelsRef<Datum>>): JSX.Element {
   const ref = useRef<VisComponentElement<XYLabels<Datum>>>(null)

--- a/packages/react/src/html-components/bullet-legend/index.tsx
+++ b/packages/react/src/html-components/bullet-legend/index.tsx
@@ -3,6 +3,8 @@ import { BulletLegend, BulletLegendConfigInterface } from '@unovis/ts'
 
 export type VisBulletLegendProps = BulletLegendConfigInterface
 
+export const VisBulletLegendSelectors = BulletLegend.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function VisBulletLegend (props: VisBulletLegendProps): JSX.Element {
   const container = useRef<HTMLDivElement>(null)

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -2,6 +2,8 @@ import React, { ForwardedRef, Ref, useEffect, useImperativeHandle, useRef, useSt
 import { LeafletFlowMap, LeafletFlowMapConfigInterface } from '@unovis/ts'
 import { arePropsEqual } from '../../utils/react'
 
+export const VisLeafletFlowMapSelectors = LeafletFlowMap.selectors
+
 export type VisLeafletFlowMapProps<
   PointDatum extends Record<string, unknown>,
   FlowDatum extends Record<string, unknown>,

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -2,6 +2,8 @@ import React, { ForwardedRef, Ref, useEffect, useImperativeHandle, useRef, useSt
 import { LeafletMap, LeafletMapConfigInterface } from '@unovis/ts'
 import { arePropsEqual } from '../../utils/react'
 
+export const VisLeafletMapSelectors = LeafletMap.selectors
+
 export type VisLeafletMapProps<Datum extends Record<string, unknown>> = LeafletMapConfigInterface<Datum> & {
   data?: Datum[];
   ref?: Ref<VisLeafletMapRef<Datum>>;


### PR DESCRIPTION
Exporting component selectors to allow for easier import, e.g. when using React lazy with Suspense.

#0