### PR TITLE
Component | Graph: Multiple node selection

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-multinode-dragging/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-multinode-dragging/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { VisSingleContainer, VisGraph } from '@unovis/react'
+import { generateNodeLinkData } from '@src/utils/data'
+
+export const title = 'Graph Brushing'
+export const subTitle = ''
+const data = generateNodeLinkData(100)
+
+export const component = (): JSX.Element => {
+  return (
+    <>
+      <VisSingleContainer data={data} height={'100vh'}>
+        <VisGraph
+          nodeLabel={n => String(n.id)}
+          // disableZoom={true}
+          // onNodeSelectionBrush={console.log}
+          // onNodeSelectionDrag={console.log}
+        />
+      </VisSingleContainer>
+    </>
+  )
+}
+

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-selections/index.tsx
@@ -7,16 +7,20 @@ export const title = 'Graph: Node Selection'
 export const subTitle = 'Select Node on Click'
 
 export const component = (): JSX.Element => {
-  const data = useMemo(() => generateNodeLinkData(), [])
+  const data = useMemo(() => generateNodeLinkData(50), [])
   const ref = useRef<VisGraphRef<NodeDatum, LinkDatum>>(null)
-  const [selectedNode, setSelectedNode] = useState<string | undefined>()
+  const [selectedNodes, setSelectedNodes] = useState<string[] | undefined>()
   const [text, setText] = useState<string>()
 
+  const selectNode = useCallback((n: NodeDatum) => {
+    setSelectedNodes([...selectedNodes ?? [], n.id])
+  }, [selectedNodes])
+
   useEffect(() => {
-    const external = selectedNode ?? 'undefined'
-    const internal = ref.current?.component?.config.selectedNodeId ?? 'undefined'
-    setText([external, internal].join(' / '))
-  }, [selectedNode])
+    const external = selectedNodes ?? 'undefined'
+    const internal = ref.current?.component?.selectedNodes ?? 'undefined'
+    setText([external, internal].join(' | '))
+  }, [selectedNodes])
 
   return (
     <>
@@ -31,13 +35,14 @@ export const component = (): JSX.Element => {
           nodeIcon={useCallback((n: NodeDatum) => n.id, [])}
           events={useMemo(() => ({
             [Graph.selectors.node]: {
-              click: (n: NodeDatum) => { setSelectedNode(n.id) },
+              click: (n: NodeDatum) => { selectNode(n) },
             },
             [Graph.selectors.background]: {
-              click: () => { setSelectedNode(undefined) },
+              click: () => { setSelectedNodes(undefined) },
             },
-          }), [])}
-          selectedNodeId={selectedNode}
+          }), [selectedNodes])}
+          // selectedNodeId={'1'}
+          selectedNodeIds={selectedNodes}
         />
       </VisSingleContainer>
 

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -193,6 +193,8 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   nodeExitScale?: NumericAccessor<N> | undefined;
   /** Set selected node by unique id. Default: `undefined` */
   selectedNodeId?: number | string;
+  /** Set selected nodes by unique id. Default: `undefined` */
+  selectedNodeIds?: number[] | string[];
 
   /** Panels configuration. An array of `GraphPanelConfig` objects. Default: `[]` */
   panels?: GraphPanelConfig[] | undefined;
@@ -291,6 +293,7 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   nodeSort: undefined,
 
   selectedNodeId: undefined,
+  selectedNodeIds: undefined,
   panels: undefined,
 
   onNodeDragStart: undefined,

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -1,3 +1,4 @@
+import { D3BrushEvent } from 'd3-brush'
 import { D3DragEvent } from 'd3-drag'
 import { D3ZoomEvent } from 'd3-zoom'
 
@@ -24,6 +25,7 @@ import {
   GraphLink,
 } from './types'
 
