### PR TITLE
Component | Graph: Layout recalculation and persistency fix

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-dynamic-layout/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-dynamic-layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { VisSingleContainer, VisGraph } from '@unovis/react'
 import { GraphLayoutType } from '@unovis/ts'
 import { generateNodeLinkData } from '@src/utils/data'
@@ -7,10 +7,29 @@ export const title = 'Dynamic Layout'
 export const subTitle = 'Select Layout From Dropdown'
 
 export const component = (): JSX.Element => {
-  const data = useMemo(() => generateNodeLinkData(50, () => 1), [])
+  const [data, setData] = useState(generateNodeLinkData(50))
   const layouts = Object.values(GraphLayoutType)
   const initial = GraphLayoutType.Circular
   const [layout, setLayout] = useState<string>(initial)
+
+  // Generate new data every 2 seconds
+  useEffect(() => {
+    setTimeout(() => {
+      const newData = generateNodeLinkData(10 + Math.floor(Math.random() * 50))
+
+      // Adding some random x, y values to the nodes for `GraphLayoutType.Precalculated`
+      newData.nodes.forEach(n => {
+        n.x = Math.random() * 1000
+        n.y = Math.random() * 1000
+      })
+
+      setData(newData)
+    }, 2000)
+  }, [data])
+
+  const forceLayoutSettings = useMemo(() => ({
+    fixNodePositionAfterSimulation: true,
+  }), [])
 
   return (
     <>
@@ -18,7 +37,7 @@ export const component = (): JSX.Element => {
         {layouts.map(l => <option key={l} value={l}>{l}</option>)}
       </select>
       <VisSingleContainer data={data} height={900}>
-        <VisGraph layoutType={layout}/>
+        <VisGraph layoutType={layout} forceLayoutSettings={forceLayoutSettings}/>
       </VisSingleContainer>
     </>
   )

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-dynamic-layout/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-dynamic-layout/index.tsx
@@ -1,0 +1,26 @@
+import React, { useMemo, useState } from 'react'
+import { VisSingleContainer, VisGraph } from '@unovis/react'
+import { GraphLayoutType } from '@unovis/ts'
+import { generateNodeLinkData } from '@src/utils/data'
+
+export const title = 'Dynamic Layout'
+export const subTitle = 'Select Layout From Dropdown'
+
+export const component = (): JSX.Element => {
+  const data = useMemo(() => generateNodeLinkData(50, () => 1), [])
+  const layouts = Object.values(GraphLayoutType)
+  const initial = GraphLayoutType.Circular
+  const [layout, setLayout] = useState<string>(initial)
+
+  return (
+    <>
+      <select onChange={e => setLayout(e.target.value)} defaultValue={initial}>
+        {layouts.map(l => <option key={l} value={l}>{l}</option>)}
+      </select>
+      <VisSingleContainer data={data} height={900}>
+        <VisGraph layoutType={layout}/>
+      </VisSingleContainer>
+    </>
+  )
+}
+

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -85,6 +85,7 @@ export class Graph<
   private _prevWidth: number
   private _prevHeight: number
   private _shouldRecalculateLayout = false
+  private _currentLayoutType: GraphLayoutType | undefined
   private _layoutCalculationPromise: Promise<boolean> | undefined
 
   private _shouldFitLayout: boolean
@@ -350,11 +351,11 @@ export class Graph<
   }
 
   private async _calculateLayout (): Promise<boolean> {
-    const { prevConfig, config, datamodel } = this
+    const { config, datamodel } = this
     const firstRender = this._isFirstRender
 
     // If the layout type has changed, we need to reset the node positions if they were fixed before
-    if (prevConfig.layoutType !== config.layoutType) {
+    if (this._currentLayoutType !== config.layoutType) {
       for (const node of datamodel.nodes) {
         delete node._state.fx
         delete node._state.fy
@@ -394,6 +395,7 @@ export class Graph<
     this.config.onLayoutCalculated?.(datamodel.nodes, datamodel.links)
 
     this._shouldRecalculateLayout = false
+    this._currentLayoutType = config.layoutType as GraphLayoutType
 
     return firstRender
   }

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -14,7 +14,7 @@ import { GraphInputLink, GraphInputNode } from 'types/graph'
 import { Spacing } from 'types/spacing'
 
 // Utils
-import { isNumber, clamp, shallowDiff, isFunction, getBoolean } from 'utils/data'
+import { isNumber, clamp, shallowDiff, isFunction, getBoolean, isPlainObject } from 'utils/data'
 import { smartTransition } from 'utils/d3'
 
 // Local Types
@@ -349,9 +349,17 @@ export class Graph<
   }
 
   private async _calculateLayout (): Promise<boolean> {
-    const { config, datamodel } = this
-
+    const { prevConfig, config, datamodel } = this
     const firstRender = this._isFirstRender
+
+    // If the layout type has changed, we need to reset the node positions if they were fixed before
+    if (prevConfig.layoutType !== config.layoutType) {
+      for (const node of datamodel.nodes) {
+        delete node._state.fx
+        delete node._state.fy
+      }
+    }
+
     switch (config.layoutType) {
       case GraphLayoutType.Precalculated:
         break
@@ -727,6 +735,20 @@ export class Graph<
     if (prevConfig.layoutType === GraphLayoutType.Dagre) {
       const dagreSettingsDiff = shallowDiff(prevConfig.dagreLayoutSettings, config.dagreLayoutSettings)
       if (Object.keys(dagreSettingsDiff).length) return true
+    }
+
+    if (prevConfig.layoutType === GraphLayoutType.Elk) {
+      if (isPlainObject(prevConfig.layoutElkSettings) && isPlainObject(config.layoutElkSettings)) {
+        // Do a deeper comparison if `config.layoutElkSettings` is an object
+        const elkSettingsDiff = shallowDiff(
+          prevConfig.layoutElkSettings as Record<string, string>,
+          config.layoutElkSettings as Record<string, string>
+        )
+        return Boolean(Object.keys(elkSettingsDiff).length)
+      } else {
+        // Otherwise, do a simple `===` comparison
+        return prevConfig.layoutElkSettings !== config.layoutElkSettings
+      }
     }
 
     if (

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -160,6 +160,7 @@ export class Graph<
 
     this._shouldRecalculateLayout = this._shouldRecalculateLayout || this._shouldLayoutRecalculate()
     this._shouldFitLayout = this._shouldFitLayout || this._shouldRecalculateLayout
+    if (this._shouldFitLayout) this._isAutoFitDisabled = false
     this._shouldSetPanels = true
   }
 

--- a/packages/ts/src/components/graph/modules/layout.ts
+++ b/packages/ts/src/components/graph/modules/layout.ts
@@ -420,6 +420,11 @@ export async function applyLayoutForce<N extends GraphInputNode, L extends Graph
       d.fx = isNil(d._state.fx) ? undefined : d._state.fx
       d.fy = isNil(d._state.fy) ? undefined : d._state.fy
     })
+  } else {
+    nodes.forEach((d: GraphForceSimulationNode<N, L>) => {
+      delete d._state.fx
+      delete d._state.fy
+    })
   }
 
   const simulation = forceSimulation(layoutNonConnectedAside ? connectedNodes : nodes)


### PR DESCRIPTION
This PR fixes layout problems reported in #393:
- `fixNodePositionAfterSimulation` not working correctly in Force Layout
- Layout update when dynamically switching between different layouts