### PR TITLE
Component | XYLabels: Fix clustering config not taking effect

### DIFF
--- a/packages/ts/src/components/xy-labels/index.ts
+++ b/packages/ts/src/components/xy-labels/index.ts
@@ -76,7 +76,7 @@ export class XYLabels<Datum> extends XYComponentCore<Datum, XYLabelsConfigInterf
       return acc
     }, []) ?? []
 
-    return this._getClusteredLabels(labels)
+    return config.clustering ? this._getClusteredLabels(labels) : labels
   }
 
   private _getClusteredLabels (labels: XYLabel<Datum>[]): (XYLabel<Datum> | XYLabelCluster<Datum>)[] {


### PR DESCRIPTION
The `clustering` config property was not used in the code which prevented this setting to work.

Reported by @crllnsmnn! https://github.com/f5/unovis/discussions/204#discussioncomment-8702953