### PR TITLE
Component | Axis: Add tick label rotation

### DIFF
--- a/packages/dev/src/examples/xy-components/axis/axis-rotation/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-rotation/index.tsx
@@ -1,0 +1,73 @@
+import React, { useRef } from 'react'
+import { VisXYContainer, VisAxis, VisLine, VisGroupedBar } from '@unovis/react'
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { Scale } from '@unovis/ts'
+
+export const title = 'Axis with Ticks Rotation'
+export const subTitle = 'Generated Data'
+
+export const component = (): JSX.Element => {
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+    () => Math.random(),
+    () => Math.random(),
+  ]
+  return (
+    <>
+      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}
+        xScale={Scale.scaleTime()}
+        margin={{ top: 5, left: 5, bottom: 40, right: 5 }}>
+        <VisLine x={d => d.x} y={accessors}/>
+        <VisAxis type='x'
+          numTicks={15}
+          tickFormat={(x: number) => `${Intl.DateTimeFormat().format(x)}`}
+          tickTextAngle={60}
+          tickTextAlign={'left'}
+        />
+        <VisAxis type='y'
+          tickFormat={(y: number) => `${y * 10000}`}
+          tickTextAngle={40}
+          position={'right'}
+        />
+      </VisXYContainer>
+
+      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}
+        xScale={Scale.scaleTime()}
+        margin={{ top: 35, left: 65, bottom: 5, right: 5 }}>
+        <VisLine x={d => d.x} y={accessors}/>
+        <VisAxis type='x'
+          numTicks={15}
+          tickFormat={(x: number) => `${x}`}
+          tickTextAngle={30}
+          tickTextFitMode='trim'
+          tickTextAlign={'right'}
+          position='top'
+        />
+        <VisAxis type='y'
+          tickFormat={(y: number) => `${y}`}
+          tickTextAngle={40}
+          position={'right'}
+        />
+      </VisXYContainer>
+
+      <VisXYContainer<XYDataRecord> ariaLabel='A simple example of a Grouped Bar chart' data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }} xDomain={[1, 10]}>
+        <VisGroupedBar x={d => d.x} y={accessors} />
+        <VisAxis
+          type='x'
+          tickFormat= { d => new Date(d).toDateString()}
+          tickTextAngle={-30}
+          tickTextWidth={20}
+          tickTextFitMode='wrap'
+          tickTextAlign={'right'}
+        />
+        <VisAxis
+          type='y'
+          tickFormat={(y: number) => `${y * 100000000}`}
+          tickTextAngle={-60}
+        />
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
+++ b/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react'
 import { VisXYContainer, VisAxis, VisTooltip, VisCrosshair, VisBulletLegend, VisLine } from '@unovis/react'
 import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
-import { Scale } from '@unovis/ts'
 
 export const title = 'Multi Line Chart'
 export const subTitle = 'Generated Data'
@@ -17,26 +16,10 @@ export const component = (): JSX.Element => {
   ]
   return (
     <>
-      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}
-        xScale={Scale.scaleTime()}
-        margin={{ top: 5, left: 5, bottom: 40, right: 5 }}>
+      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}>
         <VisLine x={d => d.x} y={accessors}/>
-        <VisAxis type='x'
-          numTicks={15}
-          tickFormat={(x: number) => `${Intl.DateTimeFormat().format(x)}`}
-          // tickTextAngle={60}
-          tickTextWidth={10}
-          tickTextFitMode='wrap'
-          // maxWidth={20}
-          // position={'bottom'}
-          tickTextAlign={'left'}
-        />
-        <VisAxis type='y'
-          tickFormat={(y: number) => `${y * 100000000}`}
-          // tickTextAngle={40}
-          tickTextFitMode={'wrap'}
-          // position={'right'}
-        />
+        <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} />
+        <VisAxis type='y' tickFormat={(y: number) => `${y}`} />
         <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
         <VisTooltip ref={tooltipRef} />
       </VisXYContainer>

