### PR TITLE
Core Component and Tooltip event handling tweaks

### DIFF
--- a/packages/ts/src/components/tooltip/config.ts
+++ b/packages/ts/src/components/tooltip/config.ts
@@ -33,7 +33,7 @@ export interface TooltipConfigInterface {
    * ```
    */
   triggers?: {
-    [selector: string]: (data: any, i: number, elements: (HTMLElement | SVGElement)[]) => string | HTMLElement | undefined | null;
+    [selector: string]: ((data: any, i: number, elements: (HTMLElement | SVGElement)[]) => string | HTMLElement | undefined | null) | undefined | null;
   };
   /** Custom DOM attributes for the tooltip. Useful when you need to refer to a specific tooltip instance
    * by using a CSS selector. Attributes configuration object has the following structure:

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -163,7 +163,7 @@ export class Tooltip {
   private _setContainerPosition (): void {
     // Tooltip position calculation relies on the parent position
     // If it's not set (static), we set it to `relative` (not a good practice)
-    if (getComputedStyle(this._container)?.position === 'static') {
+    if (this._container !== document.body && getComputedStyle(this._container)?.position === 'static') {
       this._container.style.position = 'relative'
     }
   }

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -185,6 +185,8 @@ export class Tooltip {
           // Go through all of the configured triggers
           for (const className of Object.keys(triggers)) {
             const template = triggers[className]
+            if (!template) continue // Skip if the trigger is not configured
+
             const els = selection.selectAll<HTMLElement | SVGGElement, unknown>(`.${className}`).nodes()
 
             // Go through all of the elements in the event path (from the deepest element upwards)

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -141,7 +141,7 @@ export class ComponentCore<
           const els = selection.nodes()
           const i = els.indexOf(event.currentTarget as SVGGElement | HTMLElement)
           const eventFunction = events[className][eventType as VisEventType]
-          return eventFunction(d, event, i, els)
+          return eventFunction?.(d, event, i, els)
         })
       })
     })


### PR DESCRIPTION
This PR tweaks the behavior of the core component and the tooltip related to events:
* Core | Component | Events: Check if the callback exists before execution
* Component | Tooltip: Allowing `triggers` to be `undefined` or `null`
* Component | Tooltip: If the container is `body`, don't change its position style because it can have unwanted effect
