### PR TITLE
Shared | Autogen: Adding support for standalone components

### DIFF
--- a/packages/angular/autogen/component.ts
+++ b/packages/angular/autogen/component.ts
@@ -17,6 +17,16 @@ function getJSDocComments (jsdocStringArray: string[]): string {
   }).join('\n')
 }
 
+function checkGeneric (type: string, generics?: GenericParameter[]): string {
+  // Override the default generic with specified type from generics array
+  const isFound = type.search(/[<|\s](Datum)>/)
+  const isValid = generics?.find(t => t.name === 'Datum')
+  if (isFound !== -1 && !isValid) {
+    return `${type.slice(0, isFound + 1)}${generics[0].name}${type.slice(isFound + 6)}`
+  }
+  return type
+}
+
 export function getComponentCode (
   componentName: string,
   generics: GenericParameter[],
@@ -24,49 +34,57 @@ export function getComponentCode (
   provide: string,
   importStatements: { source: string; elements: string[] }[],
   dataType = 'any',
-  kebabCaseName?: string
+  kebabCaseName?: string,
+  isStandAlone = false,
+  styles = []
 ): string {
   const genericsStr = generics ? `<${generics?.map(g => g.name).join(', ')}>` : ''
   const genericsDefStr = generics
     ? `<${generics?.map(g => g.name + (g.extends ? ` extends ${g.extends}` : '') + (g.default ? ` = ${g.default}` : '')).join(', ')}>`
     : ''
+  const decoratorProps = isStandAlone ? `template: '<div #container class="${kebabCaseName ?? kebabCase(componentName)}-container"></div>',
+    styles: ['.${kebabCaseName ?? kebabCase(componentName)}-container { ${styles?.join('; ')} }']`
+    : 'template: \'\''
+  const constructorArgs = isStandAlone
+    ? `this.containerRef.nativeElement, this.getConfig()${dataType ? ', this.data' : ''}`
+    : 'this.getConfig()'
+  // Override the default generic with specified type from generics array
   return `// !!! This code was automatically generated. You should not change it !!!
-import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
+import { Component, AfterViewInit, Input, SimpleChanges${isStandAlone ? ', ViewChild, ElementRef' : ''} } from '@angular/core'
 ${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n')}
 import { ${provide} } from '../../core'
 
 @Component({
   selector: 'vis-${kebabCaseName ?? kebabCase(componentName)}',
-  template: '',
+  ${decoratorProps},
   // eslint-disable-next-line no-use-before-define
   providers: [{ provide: ${provide}, useExisting: Vis${componentName}Component }],
 })
 export class Vis${componentName}Component${genericsDefStr} implements ${componentName}ConfigInterface${genericsStr}, AfterViewInit {
+  ${isStandAlone ? '@ViewChild(\'container\', { static: false }) containerRef: ElementRef' : ''}
 ${
   configProps
     .map((p: ConfigProperty) => `
       ${getJSDocComments(p.doc ?? [])}
-      @Input() ${p.name}${p.required ? '' : '?'}: ${p.type}`)
+      @Input() ${p.name}${p.required ? '' : '?'}: ${checkGeneric(p.type, generics)}`)
     .join('\n')
 }
-  ${dataType ? `@Input() data: ${dataType}` : ''}
-
+  ${dataType ? `@Input() data: ${dataType}\n` : ''}
   component: ${componentName}${genericsStr} | undefined
-  public componentContainer: ContainerCore | undefined
-
+  ${isStandAlone ? '' : 'public componentContainer: ContainerCore | undefined\n'}
   ngAfterViewInit (): void {
-    this.component = new ${componentName}${genericsStr}(this.getConfig())
+    this.component = new ${componentName}${genericsStr}(${constructorArgs})
     ${dataType ? `
       if (this.data) {
         this.component.setData(this.data)
-        this.componentContainer?.render()
+        ${isStandAlone ? '' : 'this.componentContainer?.render()'}
       }` : ''}
   }
 
   ngOnChanges (changes: SimpleChanges): void {
     ${dataType ? 'if (changes.data) { this.component?.setData(this.data) }' : ''}
-    this.component?.setConfig(this.getConfig())
-    this.componentContainer?.render()
+    this.component?.${componentName === 'BulletLegend' ? 'update' : 'setConfig'}(this.getConfig())
+    ${isStandAlone ? '' : 'this.componentContainer?.render()'}
   }
 
   private getConfig (): ${componentName}ConfigInterface${genericsStr} {

--- a/packages/angular/autogen/index.ts
+++ b/packages/angular/autogen/index.ts
@@ -14,12 +14,11 @@ import { getImportStatements, kebabCase, getConfigSummary } from '@unovis/shared
 import { getComponentCode } from './component'
 import { getModuleCode } from './module'
 
-const skipProperties = ['width', 'height']
 const components = getComponentList() as AngularComponentInput[]
 
 for (const component of components) {
-  const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties, false)
-  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics, ['ContainerCore'])
+  const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, [], false)
+  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics, component.isStandAlone ? [] : ['ContainerCore'])
 
   const componentCode = getComponentCode(
     component.name,
@@ -28,12 +27,14 @@ for (const component of components) {
     component.angularProvide,
     importStatements,
     component.dataType,
-    component.kebabCaseName
+    component.kebabCaseName,
+    component.isStandAlone,
+    component.angularStyles
   )
   const moduleCode = getModuleCode(component.name, component.kebabCaseName)
 
   const nameKebabCase = component.kebabCaseName ?? kebabCase(component.name)
-  const pathComponentBase = `src/components/${nameKebabCase}`
+  const pathComponentBase = `src/${component.isStandAlone ? 'html-' : ''}components/${nameKebabCase}`
   const pathComponent = `${pathComponentBase}/${nameKebabCase}.component.ts`
   const pathModule = `${pathComponentBase}/${nameKebabCase}.module.ts`
 

--- a/packages/angular/src/components/nested-donut/nested-donut.component.ts
+++ b/packages/angular/src/components/nested-donut/nested-donut.component.ts
@@ -79,7 +79,7 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
   /** Direction of hierarchy flow from root to leaf.
    * `NestedDonutDirection.Inwards` starts from the outer most radius and works towards center
    * `NestedDonutDirection.Outwards` starts from the inner most radius the consecutive layers outward.
-   * Default: `NestedDonutDirection.Inwards` */
+   *  Default: `NestedDonutDirection.Inwards` */
   @Input() direction?: NestedDonutDirection | string
 
 
@@ -105,7 +105,12 @@ export class VisNestedDonutComponent<Datum> implements NestedDonutConfigInterfac
   /** Array of accessor functions to defined the nested groups */
   @Input() layers: StringAccessor<Datum>[]
 
-
+  /** Configuration properties for individual layers. Accepts an accessor or constant of type:
+   * {
+   *   backgroundColor?: string;
+   *   labelAlignment?: NestedDonutSegmentLabelAlignment;
+   *   width?: number | string;
+   * } */
   @Input() layerSettings?: GenericAccessor<NestedDonutLayerSettings, number>
 
 

--- a/packages/angular/src/components/tooltip/tooltip.component.ts
+++ b/packages/angular/src/components/tooltip/tooltip.component.ts
@@ -65,7 +65,6 @@ export class VisTooltipComponent implements TooltipConfigInterface, AfterViewIni
     [attr: string]: string | number | boolean;
   }
 
