### PR TITLE
Core | Percy Test: Add wait time

### DIFF
--- a/packages/dev/cypress/e2e/unovis.cy.ts
+++ b/packages/dev/cypress/e2e/unovis.cy.ts
@@ -14,7 +14,7 @@ describe('Unovis Test', () => {
           duration: test.duration,
         },
       })
-      cy.wait(test.duration > 100 ? test.duration : 100)
+      cy.wait(test.duration > 1000 ? test.duration : 1000)
       cy.percySnapshot(test.title, { scope: scopeSelector })
     })
   })


### PR DESCRIPTION
Noticed some charts didn't get fully rendered before Percy took a screenshot. Increased wait time from `100` to `500`. 