### PR TITLE
Crosshair: Configurable `stroke` and `strokeWidth`

### DIFF
--- a/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
+++ b/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
@@ -8,10 +8,10 @@ import {
   ChordInputLink,
   VisEventType,
   VisEventCallback,
-  ColorAccessor,
-  ChordLinkDatum,
   NumericAccessor,
   ChordNodeDatum,
+  ColorAccessor,
+  ChordLinkDatum,
   StringAccessor,
   GenericAccessor,
   ChordLabelAlignment,
@@ -75,6 +75,12 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
     };
   }
 
+  /** Angular range of the diagram. Default: `[0, 2 * Math.PI]` */
+  @Input() angleRange?: [number, number]
+
+  /** Corner radius constant value or accessor function. Default: `2` */
+  @Input() cornerRadius?: NumericAccessor<ChordNodeDatum<N>>
+
   /** Node id or index to highlight. Overrides default hover behavior if supplied. Default: `undefined` */
   @Input() highlightedNodeId?: number | string
 
@@ -108,12 +114,6 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
   /** Pad angle in radians. Default: `0.02` */
   @Input() padAngle?: number
 
-  /** Corner radius constant value or accessor function. Default: `2` */
-  @Input() cornerRadius?: NumericAccessor<ChordNodeDatum<N>>
-
-  /** Angular range of the diagram. Default: `[0, 2 * Math.PI]` */
-  @Input() angleRange?: [number, number]
-
   /** The exponent property of the radius scale. Default: `2` */
   @Input() radiusScaleExponent?: number
   @Input() data: { nodes: N[]; links?: L[] }
