### PR TITLE
Core | Bug: Xy-container size rendering fix

### DIFF
--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -346,6 +346,7 @@ export class XYContainer<Datum> extends ContainerCore {
     if (isYDirectionSouth) yRange.reverse()
 
     for (const c of components) {
+      c.setSize(this.width, this.height, this.containerWidth, this.containerHeight)
       c.setScaleRange(ScaleDimension.X, config.xRange ?? xRange)
       c.setScaleRange(ScaleDimension.Y, config.yRange ?? yRange)
     }


### PR DESCRIPTION
Fixed a bug which caused xy-container not rendering size correctly. 

![Screenshot 2024-08-15 at 2 37 46 PM](https://github.com/user-attachments/assets/dcb294ac-01ba-4947-90d8-30396e1e980a)
