### PR TITLE
Component | Brush: Additional styling options via CSS variables

### DIFF
--- a/packages/dev/src/examples/xy-components/brush/basic-brush/index.tsx
+++ b/packages/dev/src/examples/xy-components/brush/basic-brush/index.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { D3BrushEvent } from 'd3-brush'
+import { VisXYContainer, VisArea, VisAxis, VisBrush } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+
+// Style
+import s from './style.module.css'
+
+export const title = 'Custom Style Brush'
+export const subTitle = 'Programmatically set selection range'
+export const component = (): JSX.Element => {
+  const [selectedRange, setSelectedRange] = useState<[number, number] | undefined>(undefined)
+
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  const data = useMemo(() => generateXYDataRecords(25), [])
+  useEffect(() => {
+    setTimeout(() => {
+      setSelectedRange([data[0].x, data[10].x])
+    }, 1000)
+  }, [])
+
+  const onBrushMove = (
+    range: [number, number] | undefined,
+    e: D3BrushEvent<XYDataRecord>,
+    userDriven: boolean
+  ): void => {
+    if (userDriven) setSelectedRange(range)
+  }
+  return (
+    <VisXYContainer<XYDataRecord> className={s.brush} data={data} height={125} duration={0}>
+      <VisArea x={d => d.x} y={accessors} />
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number | Date) => `${x}ms`}/>
+      <VisBrush onBrushMove={onBrushMove} draggable={true} selection={selectedRange}/>
+    </VisXYContainer>
+  )
+}

--- a/packages/dev/src/examples/xy-components/brush/basic-brush/style.module.css
+++ b/packages/dev/src/examples/xy-components/brush/basic-brush/style.module.css
@@ -1,0 +1,10 @@
+.brush {
+  --vis-brush-selection-fill-color: #0b1640;
+  --vis-brush-selection-stroke-color: none;
+  --vis-brush-selection-stroke-width: 0;
+  --vis-brush-selection-opacity: 0.4;
+  --vis-brush-unselected-fill-color: #fff;
+  --vis-brush-unselected-stroke-color: #acb2b9;
+  --vis-brush-unselected-stroke-width: 0;
+  --vis-brush-unselected-opacity: 0.8;
+}

--- a/packages/ts/src/components/brush/style.ts
+++ b/packages/ts/src/components/brush/style.ts
@@ -1,44 +1,50 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css } from '@emotion/css'
+import { getCssVarNames, injectGlobalCssVariables } from 'utils/style'
 
 export const root = css`
   label: brush-component;
 `
 