--- a/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
+++ b/packages/dev/src/examples/xy-components/line/multi-line-chart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react'
 import { VisXYContainer, VisAxis, VisTooltip, VisCrosshair, VisBulletLegend, VisLine } from '@unovis/react'
 import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { Scale } from '@unovis/ts'
 
 export const title = 'Multi Line Chart'
 export const subTitle = 'Generated Data'
@@ -16,10 +17,26 @@ export const component = (): JSX.Element => {
   ]
   return (
     <>
-      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}>
+      <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)}
+        xScale={Scale.scaleTime()}
+        margin={{ top: 5, left: 5, bottom: 40, right: 5 }}>
         <VisLine x={d => d.x} y={accessors}/>
-        <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} />
-        <VisAxis type='y' tickFormat={(y: number) => `${y}`} />
+        <VisAxis type='x'
+          numTicks={15}
+          tickFormat={(x: number) => `${Intl.DateTimeFormat().format(x)}`}
+          // tickTextAngle={60}
+          tickTextWidth={10}
+          tickTextFitMode='wrap'
+          // maxWidth={20}
+          // position={'bottom'}
+          tickTextAlign={'left'}
+        />
+        <VisAxis type='y'
+          tickFormat={(y: number) => `${y * 100000000}`}
+          // tickTextAngle={40}
+          tickTextFitMode={'wrap'}
+          // position={'right'}
+        />
         <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
         <VisTooltip ref={tooltipRef} />
       </VisXYContainer>

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -51,6 +51,8 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickTextAlign?: TextAlign | string;
   /** Font color of the tick text as CSS string. Default: `null` */
   tickTextColor?: string | null;
+  /** Text rotation angle for ticks. Default: `undefined` */
+  tickTextAngle?: number;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   tickPadding?: number;
 }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -232,6 +232,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         const textOptions: UnovisTextOptions = {
           verticalAlign: config.type === AxisType.X ? VerticalAlign.Top : VerticalAlign.Middle,
           width: textMaxWidth,
+          fitMode: config.tickTextFitMode,
           separator: config.tickTextSeparator,
           wordBreak: config.tickTextForceWordBreak,
         }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -24,7 +24,6 @@ import { AxisDefaultConfig, AxisConfigInterface } from './config'
 
 // Styles
 import * as s from './style'
-import { tick } from '../../../lib/components/axis/style'
 
 export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datum>> {
   static selectors = s
@@ -217,7 +216,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     tickText.nodes().forEach(node => interrupt(node))
 
     tickText.each((value: number | Date, i: number, elements: ArrayLike<SVGTextElement>) => {
-      const text = config.tickFormat?.(value, i, tickValues) ?? `${value}`
+      let text = config.tickFormat?.(value, i, tickValues) ?? `${value}`
       const textElement = elements[i] as SVGTextElement
       const textMaxWidth = config.tickTextWidth || (config.type === AxisType.X ? this._containerWidth / (ticks.size() + 1) : this._containerWidth / 5)
       const styleDeclaration = getComputedStyle(textElement)
@@ -234,14 +233,11 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       if (config.tickTextFitMode === FitMode.Trim) {
         const textElementSelection = select<SVGTextElement, string>(textElement).text(text)
         trimSVGText(textElementSelection, textMaxWidth, config.tickTextTrimType as TrimMode, true, fontSize, 0.58)
-
-        const trimedText = select<SVGTextElement, string>(textElement).text() ?? ''
-        const textBlock: UnovisText = { trimedText, fontFamily, fontSize }
-        renderTextToSvgTextElement(textElement, textBlock, textOptions, true)
-      } else {
-        const textBlock: UnovisText = { text, fontFamily, fontSize }
-        renderTextToSvgTextElement(textElement, textBlock, textOptions)
+        text = select<SVGTextElement, string>(textElement).text()
       }
+
+      const textBlock: UnovisText = { text, fontFamily, fontSize }
+      renderTextToSvgTextElement(textElement, textBlock, textOptions)
     })
 
     selection
@@ -316,7 +312,6 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
     const marginX = type === AxisType.X ? 0 : (-1) ** (+(axisPosition === Position.Left)) * labelMargin
     const marginY = type === AxisType.X ? (-1) ** (+(axisPosition === Position.Top)) * labelMargin : 0
-
     // Append new label
     selection
       .append('text')
@@ -343,47 +338,18 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         }
     }
   }
