### PR TITLE
Unovis | Angular: Fix Stackblitz

### DIFF
--- a/packages/website/src/utils/stackblitz.ts
+++ b/packages/website/src/utils/stackblitz.ts
@@ -37,25 +37,20 @@ function getStarterFiles (framework: Framework, e: Example): ProjectFiles {
       return {
         'src/index.html': '<app-component></app-component>',
         'src/main.ts': trimMultiline(`
-          import 'zone.js/dist/zone'
-          import { NgModule, Component } from '@angular/core'
-          import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
-          import { BrowserModule } from '@angular/platform-browser'
+          import 'zone.js'
+          import { Component } from '@angular/core'
+          import { bootstrapApplication } from '@angular/platform-browser'
           import { ${e.codeAngular.module.match(/export class\s*(?<name>\S+)/).groups.name} as ComponentModule } from './${e.pathname}/${e.pathname}.module'
 
           @Component({
             selector: 'app-component',
+            imports: [ ComponentModule ],
+            standalone: true,
             template: '<${e.pathname}></${e.pathname}>'
-          }) export class AppComponent { }
+          }) 
+          export class AppModule {}
 
-          @NgModule({
-            imports:      [ BrowserModule, ComponentModule ],
-            declarations: [ AppComponent ],
-            bootstrap:    [ AppComponent ]
-          })
-          export class AppModule { }
-
-          platformBrowserDynamic().bootstrapModule(AppModule)
+          bootstrapApplication(AppModule)
         `),
         [`src/${e.pathname}/${e.pathname}.component.ts`]: e.codeAngular.component,
         [`src/${e.pathname}/${e.pathname}.component.html`]: e.codeAngular.html,


### PR DESCRIPTION
This is my attempt to fix StackBlitz for Angular ([issue](https://github.com/unovis/issues-only/issues/33)). 

One issue i've noticed was `platform-browser-dynamic` was not being imported. I'm not sure if there's a specific reason to use that, if not, based on this [article](https://web.archive.org/web/20161012212853/https://angular.io/docs/ts/latest/guide/ngmodule.html#!#bootstrap), I think we could just use `platform-browser` instead. And to simplify things, since angular has `standalone` component now, I think we could just make this a standalone component and avoid `NgModule` all together. 

These updates are based on a working [example](https://stackblitz.com/edit/stackblitz-starters-utfuhq?file=src%2Fvis%2Fvis.component.ts) from @reb-dev (thanks). 

Again, I'm very new to the project, so if I missed something, please let me know.
