### PR TITLE
Component | Scatter: Make`sizeScale` immutable to prevent `sizeRange` collisions

### DIFF
--- a/packages/dev/src/examples/xy-components/scatter/scatter-size-range/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-size-range/index.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from 'react'
+import { VisXYContainer, VisScatter, VisAxis } from '@unovis/react'
+import { generateXYDataRecords, XYDataRecord } from '@src/utils/data'
+
+export const title = 'Point Sizes'
+export const subTitle = 'Varied sizeRange comparison'
+
+const data = generateXYDataRecords(100)
+
+export const component = (): JSX.Element => {
+  const scatterProps = {
+    x: useCallback((d: XYDataRecord) => d.x, []),
+    y: useCallback((d: XYDataRecord) => d.y, []),
+    size: useCallback((d: XYDataRecord) => d.x, []),
+  }
+
+  const sizeRanges: ([number, number] | undefined)[] = [
+    [2, 10],
+    [4, 32],
+    [12, 50],
+  ]
+
+  return (
+    <>
+      {sizeRanges.map((s, i) => (
+        <VisXYContainer key={`s${i}`} data={data}>
+          <VisScatter {...scatterProps} sizeRange={s}/>
+          <VisAxis type='x'/>
+          <VisAxis type='y'/>
+        </VisXYContainer>
+      ))}
+    </>
+  )
+}


### PR DESCRIPTION
### Summary
This PR makes Scatter's `sizeScale` config property immutable so that if there is a shared instance to `config` or `config.sizeScale`, the `sizeRange` property does not get overridden. More explanation below as it is a bit of an edge case.

### Background
When trying to figure out why this [scatter gallery example](https://unovis.dev/gallery/view?collection=Auxiliary%20Components&title=Scatter%20Plot%20with%20Free%20Brush) looks wrong (i.e. the minimap's points are too large for `sizeRange: [3, 10]`), I discovered that the issue comes from using a shared config object between the two charts. Since `sizeScale` is undefined, when it is initialized with the default value in the first component, that becomes the same instance of `sizeScale` for both.

This means that despite both components specifying different values for `config.sizeRange`, when the hidden shared reference to `config.sizeScale` ends up being mutated in the `_updateSizeScale` function, it overrides any previous domain or range that was set. For this reason I think we should use a private instance instead of manipulating `config.sizeScale` directly.

### Expected behavior
Given the following two scatters with the same data:
```jsx
const props = { x: d => d.x, y: d => d.y, size: d => d.x }

{/* Scatter 1 */}
<VisScatter {...props} sizeRange={[2, 10]}/>

{/* Scatter 2 */}
<VisScatter {...props} sizeRange={[4, 32]}/>
```
We expect the first to have points ranging in radius from `2-10px` and the second in from `4-32px`.

### Before
![Screenshot 2024-07-01 at 1 33 56 PM](https://github.com/f5/unovis/assets/52078477/c920e48b-7d68-43ef-9ba9-e77c7e017f35)

### After
![Screenshot 2024-07-01 at 1 32 55 PM](https://github.com/f5/unovis/assets/52078477/82bc64ec-b57f-47ee-b2b7-892e4442afaa)

