### PR TITLE
Core | Container: Improve ResizeObserver handling

### DIFF
--- a/packages/dev/src/examples/misc/donut/donut-full-height/index.tsx
+++ b/packages/dev/src/examples/misc/donut/donut-full-height/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Donut: Full Height'
+export const subTitle = 'Testing the resize behavior'
+
+export const component = (props: ExampleViewerDurationProps): JSX.Element => {
+  const data = [3, 2, 5, 4, 0, 1]
+  return (
+    <VisSingleContainer style={{ height: '100%' }}>
+      <VisDonut
+        value={d => d}
+        data={data}
+        padAngle={0.02}
+        duration={props.duration}
+        arcWidth={80}
+      />
+    </VisSingleContainer>
+  )
+}
+

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -147,8 +147,8 @@ export class SingleContainer<Data> extends ContainerCore {
     if (!this._resizeObserver) this._setUpResizeObserver()
 
     // Schedule the actual rendering in the next frame
-    cancelAnimationFrame(this._requestedAnimationFrame)
-    this._requestedAnimationFrame = requestAnimationFrame(() => {
+    cancelAnimationFrame(this._renderAnimationFrameId)
+    this._renderAnimationFrameId = requestAnimationFrame(() => {
       this._preRender()
       this._render(duration)
     })


### PR DESCRIPTION
This PR fixes #455, a problem with ResizeObserver throwing an error when scrollbars appear/disappear. Solving this by delaying the resize by one frame.

The only tradeoff is scrollbar flickering when changing the size, but it only appears when "Show scroll bars" setting is set to "Always" on macOS (not sure about the other platforms).

<img width="491" alt="image" src="https://github.com/user-attachments/assets/e6b327dd-bb3a-4906-8314-24fdc6a78e66">

https://github.com/user-attachments/assets/b6f15fe6-acad-484b-9712-bc51e48ca864

Changelog:
- Use requestAnimationFrame to avoid multiple resize events when scrollbars appear/disappear
- Cancel previous animation frame IDs before scheduling new ones
- Renamed `_requestedAnimationFrame` to `_renderAnimationFrameId`