+
 export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphInputLink> extends ComponentConfigInterface {
   // Zoom and drag
   /** Zoom level constraints. Default: [0.35, 1.25] */
@@ -32,6 +34,8 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   disableZoom?: boolean;
   /** Disable node dragging. Default: `false` */
   disableDrag?: boolean;
+  /** Disable brush for multiple node selection. Default: `false` */
+  disableBrush?: boolean;
   /** Interval to re-render the graph when zooming. Default: `100` */
   zoomThrottledUpdateNodeThreshold?: number;
 
@@ -210,6 +214,10 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   onZoom?: (zoomScale: number, zoomScaleExtent: [number, number], event: D3ZoomEvent<SVGGElement, unknown> | undefined) => void;
   /** Callback function to be called when the graph layout is calculated. Default: `undefined` */
   onLayoutCalculated?: (n: GraphNode<N, L>[], links: GraphLink<N, L>[]) => void;
+  /** Graph node selection brush callback function. Default: `undefined` */
+  onNodeSelectionBrush?: (selectedNodes: GraphNode<N, L>[], event: D3BrushEvent<SVGGElement> | undefined) => void;
+  /** Graph multiple node drag callback function. Default: `undefined` */
+  onNodeSelectionDrag?: (selectedNodes: GraphNode<N, L>[], event: D3DragEvent<SVGGElement, GraphNode<N, L>, unknown>) => void;
 }
 
 export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInputLink> = {
@@ -218,6 +226,7 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   zoomScaleExtent: [0.35, 1.25],
   disableZoom: false,
   disableDrag: false,
+  disableBrush: false,
   zoomThrottledUpdateNodeThreshold: 100,
   layoutType: GraphLayoutType.Force,
   layoutAutofit: true,
@@ -301,4 +310,6 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   onNodeDragEnd: undefined,
   onZoom: undefined,
   onLayoutCalculated: undefined,
+  onNodeSelectionBrush: undefined,
+  onNodeSelectionDrag: undefined,
 }

--- a/packages/ts/src/components/graph/modules/node/index.ts
+++ b/packages/ts/src/components/graph/modules/node/index.ts
@@ -104,11 +104,11 @@ export function updateSelectedNodes<N extends GraphInputNode, L extends GraphInp
     const group: Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> = select(elements[i])
     const isGreyout = getBoolean(d, nodeDisabled, d._index) || d._state.greyout
 
-    group.classed(nodeSelectors.greyedOutNode, isGreyout)
+    group.classed(nodeSelectors.greyedOutNode, isGreyout && !d._state.brushed)
       .classed(nodeSelectors.draggable, !config.disableDrag)
 
     const nodeSelectionOutline = group.selectAll<SVGGElement, GraphNode<N, L>>(`.${nodeSelectors.nodeSelection}`)
-    nodeSelectionOutline.classed(nodeSelectors.nodeSelectionActive, d._state.selected)
+    nodeSelectionOutline.classed(nodeSelectors.nodeSelectionActive, d._state.selected || d._state.brushed)
 
     group.selectAll<SVGTextElement, GraphCircleLabel>(`.${nodeSelectors.sideLabel}`)
       .style('fill', (l) => isGreyout ? null : getSideLabelTextColor(l, selection.node()))

--- a/packages/ts/src/components/graph/modules/node/style.ts
+++ b/packages/ts/src/components/graph/modules/node/style.ts
@@ -68,6 +68,11 @@ export const variables = injectGlobal`
     --vis-dark-graph-node-icon-greyout-color: var(--vis-color-grey);
     --vis-dark-graph-node-side-label-background-greyout-color: #494B56;
 
+    /* Brushed */
+    --vis-graph-brushed-node-stroke-color: var(--vis-color-main);
+    --vis-graph-brushed-node-label-text-color: var(--vis-color-main);
+    --vis-graph-brushed-node-icon-fill-color: var(--vis-color-main);
+    
     /* Misc */
     --vis-graph-node-dominant-baseline: middle;
   }
@@ -98,12 +103,20 @@ export const variables = injectGlobal`
   }
 `
 
+export const brushable = css`
+  label: brushable;
+`
+
+
 export const node = css`
   label: node-shape;
 
   stroke: var(--vis-graph-node-stroke-color);
   fill: var(--vis-graph-node-fill-color);