-  // const textElementX = options.x ?? +textElement.getAttribute('x')
-  // const textElementY = options.y ?? +textElement.getAttribute('y')
-  // const x = textElementX ?? 0
-  // let y = textElementY ?? 0
-
-  // if (options.textAlign) {
-  //   textElement.setAttribute('text-anchor', getTextAnchorFromTextAlign(options.textAlign))
-  // }
-
-  // if (options.verticalAlign && options.verticalAlign !== VerticalAlign.Top) {
-  //   const height = estimateWrappedTextHeight(wrappedText)
-  //   const dy = options.verticalAlign === VerticalAlign.Middle ? -height / 2
-  //     : options.verticalAlign === VerticalAlign.Bottom ? -height : 0
-
-  //   y += dy
-  // }
-  // if (options.textRotationAngle) {
-  //   textElement.setAttribute('transform', `rotate(${(options.textRotationAngle === 0 || options.textRotationAngle) ? options.textRotationAngle : 0} ${x} ${y})`)
-  // } else {
-  //   textElement.removeAttribute('transform')
-  // }
 
   _alignTickLabels (): void {
     const { config: { type, tickTextAlign, tickTextAngle, position } } = this
     const tickText = this.g.selectAll('g.tick > text')
+
     const textAnchor = this._getTickTextAnchor(tickTextAlign as TextAlign)
     const translateX = type === AxisType.X
       ? 0
       : this._getYTickTextTranslate(tickTextAlign as TextAlign, position as Position)
 
-    tickText.each((value: number | Date, i: number, elements: ArrayLike<SVGTextElement>) => {
-      const textElement = elements[i] as SVGTextElement
-      const rotate = textElement.getAttribute('transform')
-      textElement
-        // .setAttribute('text-anchor', textAnchor)
-        .setAttribute('transform', `translate(${translateX},0) ${rotate}`)
-      // console.log(textElement.getAttribute("transform"), translateX)
-    })
-
-    // console.log(tickText[0].getAttribute('x'))
     tickText
+      .attr('transform', `translate(${translateX},0) rotate(${tickTextAngle})`)
       .attr('text-anchor', textAnchor)
   }
 

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -13,6 +13,7 @@ export enum VerticalAlign {
 export enum FitMode {
   Wrap = 'wrap',
   Trim = 'trim',
+  Rotate = 'rotate',
 }
 
 export enum TextAlign {
@@ -45,6 +46,8 @@ export type UnovisText = {
 export type UnovisWrappedText = UnovisText & {
   // An array of text lines, where each element represents a single line of text.
   _lines: string[];
+  // Maximum width of any line of text in this text block
+  _maxWidth: number;
   // Estimated height of this text block
   _estimatedHeight: number;
 }
@@ -62,6 +65,8 @@ export type UnovisTextOptions = {
   verticalAlign?: VerticalAlign | string;
   // The horizontal text alignment ('left', 'center', or 'right').
   textAlign?: TextAlign | string;
+  // The strategy for containing text within the available width.
+  fitMode?: FitMode | string;
   // Whether to use a fast estimation method or a more accurate one for text calculations.
   fastMode?: boolean;
   // Force word break if they don't fit into the width

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -13,7 +13,6 @@ export enum VerticalAlign {
 export enum FitMode {
   Wrap = 'wrap',
   Trim = 'trim',
-  Rotate = 'rotate',
 }
 
 export enum TextAlign {
@@ -65,8 +64,7 @@ export type UnovisTextOptions = {
   verticalAlign?: VerticalAlign | string;
   // The horizontal text alignment ('left', 'center', or 'right').
   textAlign?: TextAlign | string;
-  // The strategy for containing text within the available width.
-  fitMode?: FitMode | string;
+  textRotationAngle?: number;
   // Whether to use a fast estimation method or a more accurate one for text calculations.
   fastMode?: boolean;
   // Force word break if they don't fit into the width

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -64,6 +64,7 @@ export type UnovisTextOptions = {
   verticalAlign?: VerticalAlign | string;
   // The horizontal text alignment ('left', 'center', or 'right').
   textAlign?: TextAlign | string;
+  // Text rotation
   textRotationAngle?: number;
   // Whether to use a fast estimation method or a more accurate one for text calculations.
   fastMode?: boolean;

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -3,7 +3,7 @@ import { sum } from 'd3-array'
 import striptags from 'striptags'
 
 // Types
-import { TextAlign, TrimMode, UnovisText, UnovisTextFrameOptions, UnovisTextOptions, UnovisWrappedText, VerticalAlign } from 'types/text'
+import { FitMode, TextAlign, TrimMode, UnovisText, UnovisTextFrameOptions, UnovisTextOptions, UnovisWrappedText, VerticalAlign } from 'types/text'
 
 // Utils
 import { flatten, isArray, merge } from 'utils/data'
@@ -382,10 +382,18 @@ export function getWrappedText (
 
     h += effectiveMarginPx
     const dh = text.fontSize * text.lineHeight
+    let maxWidth = 0
     // Iterate over lines and handle text overflow based on the height limit if provided
     for (let k = 0; k < lines.length; k += 1) {
       let line = lines[k]
       h += dh
+
+      const lineWithEllipsis = `${line} …`
+      const textLengthPx = fastMode
+        ? estimateStringPixelLength(lineWithEllipsis, text.fontSize, text.fontWidthToHeightRatio)
+        : getPreciseStringLengthPx(lineWithEllipsis, text.fontFamily, text.fontSize)
+
+      maxWidth = Math.max(textLengthPx, maxWidth)
 
       if (height && (h + dh) > height && (k !== lines.length - 1)) {
         // Remove hyphen character from the end of the line if it's there
@@ -393,11 +401,6 @@ export function getWrappedText (
         if (lastCharacter === UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT) {
           line = line.substr(0, lines[k].length - 1)
         }
-
-        const lineWithEllipsis = `${line} …`
-        const textLengthPx = fastMode
-          ? estimateStringPixelLength(lineWithEllipsis, text.fontSize, text.fontWidthToHeightRatio)
-          : getPreciseStringLengthPx(lineWithEllipsis, text.fontFamily, text.fontSize)
 
         if (textLengthPx < width) {
           lines[k] = lineWithEllipsis
@@ -411,7 +414,7 @@ export function getWrappedText (
     }
 
     // Create wrapped text block with its calculated properties
-    blocks.push({ ...text, _lines: lines, _estimatedHeight: h - (prevBlock?._estimatedHeight || 0) })
+    blocks.push({ ...text, _lines: lines, _estimatedHeight: h - (prevBlock?._estimatedHeight ?? 0), _maxWidth: Math.max(maxWidth, prevBlock?._maxWidth ?? 0) })
   })
 
   return blocks
@@ -483,18 +486,33 @@ export function renderTextToSvgTextElement (
   text: UnovisText | UnovisText[],
   options: UnovisTextOptions
 ): void {
-  const wrappedText = getWrappedText(text, options.width, undefined, options.fastMode, options.separator, options.wordBreak)
+  const isVertical = options.verticalAlign !== VerticalAlign.Top
+  const width = options.fitMode !== FitMode.Rotate ? options.width : undefined
+  const wrappedText = getWrappedText(text, width, undefined, options.fastMode, options.separator, options.wordBreak)
+  const height = estimateWrappedTextHeight(wrappedText)
   const textElementX = options.x ?? +textElement.getAttribute('x')
   const textElementY = options.y ?? +textElement.getAttribute('y')
   const x = textElementX ?? 0
   let y = textElementY ?? 0
-  if (options.textAlign) textElement.setAttribute('text-anchor', getTextAnchorFromTextAlign(options.textAlign))
-  if (options.verticalAlign && options.verticalAlign !== VerticalAlign.Top) {
-    const height = estimateWrappedTextHeight(wrappedText)
+
+  if (options.textAlign) {
+    textElement.setAttribute('text-anchor', getTextAnchorFromTextAlign(options.textAlign))
+  }
+
+  if (isVertical) {
     const dy = options.verticalAlign === VerticalAlign.Middle ? -height / 2
       : options.verticalAlign === VerticalAlign.Bottom ? -height : 0
-
     y += dy
+  }
+
+  if (options.fitMode === FitMode.Rotate) {
+    const offset = isVertical ? 0 : height
+    y += isVertical ? 0
+      : (Math.max(...wrappedText.map((b) => b._maxWidth)) - y) / 3
+
+    textElement.setAttribute('transform', `rotate(${isVertical ? 30 : -60} ${x} ${y + offset}) translate(0,${y / 3})`)
+  } else {
+    textElement.removeAttribute('transform')
   }
 
   const parser = new DOMParser()

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -124,6 +124,18 @@ Change the tick's label alignment with respect to the tick marker using `tickTex
   options={['right', 'center', 'left']}
   property="tickTextAlign"/>
 
+### Label Rotation
+Change the tick's label angle using `tickTextAngle` property with a number value. Use this variable along with `tickTextAlign` to make sure the tick label displays as desired.
+<XYWrapperWithInput
+  {...defaultProps()}
+  tickTextAlign="left"
+  inputType="select"
+  data={generateTimeSeries(10)}
+  hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString()}}
+  defaultValue={15}
+  options={[15, 30, 45]}
+  property="tickTextAngle"/>
+
 ### Label Width
 To limit the width of the tick labels (in pixels), you can use the `tickTextWidth` property.
 <XYWrapperWithInput
@@ -136,14 +148,14 @@ To limit the width of the tick labels (in pixels), you can use the `tickTextWidt
 />
 
 ### Label Fit Mode
-_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap`, `FitMode.Trim` or `FitMode.Rotate`. This determines how the axis will
+_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap` or `FitMode.Trim`. This determines how the axis will
 handle tick text overflow. The following example showcases the previous example using `"trim"` instead of `"wrap"`.
 <XYWrapperWithInput inputType="select"
   {...defaultProps()}
   tickTextWidth={10}
   data={generateTimeSeries(10)}
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString(), tickTextTrimType:"end"}}
-  options={['trim', 'wrap', 'rotate']}
+  options={['trim', 'wrap']}
   property="tickTextFitMode"/>
 
 ### Label Trim Type

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -124,7 +124,6 @@ Change the tick's label alignment with respect to the tick marker using `tickTex
   options={['right', 'center', 'left']}
   property="tickTextAlign"/>
 
-
 ### Label Width
 To limit the width of the tick labels (in pixels), you can use the `tickTextWidth` property.
 <XYWrapperWithInput
@@ -137,14 +136,14 @@ To limit the width of the tick labels (in pixels), you can use the `tickTextWidt
 />
 
 ### Label Fit Mode
-_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap` or `FitMode.Trim`. This determines how the axis will
+_Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap`, `FitMode.Trim` or `FitMode.Rotate`. This determines how the axis will
 handle tick text overflow. The following example showcases the previous example using `"trim"` instead of `"wrap"`.
 <XYWrapperWithInput inputType="select"
   {...defaultProps()}
   tickTextWidth={10}
   data={generateTimeSeries(10)}
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString(), tickTextTrimType:"end"}}
-  options={['trim', 'wrap']}
+  options={['trim', 'wrap', 'rotate']}
   property="tickTextFitMode"/>
 
 ### Label Trim Type


### PR DESCRIPTION
Following this [PR](https://github.com/f5/unovis/pull/315). Moved `rotate` out of `FitMode`.

- [x] Adding a new variable called `tickTextAngle` to allow user to pass in a number for label rotation. This feature should be used along with `tickTextAlign` to get the desired result (we want to provide more control to the user). 
- [x] New dev example
- [x] Add related documentation  

![Screenshot 2024-05-28 at 2 31 05 PM](https://github.com/f5/unovis/assets/5026041/c2469fa0-6789-4aa9-9f8c-77503c45f188)