@@ -137,8 +137,8 @@ export class VisChordDiagramComponent<N extends ChordInputNode, L extends ChordI
   }
 
   private getConfig (): ChordDiagramConfigInterface<N, L> {
-    const { duration, events, attributes, highlightedNodeId, highlightedLinkIds, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent } = this
-    const config = { duration, events, attributes, highlightedNodeId, highlightedLinkIds, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, cornerRadius, angleRange, radiusScaleExponent }
+    const { duration, events, attributes, angleRange, cornerRadius, highlightedNodeId, highlightedLinkIds, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, radiusScaleExponent } = this
+    const config = { duration, events, attributes, angleRange, cornerRadius, highlightedNodeId, highlightedLinkIds, linkColor, linkValue, nodeLevels, nodeWidth, nodeColor, nodeLabel, nodeLabelColor, nodeLabelAlignment, padAngle, radiusScaleExponent }
     const keys = Object.keys(config) as (keyof ChordDiagramConfigInterface<N, L>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/crosshair/crosshair.component.ts
+++ b/packages/angular/src/components/crosshair/crosshair.component.ts
@@ -99,6 +99,12 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
    * Default: `false` */
   @Input() excludeFromDomainCalculation?: boolean
 
+  /** Optional stroke color accessor function for crosshair circles. Default: `undefined` */
+  @Input() strokeColor?: ColorAccessor<Datum>
+
+  /** Optional stroke width for crosshair circles. Default: `undefined` */
+  @Input() strokeWidth?: NumericAccessor<Datum>
+
   /** Separate array of accessors for stacked components (eg StackedBar, Area). Default: `undefined` */
   @Input() yStacked?: NumericAccessor<Datum>[]
 
@@ -150,8 +156,8 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
   }
 
   private getConfig (): CrosshairConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles }
     const keys = Object.keys(config) as (keyof CrosshairConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/nested-donut/nested-donut.component.ts
+++ b/packages/angular/src/components/nested-donut/nested-donut.component.ts
@@ -133,9 +133,8 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
    * Default: `false` */
   @Input() showEmptySegments?: boolean
 
-  /** Show labels for individual segments. Default: `true` */
-  @Input() showSegmentLabels?: boolean
 
+  @Input() showSegmentLabels?: boolean
   @Input() data: Datum[]
 
   component: NestedDonut<Datum> | undefined
@@ -157,8 +156,8 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
   }
 
   private getConfig (): NestedDonutConfigInterface<Datum> {
-    const { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments } = this
-    const config = { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments }
+    const { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments, showSegmentLabels } = this
+    const config = { duration, events, attributes, angleRange, direction, value, centralLabel, centralSubLabel, centralSubLabelWrap, showBackground, sort, layers, layerSettings, layerPadding, cornerRadius, emptySegmentAngle, hideOverflowingSegmentLabels, segmentColor, segmentLabel, segmentLabelColor, showEmptySegments, showSegmentLabels }
     const keys = Object.keys(config) as (keyof NestedDonutConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/tooltip/tooltip.component.ts
+++ b/packages/angular/src/components/tooltip/tooltip.component.ts
@@ -43,7 +43,7 @@ export class VisTooltipComponent implements TooltipConfigInterface, AfterViewIni
    * }
    * ``` */
   @Input() triggers?: {
-    [selector: string]: (data: any, i: number, elements: (HTMLElement | SVGElement)[]) => string | HTMLElement | undefined | null;
+    [selector: string]: ((data: any, i: number, elements: (HTMLElement | SVGElement)[]) => string | HTMLElement | undefined | null) | undefined | null;
   }
 
   /** Custom DOM attributes for the tooltip. Useful when you need to refer to a specific tooltip instance

--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -15,6 +15,10 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
   y?: NumericAccessor<Datum> | NumericAccessor<Datum>[];
   /** Optional color array or color accessor function for crosshair circles. Default: `d => d.color` */
   color?: ColorAccessor<Datum>;
+  /** Optional stroke color accessor function for crosshair circles. Default: `undefined` */
+  strokeColor?: ColorAccessor<Datum>;
+  /** Optional stroke width for crosshair circles. Default: `undefined` */
+  strokeWidth?: NumericAccessor<Datum>;
   /** Separate array of accessors for stacked components (eg StackedBar, Area). Default: `undefined` */
   yStacked?: NumericAccessor<Datum>[];
   /** Baseline accessor function for stacked values, useful with stacked areas. Default: `null` */
@@ -54,5 +58,7 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   snapToData: true,
   getCircles: undefined,
   color: undefined,
+  strokeColor: undefined,
+  strokeWidth: undefined,
 }
 

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -102,6 +102,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       .attr('cx', this.x)
       .attr('cy', d => d.y)
       .style('fill', d => d.color)
+      .style('stroke', d => d.strokeColor)
+      .style('stroke-width', d => d.strokeWidth)
 
     smartTransition(circlesEnter.merge(circles), duration, easeLinear)
       .attr('cx', this.x)
@@ -109,6 +111,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       .attr('r', 4)
       .style('opacity', d => d.opacity)
       .style('fill', d => d.color)
+      .style('stroke', d => d.strokeColor)
+      .style('stroke-width', d => d.strokeWidth)
 
     circles.exit().remove()
   }
@@ -201,6 +205,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
           y: this.yScale(value + baselineValue),
           opacity: getNumber(this.datum, yStackedAccessors[index]) ? 1 : 0,
           color: getColor(this.datum, config.color, index),
+          strokeColor: config.strokeColor ? getColor(this.datum, config.strokeColor, index) : undefined,
+          strokeWidth: config.strokeWidth ? getNumber(this.datum, config.strokeWidth, index) : undefined,
         }))
 
       const regularValues: CrosshairCircle[] = yAccessors
@@ -210,6 +216,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
             y: this.yScale(value),
             opacity: value ? 1 : 0,
             color: getColor(this.datum, config.color, stackedValues.length + index),
+            strokeColor: config.strokeColor ? getColor(this.datum, config.strokeColor, index) : undefined,
+            strokeWidth: config.strokeWidth ? getNumber(this.datum, config.strokeWidth, index) : undefined,
           }
         })
 

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -203,7 +203,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       const stackedValues: CrosshairCircle[] = getStackedValues(this.datum, this.datumIndex, ...yStackedAccessors)
         .map((value, index, arr) => ({
           y: this.yScale(value + baselineValue),
-          opacity: getNumber(this.datum, yStackedAccessors[index]) ? 1 : 0,
+          opacity: isNumber(getNumber(this.datum, yStackedAccessors[index])) ? 1 : 0,
           color: getColor(this.datum, config.color, index),
           strokeColor: config.strokeColor ? getColor(this.datum, config.strokeColor, index) : undefined,
           strokeWidth: config.strokeWidth ? getNumber(this.datum, config.strokeWidth, index) : undefined,
@@ -214,7 +214,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
           const value = getNumber(this.datum, a)
           return {
             y: this.yScale(value),
-            opacity: value ? 1 : 0,
+            opacity: isNumber(value) ? 1 : 0,
             color: getColor(this.datum, config.color, stackedValues.length + index),
             strokeColor: config.strokeColor ? getColor(this.datum, config.strokeColor, index) : undefined,
             strokeWidth: config.strokeWidth ? getNumber(this.datum, config.strokeWidth, index) : undefined,

--- a/packages/ts/src/components/crosshair/style.ts
+++ b/packages/ts/src/components/crosshair/style.ts
@@ -4,8 +4,10 @@ export const globalStyles = injectGlobal`
   :root {
     --vis-crosshair-line-stroke-color: #888;
     --vis-crosshair-line-stroke-width: 1px;
+    --vis-crosshair-line-stroke-opacity: 1;
     --vis-crosshair-circle-stroke-color: #fff;
     --vis-crosshair-circle-stroke-width: 1px;
+    --vis-crosshair-circle-stroke-opacity: 0.75;
   }
 `
 
@@ -16,13 +18,13 @@ export const root = css`
 export const line = css`
   stroke: var(--vis-crosshair-line-stroke-color);
   stroke-width: var(--vis-crosshair-line-stroke-width);
-  stroke-opacity: 1;
+  stroke-opacity: var(--vis-crosshair-line-stroke-opacity);
   pointer-events: none;
 `
 
 export const circle = css`
   stroke: var(--vis-crosshair-circle-stroke-color);
   stroke-width: var(--vis-crosshair-circle-stroke-width);
-  stroke-opacity: 0.75;
+  stroke-opacity: var(--vis-crosshair-circle-stroke-opacity);
   pointer-events: none;
 `

--- a/packages/ts/src/components/crosshair/types.ts
+++ b/packages/ts/src/components/crosshair/types.ts
@@ -5,6 +5,8 @@ export type CrosshairCircle = {
   color: string;
   opacity?: number;
   id?: string;
+  strokeColor?: string;
+  strokeWidth?: number;
 }
 
 export type CrosshairAccessors<Datum> = {

--- a/packages/website/docs/auxiliary/Crosshair.mdx
+++ b/packages/website/docs/auxiliary/Crosshair.mdx
@@ -9,6 +9,7 @@ export const defaultProps = (chart="Line", components, n=5) => ({
   data: generateDataRecords(n),
   showAxes: true,
   height: 150,
+  containerProps: { padding: { top: 5, bottom: 5 } },
   components: [{ name: chart, props: { x: d=>d.x, y: [d=>d.y, d=>d.y1, d=>d.y2], ...components}, key: "components" }]
 })
 
@@ -46,6 +47,10 @@ Use the `hideWhenFarFromPointerDistance` attribute with a length (in pixels) tha
 ## Custom Color
 Provide a `string` or color accessor function to the `color` attribute to customize the crosshair's point color:
 <XYWrapper {...defaultProps()} color={(d, i) => ['red', 'green', 'blue'][i]} showContext="minimal"/>
+
+## Custom Stroke Color and Width
+Provide values or accessor functions to the `strokeColor` and `strokeWidth` attributes to customize the crosshair's circle stroke color and width:
+<XYWrapper {...defaultProps()} color='none' strokeColor={(d, i) => ['red', 'green', 'blue'][i]} strokeWidth={(d, i) => [1, 2, 3][i]} showContext="minimal"/>
 
 ## Adding a Tooltip
 You can render text content for your _Crosshair_ component by providing it with a `template` property and a _Tooltip_ component within the same container.


### PR DESCRIPTION
Adds support for configurable `stroke` and `strokeWidth` crosshair circles.
Also fixes the issue with the missing circle at zero Y axis values.

@reb-dev Can you please generate new Angular wrapper for this? I'm getting problems with it again on my end. 

Requested by @shyakadavis in #338

<img width="842" alt="image" src="https://github.com/f5/unovis/assets/755708/842b65cc-7d1f-400f-951a-afdd96903368">