-
   component: Tooltip | undefined
   public componentContainer: ContainerCore | undefined
 

--- a/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
+++ b/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
@@ -1,10 +1,12 @@
+// !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
-import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface, BulletShape, GenericAccessor } from '@unovis/ts'
+import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface, GenericAccessor, BulletShape } from '@unovis/ts'
 import { VisGenericComponent } from '../../core'
 
 @Component({
   selector: 'vis-bullet-legend',
   template: '<div #container class="bullet-legend-container"></div>',
+  styles: ['.bullet-legend-container {  }'],
   // eslint-disable-next-line no-use-before-define
   providers: [{ provide: VisGenericComponent, useExisting: VisBulletLegendComponent }],
 })
@@ -14,14 +16,15 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
   /** Legend items. Array of `BulletLegendItemInterface`:
    * ```
    * {
-   *   name: string | number;
-   *   color?: string;
-   *   inactive?: boolean;
-   *   hidden?: boolean;
-   *   pointer?: boolean;
+   *  name: string | number;
+   *  color?: string;
+   *  shape?: BulletShape;
+   *  inactive?: boolean;
+   *  hidden?: boolean;
+   *  pointer?: boolean;
    * }
    * ```
-  * Default: `[]` */
+   * Default: `[]` */
   @Input() items: BulletLegendItemInterface[]
 
   /** Apply a specific class to the labels. Default: `''` */
@@ -36,7 +39,7 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
   /** Label text (<span> element) max-width CSS property. Default: `null` */
   @Input() labelMaxWidth?: string | null
 
-  /** Bullet circle size, mapped to the width and height CSS properties. Default: `null` */
+  /** Bullet shape size, mapped to the width and height CSS properties. Default: `null` */
   @Input() bulletSize?: string | null
 
   /** Bullet shape enum value or accessor function. Default: `d => d.shape ?? BulletShape.Circle */
