### PR TITLE
Dev | Examples | Expandable Sankey: Fix type error in example data

### DIFF
--- a/packages/shared/examples/expandable-sankey/data.ts
+++ b/packages/shared/examples/expandable-sankey/data.ts
@@ -12,7 +12,7 @@ export type Node = {
 
 export type Link = { source: string; target: string; value: number }
 
-export type Sankey<N, L extends Link> = {
+export type Sankey<N extends Node, L extends Link> = {
   nodes: N[];
   links: L[];
   expand: (n: SankeyNode<N, L>) => void;


### PR DESCRIPTION
Small type fix in [Expandable Sankey](https://unovis.dev/gallery/view/?collection=Networks%20and%20Flows&title=Expandable%20Sankey) example data.

Before
<img width="935" alt="image" src="https://github.com/f5/unovis/assets/2565382/5cac21b1-d228-4c46-8eba-f5e9afb2ef5b">

After
<img width="749" alt="image" src="https://github.com/f5/unovis/assets/2565382/482e485d-da02-4a05-b6bf-6c9cb7c77588">
