### PR TITLE
Component | Scatter: Label rendering fixes

### DIFF
--- a/packages/dev/src/examples/xy-components/scatter/scatter-label-positions/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-label-positions/index.tsx
@@ -1,0 +1,39 @@
+import React, { useCallback } from 'react'
+import { VisXYContainer, VisScatter, VisAxis, VisLine } from '@unovis/react'
+
+import { XYDataRecord } from '@src/utils/data'
+
+export const title = 'Point Label Positions'
+export const subTitle = 'Toggle label content'
+
+export const component = (): JSX.Element => {
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y + 5,
+  ]
+
+  const data: XYDataRecord[] = [
+    { x: 0, y: 0 },
+    { x: 2, y: 1 },
+    { x: 3, y: 0.5 },
+  ]
+  const [showLabels, setShowLabels] = React.useState(false)
+  const toggleLabels = useCallback(() => setShowLabels(!showLabels), [showLabels])
+
+  return (
+    <>
+      <label>Labels: <input type='checkbox' onChange={toggleLabels}/></label>
+      <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }}>
+        <VisLine x={d => d.x} y={accessors} />
+        <VisScatter
+          x={d => d.x}
+          y={accessors}
+          label={showLabels ? (d) => `${d.y}` : undefined}
+          labelPosition='top'
+        />
+        <VisAxis type='x'/>
+        <VisAxis type='y'/>
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -204,7 +204,7 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
               strokeWidthPx: getNumber(d, config.strokeWidth, j),
               shape: getString(d, config.shape, j) as SymbolType,
               label: getString(d, config.label, j),
-              labelColor: getColor(d, config.labelColor, j),
+              labelColor: getColor(d, config.labelColor, j, true),
               cursor: getString(d, config.cursor, j),
               groupIndex: j,
               pointIndex: i,

--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -75,8 +75,8 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
     const fontSizePx = getCSSVariableValueInPixels('var(--vis-scatter-point-label-text-font-size)', this.element)
 
     const extent = pointDataFlat.reduce((ext, d) => {
-      const labelPosition = getValue(d, this.config.labelPosition, d._point.pointIndex)
-      const labelBBox = getEstimatedLabelBBox(d, labelPosition as Position, this.xScale, this.yScale, fontSizePx)
+      const labelPosition = d._point.labelPosition
+      const labelBBox = getEstimatedLabelBBox(d, labelPosition, this.xScale, this.yScale, fontSizePx)
       const x = this.xScale(d._point.xValue)
       const y = this.yScale(d._point.yValue)
       const r = d._point.sizePx / 2
@@ -205,6 +205,7 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
               shape: getString(d, config.shape, j) as SymbolType,
               label: getString(d, config.label, j),
               labelColor: getColor(d, config.labelColor, j, true),
+              labelPosition: getValue(d, this.config.labelPosition, i) as Position,
               cursor: getString(d, config.cursor, j),
               groupIndex: j,
               pointIndex: i,

--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -75,16 +75,22 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
     const fontSizePx = getCSSVariableValueInPixels('var(--vis-scatter-point-label-text-font-size)', this.element)
 
     const extent = pointDataFlat.reduce((ext, d) => {
-      const labelPosition = d._point.labelPosition
-      const labelBBox = getEstimatedLabelBBox(d, labelPosition, this.xScale, this.yScale, fontSizePx)
       const x = this.xScale(d._point.xValue)
       const y = this.yScale(d._point.yValue)
       const r = d._point.sizePx / 2
 
-      ext.minX = Math.min(ext.minX, x - r, labelBBox.x)
-      ext.maxX = Math.max(ext.maxX, x + r, labelBBox.x + labelBBox.width)
-      ext.minY = Math.min(ext.minY, y - r, labelBBox.y)
-      ext.maxY = Math.max(ext.maxY, y + r, labelBBox.y + labelBBox.height)
+      ext.minX = Math.min(ext.minX, x - r)
+      ext.maxX = Math.max(ext.maxX, x + r)
+      ext.minY = Math.min(ext.minY, y - r)
+      ext.maxY = Math.max(ext.maxY, y + r)
+
+      if (d._point.label) {
+        const labelBBox = getEstimatedLabelBBox(d, d._point.labelPosition, this.xScale, this.yScale, fontSizePx)
+        ext.minX = Math.min(ext.minX, labelBBox.x)
+        ext.maxX = Math.max(ext.maxX, labelBBox.x + labelBBox.width)
+        ext.minY = Math.min(ext.minY, labelBBox.y)
+        ext.maxY = Math.max(ext.maxY, labelBBox.y + labelBBox.height)
+      }
       return ext
     }, {
       minX: Number.POSITIVE_INFINITY,
@@ -205,7 +211,7 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
               shape: getString(d, config.shape, j) as SymbolType,
               label: getString(d, config.label, j),
               labelColor: getColor(d, config.labelColor, j, true),
-              labelPosition: getValue(d, this.config.labelPosition, i) as Position,
+              labelPosition: getValue(d, config.labelPosition, i) as Position,
               cursor: getString(d, config.cursor, j),
               groupIndex: j,
               pointIndex: i,

--- a/packages/ts/src/components/scatter/modules/point.ts
+++ b/packages/ts/src/components/scatter/modules/point.ts
@@ -8,7 +8,6 @@ import { Symbol, SymbolType } from 'types/symbol'
 import { smartTransition } from 'utils/d3'
 import { getCSSVariableValue, isStringCSSVariable } from 'utils/misc'
 import { hexToBrightness } from 'utils/color'
-import { getValue } from 'utils/data'
 
 // Types
 import { ContinuousScale } from 'types/scale'
@@ -45,7 +44,6 @@ export function updatePoints<Datum> (
   const symbolGenerator = symbol()
 
   selection.each((d, index, elements) => {
-    const i = d._point.pointIndex
     const group: Selection<SVGGElement, ScatterPoint<Datum>, SVGGElement, ScatterPoint<Datum>[]> = select(elements[index])
     const label = group.select('text')
     const path = group.select('path')
@@ -68,7 +66,7 @@ export function updatePoints<Datum> (
       .style('stroke-width', `${pointStrokeWidth}px`)
 
     // Label
-    const labelPosition = getValue(d, config.labelPosition, i) as `${Position}`
+    const labelPosition = d._point.labelPosition
     const isLabelPositionCenter = (labelPosition !== Position.Top) && (labelPosition !== Position.Bottom) &&
       (labelPosition !== Position.Left) && (labelPosition !== Position.Right)
     const pointLabelText = d._point.label ?? ''

--- a/packages/ts/src/components/scatter/types.ts
+++ b/packages/ts/src/components/scatter/types.ts
@@ -1,3 +1,4 @@
+import { Position } from 'types/position'
 import { SymbolType } from 'types/symbol'
 
 export type ScatterPoint<D> = D & {
@@ -11,6 +12,7 @@ export type ScatterPoint<D> = D & {
     shape: SymbolType | string;
     label: string | null;
     labelColor: string | null;
+    labelPosition: Position | null;
     cursor: string | null;
     groupIndex: number;
     pointIndex: number;


### PR DESCRIPTION
This PR includes some minor refactoring and fixes the following issues:

- When `labelPosition === Position.Center`, the labels aren't visible unless explicitly setting the label color
- Scatter's bleed function adds extra space to the bottom (default label position),  even when there are no labels present