-  transition: .4s fill, .4s stroke;
+
+  :not(.${brushable}) {
+    transition: .4s fill, 4s stroke;
+  }
 `
 
 export const nodeIcon = css`
@@ -113,8 +126,11 @@ export const nodeIcon = css`
   dominant-baseline: var(--vis-graph-node-dominant-baseline);
   text-anchor: middle;
   pointer-events: none;
-  transition: .4s all;
   fill: var(--vis-graph-node-icon-fill-color);
+
+  :not(.${brushable}) {
+    transition: .4s all;
+  }
 `
 
 export const nodeBottomIcon = css`
@@ -124,10 +140,13 @@ export const nodeBottomIcon = css`
   dominant-baseline: var(--vis-graph-node-dominant-baseline);
   text-anchor: middle;
   pointer-events: none;
-  transition: .4s fill;
   fill: var(--vis-graph-node-bottom-icon-fill-color);
   stroke: var(--vis-graph-node-bottom-icon-stroke-color);
   stroke-width: var(--vis-graph-node-bottom-icon-stroke-width);
+
+  :not(.${brushable}) {
+    transition: .4s all;
+  }
 `
 
 export const nodeIsDragged = css`
@@ -298,5 +317,19 @@ export const greyedOutNode = css`
    ${`.${sideLabel}`} {
     fill: var(--vis-graph-node-side-label-fill-color-bright) !important;
     opacity: 0.25;
+  }
+`
+
+export const brushed = css`
+  label: brushed-node;
+
+  ${`.${node}`} {
+    stroke: var(--vis-graph-brushed-node-stroke-color);
+  }
+  ${`.${nodeIcon}`} {
+    fill: var(--vis-graph-brushed-node-icon-fill-color);
+  }
+  ${`.${labelTextContent}`} {
+    fill: var(--vis-graph-brushed-node-label-text-color);
   }
 `

--- a/packages/ts/src/components/graph/style.ts
+++ b/packages/ts/src/components/graph/style.ts
@@ -10,6 +10,9 @@ import * as linkSelectors from './modules/link/style'
 export const variables = injectGlobal`
   :root {
     --vis-graph-icon-font-family: ${UNOVIS_ICON_FONT_FAMILY_DEFAULT};
+
+    /* Brush */
+    --vis-graph-brush-selection-opacity: 0.2;
   }
 `
 
@@ -24,6 +27,25 @@ export const background = css`
 
 export const graphGroup = css`
   label: graph-group;
+`
+
+export const brush = css`
+  label: brush;
+
+  :not(.active) {
+    display: none;
+  }
+
+  .active {
+    .selection {
+      fill-opacity: 0;
+      stroke: none;
+    }
+
+    .handle {
+      display: none;
+    }
+  }
 `
 
 export const zoomOutLevel1 = css`

--- a/packages/ts/src/components/graph/types.ts
+++ b/packages/ts/src/components/graph/types.ts
@@ -18,6 +18,7 @@ export type GraphNode<
     fy?: number;
     selected?: boolean;
     greyout?: boolean;
+    brushed?: boolean;
   };
 
   _panels?: GraphPanel<N, L>[];

--- a/packages/ts/src/data-models/graph.ts
+++ b/packages/ts/src/data-models/graph.ts
@@ -22,11 +22,16 @@ export class GraphDataModel<
   private _nodes: OutNode[] = []
   private _links: OutLink[] = []
   private _inputNodesMap = new Map<OutNode, N>()
+  private _nodeIds = new Map<string | number, OutNode>()
 
   // Model configuration
   public nodeId: ((n: N) => string | undefined) = n => (isString(n.id) || isFinite(n.id as number)) ? `${n.id}` : undefined
   public linkId: ((n: L) => string | undefined) = l => (isString(l.id) || isFinite(l.id as number)) ? `${l.id}` : undefined
   public nodeSort: ((a: N, b: N) => number)
