### PR TITLE
Core | Container: Updating jsdoc for `width` and `height`

### DIFF
--- a/packages/angular/src/containers/single-container/single-container.component.ts
+++ b/packages/angular/src/containers/single-container/single-container.component.ts
@@ -19,9 +19,17 @@ export class VisSingleContainerComponent<Data = unknown, C extends ComponentCore
   @ContentChild(VisTooltipComponent) tooltipComponent: VisTooltipComponent
   @ContentChild(VisAnnotationsComponent) annotationsComponent: VisAnnotationsComponent
 
-  /** Width in pixels. By default, Container automatically fits to the size of the parent element. Default: `undefined`. */
+  /** Width in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `width` as a percentage, do it via `style` or `class`
+   * of the corresponding DOM element.
+   * Default: `undefined`
+  */
   @Input() width?: number
-  /** Height in pixels. By default, Container automatically fits to the size of the parent element. Default: `undefined`. */
+  /** Height in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `height` as a percentage, do it via `style` or `class`
+   * of the corresponding DOM element.
+   * Default: `undefined`
+  */
   @Input() height?: number
 
   /** Margins. Default: `{ top: 0, bottom: 0, left: 0, right: 0 }` */

--- a/packages/angular/src/containers/xy-container/xy-container.component.ts
+++ b/packages/angular/src/containers/xy-container/xy-container.component.ts
@@ -31,9 +31,17 @@ export class VisXYContainerComponent<Datum> implements AfterViewInit, AfterConte
   @ContentChild(VisTooltipComponent) tooltipComponent: VisTooltipComponent
   @ContentChild(VisAnnotationsComponent) annotationsComponent: VisAnnotationsComponent
 
-  /** Width in pixels. By default, Container automatically fits to the size of the parent element. Default: `undefined`. */
+  /** Width in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `width` as a percentage, do it via `style` or `class`
+   * of the corresponding DOM element.
+   * Default: `undefined`
+  */
   @Input() width?: number
-  /** Height in pixels. By default, Container automatically fits to the size of the parent element. Default: `undefined`. */
+  /** Height in pixels or in CSS units.
+   * Percentage units `"%"` are not supported here. If you want to set `height` as a percentage, do it via `style` or `class`
+   * of the corresponding DOM element.
+   * Default: `undefined`
+  */
   @Input() height?: number
 
   /** Scale for X dimension, e.g. Scale.scaleLinear(). Default: `Scale.scaleLinear()` */

--- a/packages/ts/src/core/container/config.ts
+++ b/packages/ts/src/core/container/config.ts
@@ -14,16 +14,14 @@ export interface ContainerConfigInterface {
   /** Defines whether components should fit into the container or the container should expand to fit to the component's size. Default: `Sizing.Fit` */
   sizing?: Sizing | string;
   /** Width in pixels or in CSS units.
-   * Percentage units `"%"` are not supported here. If you want to set `width` as a percentage, do it via `style`
+   * Percentage units `"%"` are not supported here. If you want to set `width` as a percentage, do it via `style` or `class`
    * of the corresponding DOM element.
-   * By default, Container automatically fits to the size of the parent element.
    * Default: `undefined`
   */
   width?: number | string;
   /** Height in pixels or in CSS units.
-   * Percentage units `"%"` are not supported here. If you want to set `height` as a percentage, do it via `style`
+   * Percentage units `"%"` are not supported here. If you want to set `height` as a percentage, do it via `style` or `class`
    * of the corresponding DOM element.
-   * By default, Container automatically fits to the size of the parent element.
    * Default: `undefined`
   */
   height?: number | string;


### PR DESCRIPTION
Removing the part saying that the container automatically fits to the size of the parent element because it's only true for the TypeScript version of the library.

Since the majority of Unovis users are using UI frameworks, they may be get confused by this.