### PR TITLE
Unovis React: Fixing ref initialization

### DIFF
--- a/packages/react/autogen/component.ts
+++ b/packages/react/autogen/component.ts
@@ -58,7 +58,7 @@ function Vis${componentName}FC${genericsDefStr} (props: Vis${componentName}Props
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-${elementSuffix} ref={ref} />
 }
 

--- a/packages/react/src/components/area/index.tsx
+++ b/packages/react/src/components/area/index.tsx
@@ -45,7 +45,7 @@ function VisAreaFC<Datum> (props: VisAreaProps<Datum>, fRef: ForwardedRef<VisAre
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/axis/index.tsx
+++ b/packages/react/src/components/axis/index.tsx
@@ -45,7 +45,7 @@ function VisAxisFC<Datum> (props: VisAxisProps<Datum>, fRef: ForwardedRef<VisAxi
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-axis ref={ref} />
 }
 

--- a/packages/react/src/components/brush/index.tsx
+++ b/packages/react/src/components/brush/index.tsx
@@ -45,7 +45,7 @@ function VisBrushFC<Datum> (props: VisBrushProps<Datum>, fRef: ForwardedRef<VisB
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/chord-diagram/index.tsx
+++ b/packages/react/src/components/chord-diagram/index.tsx
@@ -45,7 +45,7 @@ function VisChordDiagramFC<N extends ChordInputNode, L extends ChordInputLink> (
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/crosshair/index.tsx
+++ b/packages/react/src/components/crosshair/index.tsx
@@ -45,7 +45,7 @@ function VisCrosshairFC<Datum> (props: VisCrosshairProps<Datum>, fRef: Forwarded
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-crosshair ref={ref} />
 }
 

--- a/packages/react/src/components/donut/index.tsx
+++ b/packages/react/src/components/donut/index.tsx
@@ -45,7 +45,7 @@ function VisDonutFC<Datum> (props: VisDonutProps<Datum>, fRef: ForwardedRef<VisD
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/free-brush/index.tsx
+++ b/packages/react/src/components/free-brush/index.tsx
@@ -45,7 +45,7 @@ function VisFreeBrushFC<Datum> (props: VisFreeBrushProps<Datum>, fRef: Forwarded
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/graph/index.tsx
+++ b/packages/react/src/components/graph/index.tsx
@@ -45,7 +45,7 @@ function VisGraphFC<N extends GraphInputNode, L extends GraphInputLink> (props: 
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/grouped-bar/index.tsx
+++ b/packages/react/src/components/grouped-bar/index.tsx
@@ -45,7 +45,7 @@ function VisGroupedBarFC<Datum> (props: VisGroupedBarProps<Datum>, fRef: Forward
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/line/index.tsx
+++ b/packages/react/src/components/line/index.tsx
@@ -45,7 +45,7 @@ function VisLineFC<Datum> (props: VisLineProps<Datum>, fRef: ForwardedRef<VisLin
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/nested-donut/index.tsx
+++ b/packages/react/src/components/nested-donut/index.tsx
@@ -45,7 +45,7 @@ function VisNestedDonutFC<Datum> (props: VisNestedDonutProps<Datum>, fRef: Forwa
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/sankey/index.tsx
+++ b/packages/react/src/components/sankey/index.tsx
@@ -45,7 +45,7 @@ function VisSankeyFC<N extends SankeyInputNode, L extends SankeyInputLink> (prop
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/scatter/index.tsx
+++ b/packages/react/src/components/scatter/index.tsx
@@ -45,7 +45,7 @@ function VisScatterFC<Datum> (props: VisScatterProps<Datum>, fRef: ForwardedRef<
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/stacked-bar/index.tsx
+++ b/packages/react/src/components/stacked-bar/index.tsx
@@ -45,7 +45,7 @@ function VisStackedBarFC<Datum> (props: VisStackedBarProps<Datum>, fRef: Forward
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/timeline/index.tsx
+++ b/packages/react/src/components/timeline/index.tsx
@@ -45,7 +45,7 @@ function VisTimelineFC<Datum> (props: VisTimelineProps<Datum>, fRef: ForwardedRe
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -45,7 +45,7 @@ function VisTooltipFC (props: VisTooltipProps, fRef: ForwardedRef<VisTooltipRef>
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-tooltip ref={ref} />
 }
 

--- a/packages/react/src/components/topojson-map/index.tsx
+++ b/packages/react/src/components/topojson-map/index.tsx
@@ -45,7 +45,7 @@ function VisTopoJSONMapFC<AreaDatum, PointDatum, LinkDatum> (props: VisTopoJSONM
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/components/xy-labels/index.tsx
+++ b/packages/react/src/components/xy-labels/index.tsx
@@ -45,7 +45,7 @@ function VisXYLabelsFC<Datum> (props: VisXYLabelsProps<Datum>, fRef: ForwardedRe
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-component ref={ref} />
 }
 

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -46,7 +46,7 @@ export function VisLeafletFlowMapFC<
     component?.setConfig(props)
   })
 
-  useImperativeHandle(ref, () => ({ component }))
+  useImperativeHandle(ref, () => ({ get component () { return component } }), [component])
   return <div ref={container} className={props.className} />
 }
 

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -33,7 +33,7 @@ export function VisLeafletMapFC<Datum extends Record<string, unknown>> (props: V
     component?.setConfig(props)
   })
 
-  useImperativeHandle(ref, () => ({ component }))
+  useImperativeHandle(ref, () => ({ get component () { return component } }), [component])
   return <div ref={container} className={props.className} />
 }
 


### PR DESCRIPTION
Previously component refs were `undefined` due to the component initialization cycle. Changing the ref logic to use a getter to always return the latest instance of the component.