@@ -53,8 +56,8 @@ export class VisBulletLegendComponent implements BulletLegendConfigInterface, Af
   }
 
   private getConfig (): BulletLegendConfigInterface {
-    const { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize } = this
-    const config = { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize }
+    const { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletShape } = this
+    const config = { items, labelClassName, onLegendItemClick, labelFontSize, labelMaxWidth, bulletSize, bulletShape }
     const keys = Object.keys(config) as (keyof BulletLegendConfigInterface)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
+++ b/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
@@ -1,41 +1,36 @@
+// !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
 import {
   LeafletFlowMap,
   LeafletFlowMapConfigInterface,
+  GenericDataRecord,
   VisEventType,
   VisEventCallback,
   Bounds,
+  MapLibreStyleSpecs,
+  LeafletMapRenderer,
   MapZoomState,
   NumericAccessor,
   StringAccessor,
+  GenericAccessor,
+  LeafletMapPointShape,
   ColorAccessor,
   LeafletMapPointDatum,
+  LeafletMapClusterDatum,
   LeafletMapPointStyles,
   Tooltip,
-  LeafletMapClusterDatum,
-  GenericDataRecord,
 } from '@unovis/ts'
-import { StyleSpecification } from 'maplibre-gl'
 import { VisCoreComponent } from '../../core'
 
 @Component({
   selector: 'vis-leaflet-flow-map',
-  template: '<div #container class="unovis-leaflet-flow-map-container"></div>',
-  styles: ['.unovis-leaflet-flow-map-container { width: 100%; height: 100%; position: relative; }'],
+  template: '<div #container class="leaflet-flow-map-container"></div>',
+  styles: ['.leaflet-flow-map-container { width: 100%; height: 100%; position: relative }'],
   // eslint-disable-next-line no-use-before-define
   providers: [{ provide: VisCoreComponent, useExisting: VisLeafletFlowMapComponent }],
 })
-export class VisLeafletFlowMapComponent<
-
-  PointDatum extends GenericDataRecord,
-  FlowDatum extends GenericDataRecord,
-> implements LeafletFlowMapConfigInterface<PointDatum, FlowDatum>, AfterViewInit {
+export class VisLeafletFlowMapComponent<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> implements LeafletFlowMapConfigInterface<PointDatum, FlowDatum>, AfterViewInit {
   @ViewChild('container', { static: false }) containerRef: ElementRef
-
-  /** Width in pixels or in CSS units. By default, the map will automatically fit to the size of the parent element. Default: `undefined`. */
-  @Input() width?: number | string
-  /** Height in pixels or in CSS units. By default, the map will automatically fit to the size of the parent element. Default: `undefined`. */
-  @Input() height?: number | string
 
   /** Animation duration of the data update transitions in milliseconds. Default: `600` */
   @Input() duration?: number
@@ -87,10 +82,16 @@ export class VisLeafletFlowMapComponent<
     };
   }
 
+  /** Width in pixels or in CSS units. By default, the map will automatically fit to the size of the parent element. Default: `undefined`. */
+  @Input() width?: number | string
+
+  /** Height in pixels or in CSS units. By default, the map will automatically fit to the size of the parent element. Default: `undefined`. */
+  @Input() height?: number | string
+
   /** Animation duration when the map is automatically panning or zooming to a point or area. Default: `1500` ms */
   @Input() flyToDuration?: number
 
-  /** Padding to be used when the `fitView` function has been called. The value is in pixels. Default: `[150, 150]` */
+  /** Padding to be used when the `fitView` function has been called. The value is in pixels, [topLeft, bottomRight]. Default: `[150, 150]` */
   @Input() fitViewPadding?: [number, number]
 
   /** Animation duration for the `setZoom` function. Default: `800` ms */
@@ -108,17 +109,20 @@ export class VisLeafletFlowMapComponent<
   /** Fit the view to contain the data points on map config and data updates. Default: `false` */
   @Input() fitViewOnUpdate?: boolean
 
-  /** MapLibre StyleSpecification settings. Default: `MapLibreArcticLight` */
-  @Input() style: StyleSpecification | string | undefined
+  /** MapLibre `StyleSpecification` settings, or a URL to it. When renderer is set to`LeafletMapRenderer.Raster`, provide a template URL. Default: `undefined` */
+  @Input() style: MapLibreStyleSpecs | string | undefined
 
-  /** MapLibre StyleSpecification settings for dark theme. Default: `undefined` */
-  @Input() styleDarkTheme: StyleSpecification | string | undefined
+  /** MapLibre `StyleSpecification` settings or URL for dark theme. Default: `undefined` */
+  @Input() styleDarkTheme?: MapLibreStyleSpecs | string | undefined
 
   /** Tile server access token or API key. Default: `''` */
   @Input() accessToken?: string
 
   /** Array of attribution labels. Default: `['<a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>']` */
   @Input() attribution?: string[]
+
+  /** Rendering mode for map's tile layer. For raster files, use `LeafletMapRenderer.Raster`. Default: `LeafletMapRenderer.MapLibre` */
+  @Input() renderer?: LeafletMapRenderer | string
 
   /** Function to be called after the map's async initialization is done. Default: `undefined` */
   @Input() onMapInitialized?: (() => void)
@@ -138,7 +142,7 @@ export class VisLeafletFlowMapComponent<
   /** Map Zoom End callback function. Default: `undefined` */
   @Input() onMapZoomEnd?: (({ mapCenter, zoomLevel, bounds }: MapZoomState) => void)
 
-  /** Map Zoom End callback function. Default: `undefined` */
+  /** Map Zoom Click callback function. Default: `undefined` */
   @Input() onMapClick?: (({ mapCenter, zoomLevel, bounds }: MapZoomState) => void)
 
   /** Point longitude accessor function. Default: `d => d.longitude` */
@@ -151,7 +155,7 @@ export class VisLeafletFlowMapComponent<
   @Input() pointId?: StringAccessor<PointDatum>
 
   /** Point shape accessor function or constant value. Default: `d => d.shape` */
-  @Input() pointShape?: StringAccessor<PointDatum>
+  @Input() pointShape?: GenericAccessor<LeafletMapPointShape | string, PointDatum>
 
   /** Point color accessor function or constant value. Default: `d => d.color` */
   @Input() pointColor?: ColorAccessor<LeafletMapPointDatum<PointDatum>>
@@ -159,14 +163,13 @@ export class VisLeafletFlowMapComponent<
   /** Point radius accessor function or constant value. Default: `undefined` */
   @Input() pointRadius?: NumericAccessor<LeafletMapPointDatum<PointDatum>>
 
-  /** Point inner label accessor function. Default: `d => d.point_count ?? ''` */
+  /** Point inner label accessor function. Default: `undefined` */
   @Input() pointLabel?: StringAccessor<LeafletMapPointDatum<PointDatum>>
 
   /** Point inner label color accessor function or constant value.
    * By default, the label color will be set, depending on the point brightness, either to
    * `--vis-map-point-inner-label-text-color-light` or to `--vis-map-point-inner-label-text-color-dark` CSS variable.
-   * Default: `undefined`
-  */
+   * Default: `undefined` */
   @Input() pointLabelColor?: StringAccessor<LeafletMapPointDatum<PointDatum>>
 
   /** Point bottom label accessor function. Default: `''` */
@@ -175,30 +178,31 @@ export class VisLeafletFlowMapComponent<
   /** Point cursor value or accessor function. Default: `null` */
   @Input() pointCursor?: StringAccessor<LeafletMapPointDatum<PointDatum>>
 
+  /** The width of the ring when a point has a `LeafletMapPointShape.Ring` shape. Default: `1.25` */
+  @Input() pointRingWidth?: number
+
   /** Set selected point by its unique id. Default: `undefined` */
   @Input() selectedPointId?: string
 
-  /** Cluster color accessor function or constant value. Default: `undefined`  */
+  /** Cluster color accessor function or constant value. Default: `undefined` */
   @Input() clusterColor?: ColorAccessor<LeafletMapClusterDatum<PointDatum>>
 
-  /** Cluster radius accessor function or constant value. Default: `undefined`  */
+  /** Cluster radius accessor function or constant value. Default: `undefined` */
   @Input() clusterRadius?: NumericAccessor<LeafletMapClusterDatum<PointDatum>>
 
-  /** Cluster inner label accessor function. Default: `d => d.point_count`  */
+  /** Cluster inner label accessor function. Default: `d => d.point_count` */
   @Input() clusterLabel?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
 
   /** Cluster inner label color accessor function or constant value.
    * By default, the label color will be set, depending on the point brightness, either to
    * `--vis-map-cluster-inner-label-text-color-light` or to `--vis-map-cluster-inner-label-text-color-dark` CSS variable.
-   * Default: `undefined`
-  */
+   * Default: `undefined` */
   @Input() clusterLabelColor?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
 
   /** Cluster bottom label accessor function. Default: `''` */
   @Input() clusterBottomLabel?: StringAccessor<LeafletMapClusterDatum<PointDatum>>
 
-
-  /** The width of the cluster point outline. Default: `1.25` */
+  /** The width of the cluster point ring. Default: `1.25` */
   @Input() clusterRingWidth?: number
 
   /** When cluster is expanded, show a background circle to better separate points from the base map. Default: `true` */
@@ -211,7 +215,7 @@ export class VisLeafletFlowMapComponent<
   @Input() clusteringDistance?: number
 
   /** A single map point can have multiple properties displayed as a small pie chart (or a donut chart for a cluster of points).
-   * By setting the valuesMap configuration you can specify data properties that should be mapped to various pie / donut segments.
+   * By setting the colorMap configuration you can specify data properties that should be mapped to various pie / donut segments.
    *
    * ```
    * {
@@ -227,7 +231,7 @@ export class VisLeafletFlowMapComponent<
    * }
    * ```
    * where every data point has the `healthy`, `warning` and `danger` numerical or boolean property. */
-  @Input() valuesMap?: LeafletMapPointStyles<PointDatum>
+  @Input() colorMap?: LeafletMapPointStyles<PointDatum>
 
   /** A TopoJSON Geometry layer to be displayed on top of the map. Supports fill and stroke */
   @Input() topoJSONLayer?: {
@@ -244,59 +248,67 @@ export class VisLeafletFlowMapComponent<
   @Input() tooltip?: Tooltip
 
   /** Alternative text description of the chart for accessibility purposes. It will be applied as an
-   * `aria-label` attribute to the div element containing your chart. Default: `undefined`.
-  */
+   * `aria-label` attribute to the div element containing your chart. Default: `undefined`. */
   @Input() ariaLabel?: string | null | undefined
 
   /** Flow source point longitude accessor function or value. Default:.`f => f.sourceLongitude` */
   @Input() sourceLongitude?: NumericAccessor<FlowDatum>
+
   /** Flow source point latitude accessor function or value. Default: `f => f.sourceLatitude` */
   @Input() sourceLatitude?: NumericAccessor<FlowDatum>
+
   /** Flow target point longitude accessor function or value. Default: `f => f.targetLongitude` */
   @Input() targetLongitude?: NumericAccessor<FlowDatum>
+
   /** Flow target point latitude accessor function or value. Default: `f => f.targetLatitude` */
   @Input() targetLatitude?: NumericAccessor<FlowDatum>
+
   /** Flow source point radius accessor function or value. Default: `3` */
   @Input() sourcePointRadius?: NumericAccessor<FlowDatum>
+
   /** Source point color accessor function or value. Default: `'#88919f'` */
   @Input() sourcePointColor?: ColorAccessor<FlowDatum>
+
   /** Flow particle color accessor function or value. Default: `'#949dad'` */
   @Input() flowParticleColor?: ColorAccessor<FlowDatum>
+
   /** Flow particle radius accessor function or value. Default: `1.1` */
   @Input() flowParticleRadius?: NumericAccessor<FlowDatum>
-  /** Flow particle speed accessor function or value in angular degrees. Default: `0.07` */
+
+  /** Flow particle speed accessor function or value. The unit is arbitrary, recommended range is 0 – 0.2. Default: `0.07` */
   @Input() flowParticleSpeed?: NumericAccessor<FlowDatum>
+
   /** Flow particle density accessor function or value on the range of [0, 1]. Default: `0.6` */
   @Input() flowParticleDensity?: NumericAccessor<FlowDatum>
 
-  // Events
   /** Flow source point click callback function. Default: `undefined` */
-  @Input() onSourcePointClick?: ((f: FlowDatum, x: number, y: number, event: MouseEvent) => unknown)
-  /** Flow source point mouse over callback function. Default: `undefined` */
-  @Input() onSourcePointMouseEnter?: ((f: FlowDatum, x: number, y: number, event: MouseEvent) => unknown)
-  /** Flow source point mouse leave callback function. Default: `undefined` */
-  @Input() onSourcePointMouseLeave?: ((f: FlowDatum, event: MouseEvent) => unknown)
+  @Input() onSourcePointClick?: (f: FlowDatum, x: number, y: number, event: MouseEvent) => void
 
-  /** Data */
-  @Input() data?: { points: PointDatum[]; flows: FlowDatum[] }
+  /** Flow source point mouse over callback function. Default: `undefined` */
+  @Input() onSourcePointMouseEnter?: (f: FlowDatum, x: number, y: number, event: MouseEvent) => void
+
+  /** Flow source point mouse leave callback function. Default: `undefined` */
+  @Input() onSourcePointMouseLeave?: (f: FlowDatum, event: MouseEvent) => void
+  @Input() data: { points: PointDatum[]; flows?: FlowDatum[] }
 
   component: LeafletFlowMap<PointDatum, FlowDatum> | undefined
 
   ngAfterViewInit (): void {
-    const config = this.getConfig()
-    this.component = new LeafletFlowMap<PointDatum, FlowDatum>(this.containerRef.nativeElement, config, this.data)
+    this.component = new LeafletFlowMap<PointDatum, FlowDatum>(this.containerRef.nativeElement, this.getConfig(), this.data)
+
+    if (this.data) {
+      this.component.setData(this.data)
+    }
   }
 
   ngOnChanges (changes: SimpleChanges): void {
-    if (changes.data) {
-      this.component?.setData(this.data)
-    }
+    if (changes.data) { this.component?.setData(this.data) }
     this.component?.setConfig(this.getConfig())
   }
 
   private getConfig (): LeafletFlowMapConfigInterface<PointDatum, FlowDatum> {
-    const { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, ariaLabel, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave } = this
-    const config = { width, height, duration, events, attributes, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, accessToken, style, styleDarkTheme, attribution, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, valuesMap, topoJSONLayer, tooltip, ariaLabel, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave }
+    const { duration, events, attributes, width, height, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, style, styleDarkTheme, accessToken, attribution, renderer, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, pointRingWidth, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip, ariaLabel, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave } = this
+    const config = { duration, events, attributes, width, height, flyToDuration, fitViewPadding, zoomDuration, initialBounds, fitBoundsOnUpdate, fitViewOnInit, fitViewOnUpdate, style, styleDarkTheme, accessToken, attribution, renderer, onMapInitialized, onMapMoveZoom, onMapMoveStart, onMapMoveEnd, onMapZoomStart, onMapZoomEnd, onMapClick, pointLongitude, pointLatitude, pointId, pointShape, pointColor, pointRadius, pointLabel, pointLabelColor, pointBottomLabel, pointCursor, pointRingWidth, selectedPointId, clusterColor, clusterRadius, clusterLabel, clusterLabelColor, clusterBottomLabel, clusterRingWidth, clusterBackground, clusterExpandOnClick, clusteringDistance, colorMap, topoJSONLayer, tooltip, ariaLabel, sourceLongitude, sourceLatitude, targetLongitude, targetLatitude, sourcePointRadius, sourcePointColor, flowParticleColor, flowParticleRadius, flowParticleSpeed, flowParticleDensity, onSourcePointClick, onSourcePointMouseEnter, onSourcePointMouseLeave }
     const keys = Object.keys(config) as (keyof LeafletFlowMapConfigInterface<PointDatum, FlowDatum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.module.ts
+++ b/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.module.ts
@@ -1,3 +1,4 @@
+// !!! This code was automatically generated. You should not change it !!!
 import { NgModule } from '@angular/core'
 import { VisLeafletFlowMapComponent } from './leaflet-flow-map.component'
 

--- a/packages/angular/src/html-components/leaflet-map/leaflet-map.module.ts
+++ b/packages/angular/src/html-components/leaflet-map/leaflet-map.module.ts
@@ -1,3 +1,4 @@
+// !!! This code was automatically generated. You should not change it !!!
 import { NgModule } from '@angular/core'
 import { VisLeafletMapComponent } from './leaflet-map.component'
 

--- a/packages/react/autogen/index.ts
+++ b/packages/react/autogen/index.ts
@@ -25,11 +25,12 @@ for (const component of components) {
     generics,
     importStatements,
     component.dataType,
-    component.elementSuffix
+    component.elementSuffix,
+    component.isStandAlone
   )
 
   const nameKebabCase = component.kebabCaseName ?? kebabCase(component.name)
-  const pathComponentBase = `src/components/${nameKebabCase}`
+  const pathComponentBase = `src/${component.isStandAlone ? 'html-' : ''}components/${nameKebabCase}`
   const pathComponent = `${pathComponentBase}/index.tsx` // `${pathComponentBase}/${nameKebabCase}.component.tsx`
 
   exec(`mkdir ${pathComponentBase}`, () => {

--- a/packages/react/src/components/annotations/index.tsx
+++ b/packages/react/src/components/annotations/index.tsx
@@ -17,6 +17,8 @@ export type VisAnnotationsProps = AnnotationsConfigInterface & {
   ref?: Ref<VisAnnotationsRef>;
 }
 
+export const VisAnnotationsSelectors = Annotations.selectors
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function VisAnnotationsFC (props: VisAnnotationsProps, fRef: ForwardedRef<VisAnnotationsRef>): JSX.Element {
   const ref = useRef<VisComponentElement<Annotations>>(null)
@@ -39,10 +41,11 @@ function VisAnnotationsFC (props: VisAnnotationsProps, fRef: ForwardedRef<VisAnn
   // On Props Update
   useEffect(() => {
     const component = componentRef.current
+
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ component: componentRef.current }), [componentRef.current])
+  useImperativeHandle(fRef, () => ({ get component () { return componentRef.current } }), [])
   return <vis-annotations ref={ref} />
 }
 

--- a/packages/react/src/html-components/bullet-legend/index.tsx
+++ b/packages/react/src/html-components/bullet-legend/index.tsx
@@ -1,18 +1,30 @@
-import React, { useEffect, useRef, useState } from 'react'
+// !!! This code was automatically generated. You should not change it !!!
+import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { BulletLegend, BulletLegendConfigInterface } from '@unovis/ts'
 
-export type VisBulletLegendProps = BulletLegendConfigInterface
+// Utils
+import { arePropsEqual } from 'src/utils/react'
+
+export type VisBulletLegendRef = {
+  component?: BulletLegend;
+}
+
+export type VisBulletLegendProps = BulletLegendConfigInterface & {
+  data?: null;
+  ref?: Ref<VisBulletLegendRef>;
+  className?: string;
+}
 
 export const VisBulletLegendSelectors = BulletLegend.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function VisBulletLegend (props: VisBulletLegendProps): JSX.Element {
-  const container = useRef<HTMLDivElement>(null)
+function VisBulletLegendFC (props: VisBulletLegendProps, fRef: ForwardedRef<VisBulletLegendRef>): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<BulletLegend>()
 
   // On Mount
   useEffect(() => {
-    const c = new BulletLegend(container.current as HTMLDivElement, props)
+    const c = new BulletLegend(ref.current as HTMLDivElement, props)
     setComponent(c)
 
     return () => c?.destroy()
@@ -23,5 +35,10 @@ export function VisBulletLegend (props: VisBulletLegendProps): JSX.Element {
     component?.update(props)
   })
 
-  return <div ref={container} />
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  return <div className={props.className} ref={ref} />
 }
+
+// We export a memoized component to avoid unnecessary re-renders
+//  and define its type explicitly to help react-docgen-typescript to extract information about props
+export const VisBulletLegend: ((props: VisBulletLegendProps) => JSX.Element | null) = React.memo(React.forwardRef(VisBulletLegendFC), arePropsEqual)

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -1,39 +1,30 @@
-import React, { ForwardedRef, Ref, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import { LeafletFlowMap, LeafletFlowMapConfigInterface } from '@unovis/ts'
-import { arePropsEqual } from '../../utils/react'
+// !!! This code was automatically generated. You should not change it !!!
+import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import { LeafletFlowMap, LeafletFlowMapConfigInterface, GenericDataRecord } from '@unovis/ts'
 
-export const VisLeafletFlowMapSelectors = LeafletFlowMap.selectors
+// Utils
+import { arePropsEqual } from 'src/utils/react'
 
-export type VisLeafletFlowMapProps<
-  PointDatum extends Record<string, unknown>,
-  FlowDatum extends Record<string, unknown>,
-> = LeafletFlowMapConfigInterface<PointDatum, FlowDatum> & {
-  data?: { points: PointDatum[]; flows: FlowDatum[] };
+export type VisLeafletFlowMapRef<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> = {
+  component?: LeafletFlowMap<PointDatum, FlowDatum>;
+}
+
+export type VisLeafletFlowMapProps<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> = LeafletFlowMapConfigInterface<PointDatum, FlowDatum> & {
+  data?: { points: PointDatum[]; flows?: FlowDatum[] };
   ref?: Ref<VisLeafletFlowMapRef<PointDatum, FlowDatum>>;
   className?: string;
 }
 
-export type VisLeafletFlowMapRef<
-  PointDatum extends Record<string, unknown>,
-  FlowDatum extends Record<string, unknown>,
-> = {
-  component: LeafletFlowMap<PointDatum, FlowDatum> | undefined;
-}
+export const VisLeafletFlowMapSelectors = LeafletFlowMap.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function VisLeafletFlowMapFC<
-  PointDatum extends Record<string, unknown>,
-  FlowDatum extends Record<string, unknown>,
-> (
-  props: VisLeafletFlowMapProps<PointDatum, FlowDatum>,
-  ref: ForwardedRef<VisLeafletFlowMapRef<PointDatum, FlowDatum>>
-): JSX.Element {
-  const container = useRef<HTMLDivElement>(null)
+function VisLeafletFlowMapFC<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> (props: VisLeafletFlowMapProps<PointDatum, FlowDatum>, fRef: ForwardedRef<VisLeafletFlowMapRef<PointDatum, FlowDatum>>): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<LeafletFlowMap<PointDatum, FlowDatum>>()
 
   // On Mount
   useEffect(() => {
-    const c = new LeafletFlowMap(container.current as HTMLDivElement, props, props.data)
+    const c = new LeafletFlowMap<PointDatum, FlowDatum>(ref.current as HTMLDivElement, props, props.data)
     setComponent(c)
 
     return () => c?.destroy()
@@ -42,18 +33,13 @@ export function VisLeafletFlowMapFC<
   // On Props Update
   useEffect(() => {
     if (props.data) component?.setData(props.data)
-
     component?.setConfig(props)
   })
 
-  useImperativeHandle(ref, () => ({ get component () { return component } }), [component])
-  return <div ref={container} className={props.className} />
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  return <div className={props.className} ref={ref} />
 }
 
 // We export a memoized component to avoid unnecessary re-renders
 //  and define its type explicitly to help react-docgen-typescript to extract information about props
-export const VisLeafletFlowMap: (<
-  PointDatum extends Record<string, unknown>,
-  FlowDatum extends Record<string, unknown>,
->(props: VisLeafletFlowMapProps<PointDatum, FlowDatum>) => JSX.Element | null) =
-  React.memo(React.forwardRef(VisLeafletFlowMapFC), arePropsEqual)
+export const VisLeafletFlowMap: (<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord>(props: VisLeafletFlowMapProps<PointDatum, FlowDatum>) => JSX.Element | null) = React.memo(React.forwardRef(VisLeafletFlowMapFC), arePropsEqual)

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -1,26 +1,30 @@
-import React, { ForwardedRef, Ref, useEffect, useImperativeHandle, useRef, useState } from 'react'
-import { LeafletMap, LeafletMapConfigInterface } from '@unovis/ts'
-import { arePropsEqual } from '../../utils/react'
+// !!! This code was automatically generated. You should not change it !!!
+import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import { LeafletMap, LeafletMapConfigInterface, GenericDataRecord } from '@unovis/ts'
 
-export const VisLeafletMapSelectors = LeafletMap.selectors
+// Utils
+import { arePropsEqual } from 'src/utils/react'
 
-export type VisLeafletMapProps<Datum extends Record<string, unknown>> = LeafletMapConfigInterface<Datum> & {
+export type VisLeafletMapRef<Datum extends GenericDataRecord> = {
+  component?: LeafletMap<Datum>;
+}
+
+export type VisLeafletMapProps<Datum extends GenericDataRecord> = LeafletMapConfigInterface<Datum> & {
   data?: Datum[];
   ref?: Ref<VisLeafletMapRef<Datum>>;
   className?: string;
 }
 
-export type VisLeafletMapRef<Datum extends Record<string, unknown>> = {
-  component: LeafletMap<Datum> | undefined;
-}
+export const VisLeafletMapSelectors = LeafletMap.selectors
 
-export function VisLeafletMapFC<Datum extends Record<string, unknown>> (props: VisLeafletMapProps<Datum>, ref: ForwardedRef<VisLeafletMapRef<Datum>>): JSX.Element {
-  const container = useRef<HTMLDivElement>(null)
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function VisLeafletMapFC<Datum extends GenericDataRecord> (props: VisLeafletMapProps<Datum>, fRef: ForwardedRef<VisLeafletMapRef<Datum>>): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<LeafletMap<Datum>>()
 
   // On Mount
   useEffect(() => {
-    const c = new LeafletMap(container.current as HTMLDivElement, props, props.data)
+    const c = new LeafletMap<Datum>(ref.current as HTMLDivElement, props, props.data)
     setComponent(c)
 
     return () => c?.destroy()
@@ -29,15 +33,13 @@ export function VisLeafletMapFC<Datum extends Record<string, unknown>> (props: V
   // On Props Update
   useEffect(() => {
     if (props.data) component?.setData(props.data)
-
     component?.setConfig(props)
   })
 
-  useImperativeHandle(ref, () => ({ get component () { return component } }), [component])
-  return <div ref={container} className={props.className} />
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  return <div className={props.className} ref={ref} />
 }
 
 // We export a memoized component to avoid unnecessary re-renders
 //  and define its type explicitly to help react-docgen-typescript to extract information about props
-export const VisLeafletMap: (<Datum extends Record<string, unknown>>(props: VisLeafletMapProps<Datum>) => JSX.Element | null) =
-  React.memo(React.forwardRef(VisLeafletMapFC), arePropsEqual)
+export const VisLeafletMap: (<Datum extends GenericDataRecord>(props: VisLeafletMapProps<Datum>) => JSX.Element | null) = React.memo(React.forwardRef(VisLeafletMapFC), arePropsEqual)

--- a/packages/shared/integrations/components.ts
+++ b/packages/shared/integrations/components.ts
@@ -6,33 +6,33 @@ export function getComponentList (
 ): (AngularComponentInput | ReactComponentInput | SvelteComponentInput | VueComponentInput)[] {
   return [
     // XY Components
-    { name: 'Line', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/line'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'Area', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/area'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'Axis', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/axis'], dataType: 'Datum[]', angularProvide: 'VisXYComponent', elementSuffix: 'axis' },
     { name: 'Brush', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/brush'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
-    { name: 'FreeBrush', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/free-brush'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'Crosshair', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/crosshair'], dataType: 'Datum[]', angularProvide: 'VisXYComponent', elementSuffix: 'crosshair' },
+    { name: 'FreeBrush', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/free-brush'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'GroupedBar', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/grouped-bar'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
+    { name: 'Line', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/line'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'Scatter', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/scatter'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'StackedBar', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/stacked-bar'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'Timeline', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/timeline'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
     { name: 'XYLabels', sources: [coreComponentConfigPath, xyComponentConfigPath, '/components/xy-labels'], dataType: 'Datum[]', angularProvide: 'VisXYComponent' },
 
     // Single components
-    { name: 'Donut', sources: [coreComponentConfigPath, '/components/donut'], dataType: 'Datum[]', angularProvide: 'VisCoreComponent' },
-    { name: 'TopoJSONMap', kebabCaseName: 'topojson-map', sources: [coreComponentConfigPath, '/components/topojson-map'], dataType: '{areas?: AreaDatum[]; points?: PointDatum[]; links?: LinkDatum[]}', angularProvide: 'VisCoreComponent' },
-    { name: 'Sankey', sources: [coreComponentConfigPath, '/components/sankey'], dataType: '{ nodes: N[]; links?: L[] }', angularProvide: 'VisCoreComponent' },
-    { name: 'Graph', sources: [coreComponentConfigPath, '/components/graph'], dataType: '{ nodes: N[]; links?: L[] }', angularProvide: 'VisCoreComponent' },
     { name: 'ChordDiagram', sources: [coreComponentConfigPath, '/components/chord-diagram'], dataType: '{ nodes: N[]; links?: L[] }', angularProvide: 'VisCoreComponent' },
+    { name: 'Donut', sources: [coreComponentConfigPath, '/components/donut'], dataType: 'Datum[]', angularProvide: 'VisCoreComponent' },
+    { name: 'Graph', sources: [coreComponentConfigPath, '/components/graph'], dataType: '{ nodes: N[]; links?: L[] }', angularProvide: 'VisCoreComponent' },
     { name: 'NestedDonut', sources: [coreComponentConfigPath, '/components/nested-donut'], dataType: 'Datum[]', angularProvide: 'VisCoreComponent' },
+    { name: 'Sankey', sources: [coreComponentConfigPath, '/components/sankey'], dataType: '{ nodes: N[]; links?: L[] }', angularProvide: 'VisCoreComponent' },
+    { name: 'TopoJSONMap', kebabCaseName: 'topojson-map', sources: [coreComponentConfigPath, '/components/topojson-map'], dataType: '{areas?: AreaDatum[]; points?: PointDatum[]; links?: LinkDatum[]}', angularProvide: 'VisCoreComponent' },
 
     // Ancillary components
     { name: 'Tooltip', sources: ['/components/tooltip'], dataType: null, angularProvide: 'VisGenericComponent', elementSuffix: 'tooltip' },
-    { name: 'Annotations', sources: [coreComponentConfigPath, '/components/annotations'], dataType: null, elementSuffix: 'annotations', angularProvide: 'VisGenericComponent' },
+    { name: 'Annotations', sources: [coreComponentConfigPath, '/components/annotations'], dataType: null, angularProvide: 'VisGenericComponent', elementSuffix: 'annotations' },
 
-    // Unique cases (you can still generate a wrapper for these components, but most likely it will require some changes)
-    // { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', angularProvide: 'VisCoreComponent', svelteStyles: ['display:block', 'position:relative'] },
-    // { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', svelteStyles: ['display:block', 'position:relative'] },
-    // { name: 'BulletLegend', sources: ['/components/bullet-legend'], dataType: null,  angularProvide: 'VisGenericComponent', svelteStyles: ['display:block'] },
+    // Standalone components
+    { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', isStandAlone: true, angularProvide: 'VisCoreComponent', svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
+    { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', isStandAlone: true, svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
+    { name: 'BulletLegend', sources: ['/components/bullet-legend'], dataType: null, angularProvide: 'VisGenericComponent', isStandAlone: true, svelteStyles: ['display:block'], vueStyles: ['display:block'] },
   ]
 }

--- a/packages/shared/integrations/components.ts
+++ b/packages/shared/integrations/components.ts
@@ -31,8 +31,8 @@ export function getComponentList (
     { name: 'Annotations', sources: [coreComponentConfigPath, '/components/annotations'], dataType: null, angularProvide: 'VisGenericComponent', elementSuffix: 'annotations' },
 
     // Standalone components
-    { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', isStandAlone: true, angularProvide: 'VisCoreComponent', svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
-    { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', isStandAlone: true, svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
+    { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', isStandAlone: true, angularProvide: 'VisCoreComponent', angularStyles: ['width: 100%', 'height: 100%', 'position: relative'], svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
+    { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', isStandAlone: true, angularProvide: 'VisCoreComponent', angularStyles: ['width: 100%', 'height: 100%', 'position: relative'], svelteStyles: ['display:block', 'position:relative'], vueStyles: ['display:block', 'position:relative'] },
     { name: 'BulletLegend', sources: ['/components/bullet-legend'], dataType: null, angularProvide: 'VisGenericComponent', isStandAlone: true, svelteStyles: ['display:block'], vueStyles: ['display:block'] },
   ]
 }

--- a/packages/shared/integrations/types.ts
+++ b/packages/shared/integrations/types.ts
@@ -27,6 +27,7 @@ export type ReactComponentInput = ComponentInput
 
 export type AngularComponentInput = ComponentInput & {
   angularProvide: string;
+  angularStyles?: string[];
 }
 
 export type SvelteComponentInput = ComponentInput & {

--- a/packages/shared/integrations/types.ts
+++ b/packages/shared/integrations/types.ts
@@ -18,8 +18,9 @@ export type ComponentInput = {
   name: string;
   sources: string[];
   kebabCaseName?: string;
-  dataType?: string;
+  dataType?: string | null;
   elementSuffix?: string;
+  isStandAlone?: boolean;
 }
 
 export type ReactComponentInput = ComponentInput

--- a/packages/svelte/autogen/index.ts
+++ b/packages/svelte/autogen/index.ts
@@ -13,23 +13,15 @@ import { getImportStatements, kebabCase, getConfigSummary } from '@unovis/shared
 // Component Code
 import { getComponentCode } from './component'
 
-
-const coreComponentConfigPath = '/core/component'
-const htmlElements = ['BulletLegend', 'LeafletMap', 'LeafletFlowMap']
 const skipProperties = ['width', 'height']
-const components = [
-  ...getComponentList(),
-  { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', svelteStyles: ['display:block', 'position:relative'] },
-  { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', svelteStyles: ['display:block', 'position:relative'] },
-  { name: 'BulletLegend', sources: ['/components/bullet-legend'], dataType: null, svelteStyles: ['display:block'] },
-] as SvelteComponentInput[]
+const components = getComponentList() as SvelteComponentInput[]
 
 const exports: string[] = []
 
 for (const component of components) {
   const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties)
   const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics)
-  const isStandAlone = htmlElements.includes(component.name)
+  const isStandAlone = component.isStandAlone
   const componentCode = getComponentCode(
     component.name,
     generics,

--- a/packages/vue/autogen/index.ts
+++ b/packages/vue/autogen/index.ts
@@ -13,23 +13,15 @@ import { getImportStatements, kebabCase, getConfigSummary } from '@unovis/shared
 // Component Code
 import { getComponentCode } from './component'
 
-const coreComponentConfigPath = '/core/component'
-const htmlElements = ['BulletLegend', 'LeafletMap', 'LeafletFlowMap']
 const skipProperties = ['width', 'height']
-const components = [
-  ...getComponentList(),
-  { name: 'LeafletMap', sources: [coreComponentConfigPath, '/components/leaflet-map'], dataType: 'Datum[]', vueStyles: ['display:block', 'position:relative'] },
-  // eslint-disable-next-line max-len
-  { name: 'LeafletFlowMap', sources: [coreComponentConfigPath, '/components/leaflet-map', '/components/leaflet-flow-map'], dataType: '{ points: PointDatum[]; flows?: FlowDatum[] }', vueStyles: ['display:block', 'position:relative'] },
-  { name: 'BulletLegend', sources: ['/components/bullet-legend'], dataType: null, vueStyles: ['display:block'] },
-] as VueComponentInput[]
+const components = getComponentList() as VueComponentInput[]
 
 const exports: string[] = []
 
 for (const component of components) {
   const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties)
   const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics)
-  const isStandAlone = htmlElements.includes(component.name)
+  const isStandAlone = component.isStandAlone
   const componentCode = getComponentCode(
     component.name,
     generics,


### PR DESCRIPTION
This PR updates component autogeneration logic so that all Unovis components (not containers) can be automatically generated when running `npm run generate`. Previously, our standalone components BulletLegend, LeafletMap and LeafletFlowMap had to be updated manually in the React and Angular wrappers.

In addition to autogen, another motivation for this change is to ensure our list in `shared/integrations/components` is complete. This allows the list be used for multiple purposes across the codebase (docs, commitlint, etc).

closes: unovis/issues-only#41