### PR TITLE
Svelte | Package: Add missing exports condition for Svelte #334

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -27,6 +27,11 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "svelte": "./index.js",
+  "exports": {
+    ".": {
+      "svelte": "./index.js"
+    }
+  },
   "type": "module",
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
This should fix https://github.com/f5/unovis/issues/334.

In original PR #335 the export was pointing to `dist/index.js`, but I think it was incorrect because we publish the Svelte lib from the `dist` folder itself, and the NPM package won't have such folder.

cc @benbender