### PR TITLE
Dev | Examples | Donut chart: Component name fix while launching stac…

### DIFF
--- a/packages/shared/examples/basic-donut-chart/basic-donut-chart.component.ts
+++ b/packages/shared/examples/basic-donut-chart/basic-donut-chart.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core'
 import { data, DataRecord } from './data'
 
 @Component({
-  selector: 'basic-donut-chart-component',
+  selector: 'basic-donut-chart',
   templateUrl: './basic-donut-chart.component.html',
 })
 


### PR DESCRIPTION
When we open https://unovis.dev/gallery/view?collection=Circular%20Charts&title=Basic%20Donut%20Chart for Angular Framework, The stackblitz is not rendering the component. 
<img width="1648" alt="Screenshot 2024-07-25 at 5 18 43 PM" src="https://github.com/user-attachments/assets/558763fc-52c9-4b63-9fa8-f6fed8b3b015">

<br>

**This PR will fix this issue.**
