### PR TITLE
Containers: Don't re-append SVG defs if they didn't change

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-icons/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-icons/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { VisSingleContainer, VisGraph } from '@unovis/react'
-import { NodeDatum } from '@src/utils/data'
 
 import personIcon from './person.svg?raw'
 import roleIcon from './role.svg?raw'
@@ -10,7 +9,7 @@ import bucketIcon from './bucket.svg?raw'
 import s from './index.module.css'
 
 export const title = 'Graph: SVG Node Icons'
-export const subTitle = 'cured links, long labels'
+export const subTitle = 'Re-render every second'
 
 export const component = (): JSX.Element => {
   const svgDefs = `
@@ -37,18 +36,28 @@ export const component = (): JSX.Element => {
     { source: 1, target: 5, label: { text: '2' } },
   ]
 
-  const data = { nodes, links }
+  const [data, setData] = useState({ nodes, links })
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      // Re-render the component here to test the performance
+      setData({ nodes, links })
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [])
+
   return (
     <div className={s.graph}>
       <VisSingleContainer svgDefs={svgDefs} height={600}>
-        <VisGraph
+        <VisGraph<typeof nodes[number], typeof links[number]>
           data={data}
-          nodeIcon={(n: NodeDatum) => n.icon}
+          nodeIcon={(n) => n.icon}
           nodeIconSize={18}
           nodeStroke={'none'}
-          nodeFill={(n: NodeDatum) => n.fillColor}
-          nodeLabel={(n: NodeDatum) => n.label}
-          nodeSubLabel={(n: NodeDatum) => n.sublabel}
+          nodeFill={n => n.fillColor}
+          nodeLabel={n => n.label}
+          nodeSubLabel={n => n.sublabel}
           layoutType='dagre'
           dagreLayoutSettings={{
             rankdir: 'LR',

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -65,6 +65,7 @@ export class SingleContainer<Data> extends ContainerCore {
 
     // Defs
     this.element.appendChild(this._svgDefs.node())
+    this.element.appendChild(this._svgDefsExternal.node())
 
     if (!preventRender) this.render()
   }

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -178,6 +178,7 @@ export class XYContainer<Datum> extends ContainerCore {
 
     // Defs
     this.element.appendChild(this._svgDefs.node())
+    this.element.appendChild(this._svgDefsExternal.node())
 
     // Rendering
     if (!preventRender) this.render()

--- a/packages/ts/src/core/container/index.ts
+++ b/packages/ts/src/core/container/index.ts
@@ -22,6 +22,7 @@ export class ContainerCore {
   protected _isFirstRender = true
   protected _resizeObserver: ResizeObserver | undefined
   protected _svgDefs: Selection<SVGDefsElement, unknown, null, undefined>
+  protected _svgDefsExternal: Selection<SVGDefsElement, unknown, null, undefined>
   private _containerSize: { width: number; height: number }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -45,6 +46,7 @@ export class ContainerCore {
       .attr('aria-hidden', true)
 
     this._svgDefs = this.svg.append('defs')
+    this._svgDefsExternal = this.svg.append('defs')
     this.element = this.svg.node()
   }
 
@@ -61,12 +63,12 @@ export class ContainerCore {
 
   // The `_render` step should be used to perform the actual rendering
   protected _render (duration?: number): void {
-    const { config } = this
+    const { config, prevConfig } = this
 
     // Add `svgDefs` if provided in the config
-    if (config.svgDefs) {
-      this.svg.select('.svgDefs').remove()
-      this.svg.append('defs').attr('class', 'svgDefs').html(config.svgDefs)
+    if (config.svgDefs !== prevConfig.svgDefs) {
+      this._svgDefsExternal.selectAll('*').remove()
+      this._svgDefsExternal.html(config.svgDefs)
     }
 
     // Apply the `aria-label` attribute


### PR DESCRIPTION
Currently SVG defs are re-appended on each render and it causes flickering. This PR fixes it.

### Before (icons are flickering)

https://github.com/f5/unovis/assets/755708/e38b42c0-7b0d-40cc-9d7b-302a911d0ba2

### After (no flickering)

https://github.com/f5/unovis/assets/755708/7b309156-9aee-444d-bf2f-c7660d5f00a2