+
+  public getNodeFromId (id: string | number): OutNode {
+    return this._nodeIds.get(id)
+  }
 
   get data (): GraphData<N, L> {
     return this._data
@@ -39,6 +44,7 @@ export class GraphDataModel<
     const prevLinks = this.links
 
     this._inputNodesMap.clear()
+    this._nodeIds.clear()
     const nodes = cloneDeep(inputData?.nodes ?? []) as OutNode[]
     const links = cloneDeep(inputData?.links ?? []) as OutLink[]
 
@@ -52,6 +58,7 @@ export class GraphDataModel<
       node._index = i
       node._id = this.nodeId(node) || `${i}`
       this._inputNodesMap.set(node, inputData.nodes[i])
+      this._nodeIds.set(node._id, node)
     })
 
     // Sort nodes

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -700,6 +700,31 @@ If you use React or Angular, you can access the component instance for calling t
 onZoom: (zoomScale: number, zoomScaleExtent: number) => void;
 ```
 
+## Multiple Node Drag
+To drag multiple nodes at once, the node selection brush can be activated with the shift key.
+This behavior can be disabled by setting the `disableBrush` property to `true`.
+
+While the shift key is pressed, multiple nodes can be brushed by dragging the mouse over them.
+When the mouse releases, the selected nodes will be grouped inside a selection rectangle, which can be dragged around as a single entity.
+
+Releasing the shift key will unselect all nodes and hide the selection rectangle.
+
+The brush selection rectangle opacity can be changed with the `--vis-graph-brush-selection-opacity` CSS variable.
+The appearance of the "brushed" nodes can be customized with the following CSS variables:
+
+```css
+--vis-graph-brushed-node-stroke-color;
+--vis-graph-brushed-node-label-text-color;
+--vis-graph-brushed-node-icon-fill-color;
+```
+
+Additionally, there are two callback functions in Graph's configuration that can be used to see which nodes are being brushed and dragged.
+
+```ts
+onNodeSelectionBrush (selectedNodes: GraphNode[], event: D3BrushEvent) void;
+onNodeSelectionDrag (selectedNodes: GraphNode[], event: D3BrushEvent) void;
+```
+
 ## Events
 The following selectors are available for events:
 ```ts


### PR DESCRIPTION
This PR introduces brushing to the Graph component to allow users to select and drag multiple nodes at once.

### How it works:
Brushing mode is active when the shift key is pressed. This allows for panning, zooming and single-node dragging behavior to function independently and without interference from this new functionality. The crosshair cursor on hover indicates that the brush is able to use.

When making a selection, drag the brush over a region to group those nodes. The nodes within the selection range will be highlighted. Upon release of the mouse, the nodes within the selection can be dragged as a group.

If the shift key is released during any point, the selection resets and the brush is inactive until is it is enabled again.

Video example showcasing zooming, panning, single-node dragging and multi-node dragging in various sequences:

https://github.com/f5/unovis/assets/52078477/81016834-eec6-42a1-b889-327bce289675

### New Config Properties
- `disableBrush` - to disable this behavior
- `onNodeSelectionBrush(nodes: GraphNode<N,L>[], event: D3BrushEvent)` - callback when the brush area is being selected
- `onNodeSelectionDrag(nodes: GraphNode<N,L>[], event: D3DragEvent)` - callback for the dragging of the selection

### CSS Variables
```
--vis-graph-brushed-node-stroke-color;
--vis-graph-brushed-node-label-text-color;
--vis-graph-brushed-node-icon-fill-color;
```
Ideally we should be able to add more customization options here, I just wanted to keep it simple while we ensure the functionality is stable.

### Other Addition: `selectedNodeIds`
Although not directly related to this feature, being able to manually provide multiple `selectedNodeId` values has been requested, so I've added it. Note that `selectedNodeId` is still a valid config property but in the future we should probably deprecate it in favor of this one.