### PR TITLE
Angular: Adding new Angular versions to `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24489,9 +24489,9 @@
         "zone.js": "^0.14.0"
       },
       "peerDependencies": {
-        "@angular/common": "12 - 16",
-        "@angular/compiler": "12 - 16",
-        "@angular/core": "12 - 16",
+        "@angular/common": "12 - 18",
+        "@angular/compiler": "12 - 18",
+        "@angular/core": "12 - 18",
         "@unovis/ts": "1.4.0"
       }
     },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -45,9 +45,9 @@
   },
   "peerDependencies": {
     "@unovis/ts": "1.4.0",
-    "@angular/common": "12 - 16",
-    "@angular/compiler": "12 - 16",
-    "@angular/core": "12 - 16"
+    "@angular/common": "12 - 18",
+    "@angular/compiler": "12 - 18",
+    "@angular/core": "12 - 18"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^12.0.3",


### PR DESCRIPTION
Supporting new Angular versions 17 and 18 (not tested)

Reported by @juanmluces in #347