-export const variables = injectGlobal`
-  :root {
-    --vis-brush-selection-fill-color: #0b1640;
-    --vis-brush-selection-stroke-color: #acb2b9;
-    --vis-brush-handle-fill-color: #6d778c;
-    --vis-brush-handle-stroke-color: #eee;
+export const cssVarDefaults = {
+  '--vis-brush-selection-fill-color': 'none',
+  '--vis-brush-selection-stroke-color': 'none',
+  '--vis-brush-selection-stroke-width': '0',
+  '--vis-brush-selection-opacity': '0',
+  '--vis-brush-unselected-fill-color': '#0b1640',
+  '--vis-brush-unselected-stroke-color': '#acb2b9',
+  '--vis-brush-unselected-stroke-width': '0',
+  '--vis-brush-unselected-opacity': '0.4',
+  '--vis-brush-handle-fill-color': '#6d778c',
+  '--vis-brush-handle-stroke-color': '#eee',
 
-    --vis-dark-brush-selection-fill-color:#acb2b9;
-    --vis-dark-brush-selection-stroke-color: #0b1640;
-    --vis-dark-brush-handle-fill-color: #acb2b9;
-    --vis-dark-brush-handle-stroke-color: var(--vis-color-grey);
-  }
+  /* Dark Theme */
+  '--vis-dark-brush-selection-fill-color': 'none',
+  '--vis-dark-brush-selection-stroke-color': 'none',
+  '--vis-dark-brush-selection-stroke-width': '0',
+  '--vis-dark-brush-selection-opacity': '0',
+  '--vis-dark-brush-unselected-fill-color': '#acb2b9',
+  '--vis-dark-brush-unselected-stroke-color': '#0b1640',
+  '--vis-dark-brush-unselected-stroke-width': '0',
+  '--vis-dark-brush-unselected-opacity': '0.4',
+  '--vis-dark-brush-handle-fill-color': '#acb2b9',
+  '--vis-dark-brush-handle-stroke-color': 'var(--vis-color-grey)',
+}
 
-  body.theme-dark ${`.${root}`} {
-    --vis-brush-selection-fill-color: var(--vis-dark-brush-selection-fill-color);
-    --vis-brush-selection-stroke-color: var(--vis-dark-brush-selection-stroke-color);
-    --vis-brush-handle-fill-color: var(--vis-dark-brush-handle-fill-color);
-    --vis-brush-handle-stroke-color: var(--vis-dark-brush-handle-stroke-color);
-  }
-`
+export const variables = getCssVarNames(cssVarDefaults)
+injectGlobalCssVariables(cssVarDefaults, root)
 
 export const brush = css`
   label: brush;
-  fill: none;
-  stroke: none;
 
   .selection {
-    fill: none;
-    stroke: var(--vis-brush-selection-stroke-color);
-    stroke-width: 0;
-    stroke-opacity: 0;
+    fill: var(${variables.brushSelectionFillColor});
+    stroke: var(${variables.brushSelectionStrokeColor});
+    stroke-width: var(${variables.brushSelectionStrokeWidth});
+    opacity: var(${variables.brushSelectionOpacity});
   }
 
   .handle {
-    fill: var(--vis-brush-handle-fill-color);
+    fill: var(${variables.brushHandleFillColor});
   }
 
   &.non-draggable {
@@ -50,14 +56,17 @@ export const brush = css`
 
 export const unselected = css`
   label: unselected;
-  fill: var(--vis-brush-selection-fill-color);
-  opacity: 0.4;
+  fill: var(${variables.brushUnselectedFillColor});
+  stroke: var(${variables.brushUnselectedStrokeColor});
+  stroke-width: var(${variables.brushUnselectedStrokeWidth});
+  stroke-opacity: var(${variables.brushUnselectedOpacity});
+  opacity: var(${variables.brushUnselectedOpacity});
   pointer-events: none;
 `
 
 export const handleLine = css`
   label: handle-line;
-  stroke: var(--vis-brush-handle-stroke-color);
+  stroke: var(${variables.brushHandleStrokeColor});
   stroke-width: 1;
   fill: none;
   pointer-events: none;

--- a/packages/website/docs/auxiliary/Brush.mdx
+++ b/packages/website/docs/auxiliary/Brush.mdx
@@ -3,6 +3,7 @@ import BrowserOnly from '@docusaurus/BrowserOnly'
 import { PropsTable } from '@site/src/components/PropsTable'
 import { generateDataRecords } from '../utils/data'
 import { XYWrapper, XYWrapperWithInput, axis } from '../wrappers/xy-wrapper'
+import { Brush } from '@unovis/ts'
 
 export const defaultProps = (showAxis = true) => ({
     name: "Brush",
@@ -16,7 +17,7 @@ export const defaultProps = (showAxis = true) => ({
         key: "components",
       },
     ].concat(showAxis ? axis('x') : []),
-    data: generateDataRecords()
+    data: generateDataRecords(30)
 })
 
 ## Basic Configuration
@@ -81,22 +82,36 @@ By default, setting the desired the range relies on moving both start and end _B
 
 ### Handle Width
 `handleWidth` sets the width in pixels of the _Brush_'s handle:
-<XYWrapperWithInput {...defaultProps()} property="handleWidth" inputType="range" defaultValue={10}/>
+<XYWrapperWithInput {...defaultProps()} property="handleWidth" inputType="range" defaultValue={20}/>
+
+### Selection
+You can change the appearance of the selection by changing the corresponding CSS variables.
+For example, here's how you can modify the appearance of the selected and unselected areas:
+
+<CodeBlock language="css">
+{`--vis-brush-selection-fill-color: #0b1640;
+--vis-brush-selection-opacity: 0.6;
+--vis-brush-unselected-fill-color: #fff;
+--vis-brush-unselected-opacity: 0.9;
+`}</CodeBlock>
+
+<div style={{
+  '--vis-brush-selection-fill-color': '#0b1640',
+  '--vis-brush-selection-opacity': '0.6',
+  '--vis-brush-unselected-fill-color': '#fff',
+  '--vis-brush-unselected-opacity': '0.9',
+  }}>
+  <XYWrapper {...defaultProps()} selection={[2,5]}/>
+</div>
+
 
 ## CSS Variables
 <details open>
   <summary>Supported CSS variables and their default values</summary>
   <CodeBlock language="css">
-{`--vis-brush-selection-fill-color: #0b1640;
---vis-brush-selection-stroke-color: #acb2b9;
---vis-brush-handle-fill-color: #6d778c;
---vis-brush-handle-stroke-color: #eee;
- 
-/* Dark Theme */
---vis-dark-brush-selection-fill-color:#acb2b9;
---vis-dark-brush-selection-stroke-color: #0b1640;
---vis-dark-brush-handle-fill-color: #acb2b9;
---vis-dark-brush-handle-stroke-color: var(--vis-color-grey);
+{`${
+  Object.entries(Brush.selectors.cssVarDefaults)
+  .map(([key, value]) => `${key}: ${value};`).join('\n')}
 `}</CodeBlock>
 </details>
 


### PR DESCRIPTION
### What's new:
- I've added new CSS variables and changed the way we define them
- New dev example
- Updated the docs using newly exported `cssVarDefaults`. This way we can automatically fill the content of the CSS Variables section in the docs.

<img width="1066" alt="image" src="https://github.com/f5/unovis/assets/755708/8ba04d7a-d4e1-45d4-83e3-33b8262208f9">

<img width="1068" alt="image" src="https://github.com/f5/unovis/assets/755708/762135a9-3d82-4fbc-bf12-bed83ccc9f62">

<img width="1440" alt="image" src="https://github.com/f5/unovis/assets/755708/275d44e9-3ef5-4eb6-99a0-c174910a8284">
