### PR TITLE
Angular | SingleContainer: Add SVG defs and sizing options to SingleContainer

### DIFF
--- a/packages/angular/src/containers/single-container/single-container.component.ts
+++ b/packages/angular/src/containers/single-container/single-container.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, Input, OnDestroy, SimpleChanges, ContentChild } from '@angular/core'
 
 // Vis
-import { ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Spacing, Annotations } from '@unovis/ts'
+import { ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Spacing, Annotations, Sizing } from '@unovis/ts'
 import { VisCoreComponent } from '../../core'
 import { VisTooltipComponent } from '../../components/tooltip/tooltip.component'
 import { VisAnnotationsComponent } from '../../components/annotations/annotations.component'
@@ -32,6 +32,11 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
    * `aria-label` attribute to the div element containing your chart. Default: `undefined`.
   */
   @Input() ariaLabel?: string | null | undefined
+  /** Custom SVG defs available to all the components within the container. Default: `undefined`. */
+  @Input() svgDefs?: string
+  /** Defines whether components should fit into the container or the container should expand to fit to the component's size.
+   * Works with a limited set of components. Default: `Sizing.Fit` */
+  @Input() sizing?: Sizing | string
   /** Data to be passed to the component. Default: `undefined`. */
   @Input() data?: Data
 
@@ -55,13 +60,13 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
   }
 
   getConfig (): SingleContainerConfigInterface<Data> {
-    const { width, height, duration, margin, ariaLabel } = this
+    const { width, height, duration, margin, ariaLabel, svgDefs, sizing } = this
 
     const component = this.visComponent?.component as C
     const tooltip = this.tooltipComponent?.component as Tooltip
     const annotations = this.annotationsComponent?.component as Annotations
 
-    return { width, height, duration, margin, component, tooltip, ariaLabel, annotations }
+    return { width, height, duration, margin, component, tooltip, ariaLabel, annotations, svgDefs, sizing }
   }
 
   ngOnDestroy (): void {


### PR DESCRIPTION
This should fix #429

- `svgDefs` allows passing custom SVG defs to be available to all components within the container
- `sizing` defines whether components should fit into the container or the container should expand to fit the component's size