### PR TITLE
Component | Axis: Hiding overlapping tick labels

### DIFF
--- a/packages/dev/src/examples/xy-components/axis/axis-tick-label-overlap/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-tick-label-overlap/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { VisXYContainer, VisAxis } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { Scale } from '@unovis/ts'
+
+export const title = 'Axis Tick Label Overlap'
+export const subTitle = 'Resolving overlapping labels'
+export const component = (props: ExampleViewerDurationProps): JSX.Element => {
+  return (<>
+    <VisXYContainer xDomain={[0, 1000]} height={75}>
+      <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true}/>
+    </VisXYContainer>
+    <VisXYContainer xDomain={[0, 10000000]} height={75}>
+      <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true}/>
+    </VisXYContainer>
+    <VisXYContainer xDomain={[0, 10000000]} height={75}>
+      <VisAxis type='x' numTicks={25} duration={props.duration} tickTextHideOverlapping={true} tickTextAngle={15}/>
+    </VisXYContainer>
+    <VisXYContainer xDomain={[0, Date.now()]} height={125} xScale={Scale.scaleTime()}>
+      <VisAxis type='x' numTicks={7} duration={props.duration} tickTextHideOverlapping={true}/>
+    </VisXYContainer>
+  </>)
+}

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -29,7 +29,9 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   domainLine?: boolean;
   /** Draw only the min and max axis ticks. Default: `false` */
   minMaxTicksOnly?: boolean;
-  /** Draw only the min and max axis ticks. Default: `250` */
+  /** Draw only the min and max axis ticks, when the chart
+   * width is less than the specified value.
+   * Default: `250` */
   minMaxTicksOnlyWhenWidthIsLess?: number;
   /** Tick label formatter function. Default: `undefined` */
   tickFormat?: ((tick: number | Date, i: number, ticks: number[] | Date[]) => string);

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -27,8 +27,10 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickLine?: boolean;
   /** Sets whether to draw the domain line or not. Default: `true` */
   domainLine?: boolean;
-  /** Draw the min and max axis ticks only. Default: `false` */
+  /** Draw only the min and max axis ticks. Default: `false` */
   minMaxTicksOnly?: boolean;
+  /** Draw only the min and max axis ticks. Default: `250` */
+  minMaxTicksOnlyWhenWidthIsLess?: number;
   /** Tick label formatter function. Default: `undefined` */
   tickFormat?: ((tick: number | Date, i: number, ticks: number[] | Date[]) => string);
   /** Explicitly set tick values. Default: `undefined` */
@@ -53,6 +55,11 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickTextColor?: string | null;
   /** Text rotation angle for ticks. Default: `undefined` */
   tickTextAngle?: number;
+  /** Hide tick labels that overlap with each other.
+   * To define overlapping, a simple bounding box collision detection algorithm is used.
+   * Which means the result won't be accurate when `tickTextAngle` is specified.
+   * Default: `undefined` */
+  tickTextHideOverlapping?: boolean;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   tickPadding?: number;
 }
@@ -68,6 +75,7 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   domainLine: true,
   numTicks: undefined,
   minMaxTicksOnly: false,
+  minMaxTicksOnlyWhenWidthIsLess: 250,
   tickTextWidth: undefined,
   tickTextSeparator: undefined,
   tickTextForceWordBreak: false,
@@ -76,10 +84,12 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   tickTextFontSize: null,
   tickTextAlign: undefined,
   tickTextColor: null,
+  tickTextAngle: undefined,
   labelMargin: 8,
   labelColor: null,
   tickFormat: undefined,
   tickValues: undefined,
   fullSize: true,
   tickPadding: 8,
+  tickTextHideOverlapping: undefined,
 }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -29,8 +29,8 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   static selectors = s
   protected _defaultConfig: AxisConfigInterface<Datum> = AxisDefaultConfig
   public config: AxisConfigInterface<Datum> = this._defaultConfig
-  axisGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
-  gridGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
+  private axisGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
+  private gridGroup: Selection<SVGGElement, unknown, SVGGElement, unknown>
 
   private _axisRawBBox: DOMRect
   private _axisSizeBBox: SVGRect
@@ -38,7 +38,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   private _defaultNumTicks = 3
   private _minMaxTicksOnlyEnforceWidth = 250
 
-  events = {}
+  protected events = {}
 
   constructor (config?: AxisConfigInterface<Datum>) {
     super()
@@ -49,7 +49,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   }
 
   /** Renders axis to an invisible grouped to calculate automatic chart margins */
-  preRender (): void {
+  public preRender (): void {
     const { config } = this
     const axisRenderHelperGroup = this.g.append('g').attr('opacity', 0)
 
@@ -69,17 +69,17 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     axisRenderHelperGroup.remove()
   }
 
-  getPosition (): Position {
+  public getPosition (): Position {
     const { config: { type, position } } = this
     return (position ?? ((type === AxisType.X) ? Position.Bottom : Position.Left)) as Position
   }
 
-  _getAxisSize (selection: Selection<SVGGElement, unknown, SVGGElement, undefined>): SVGRect {
+  private _getAxisSize (selection: Selection<SVGGElement, unknown, SVGGElement, undefined>): SVGRect {
     const bBox = selection.node().getBBox()
     return bBox
   }
 
-  _getRequiredMargin (axisSize = this._axisSizeBBox): Spacing {
+  private _getRequiredMargin (axisSize = this._axisSizeBBox): Spacing {
     const { config: { type, position } } = this
 
     switch (type) {
@@ -130,7 +130,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _render (duration = this.config.duration, selection = this.axisGroup): void {
+  public _render (duration = this.config.duration, selection = this.axisGroup): void {
     const { config } = this
 
     this._renderAxis(selection, duration)
@@ -150,7 +150,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     if (config.tickTextAlign) this._alignTickLabels()
   }
 
-  _buildAxis (): D3Axis<any> {
+  private _buildAxis (): D3Axis<any> {
     const { config: { type, position, tickPadding } } = this
 
     const ticks = this._getNumTicks()
@@ -168,7 +168,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _buildGrid (): D3Axis<any> {
+  private _buildGrid (): D3Axis<any> {
     const { config: { type, position } } = this
 
     const ticks = this._getNumTicks()
@@ -186,7 +186,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _renderAxis (selection = this.axisGroup, duration = this.config.duration): void {
+  private _renderAxis (selection = this.axisGroup, duration = this.config.duration): void {
     const { config } = this
 
     const axisGen = this._buildAxis()
@@ -251,7 +251,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _getNumTicks (): number {
+  private _getNumTicks (): number {
     const { config: { type, numTicks } } = this
 
     if (numTicks) return numTicks
@@ -271,7 +271,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     return this._defaultNumTicks
   }
 
-  _getConfiguredTickValues (): number[] | null {
+  private _getConfiguredTickValues (): number[] | null {
     const { config: { tickValues, type, minMaxTicksOnly } } = this
     const scale = type === AxisType.X ? this.xScale : this.yScale
     const scaleDomain = scale?.domain() as [number, number]
@@ -287,7 +287,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     return null
   }
 
-  _getFullDomainPath (tickSize = 0): string {
+  private _getFullDomainPath (tickSize = 0): string {
     const { config: { type } } = this
     switch (type) {
       case AxisType.X: return `M0.5, ${tickSize} V0.5 H${this._width + 0.5} V${tickSize}`
@@ -295,7 +295,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _renderAxisLabel (selection = this.axisGroup): void {
+  private _renderAxisLabel (selection = this.axisGroup): void {
     const { type, label, labelMargin, labelFontSize } = this.config
 
     // Remove the old label first to calculate the axis size properly
@@ -325,7 +325,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .style('fill', this.config.labelColor)
   }
 
-  _getLabelDY (): number {
+  private _getLabelDY (): number {
     const { type, position } = this.config
     switch (type) {
       case AxisType.X:
@@ -341,7 +341,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _alignTickLabels (): void {
+  private _alignTickLabels (): void {
     const { config: { type, tickTextAlign, tickTextAngle, position } } = this
     const tickText = this.g.selectAll('g.tick > text')
 
@@ -355,7 +355,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .attr('text-anchor', textAnchor)
   }
 
-  _getTickTextAnchor (textAlign: TextAlign): string {
+  private _getTickTextAnchor (textAlign: TextAlign): string {
     switch (textAlign) {
       case TextAlign.Left: return 'start'
       case TextAlign.Right: return 'end'
@@ -364,7 +364,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     }
   }
 
-  _getYTickTextTranslate (textAlign: TextAlign, axisPosition: Position = Position.Left): number {
+  private _getYTickTextTranslate (textAlign: TextAlign, axisPosition: Position = Position.Left): number {
     const defaultTickTextSpacingPx = 9 // Default in D3
     const width = this._axisRawBBox.width - defaultTickTextSpacingPx
 

--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -18,6 +18,7 @@ export const globalStyles = injectGlobal`
     --vis-axis-tick-label-text-decoration: none;
     --vis-axis-label-font-size: 14px;
     --vis-axis-tick-line-width: 1px;
+    --vis-axis-tick-label-hide-transition: opacity 400ms ease-in-out;
     --vis-axis-grid-line-width: 1px;
     /* --vis-axis-domain-line-width: // Undefined by default to allow fallback to var(--vis-axis-grid-line-width) */
 
@@ -99,7 +100,6 @@ export const tick = css`
     text-decoration: var(--vis-axis-tick-label-text-decoration);
     stroke: none;
   }
-
 `
 
 export const label = css`
@@ -112,4 +112,10 @@ export const label = css`
 
 export const tickLabel = css`
   label: tick-label;
+`
+
+export const tickLabelHideable = css`
+  label: tick-label-hideable;
+  opacity: 0;
+  transition: var(--vis-axis-tick-label-hide-transition);
 `

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -389,6 +389,7 @@ export class XYContainer<Datum> extends ContainerCore {
 
     // At first we need to set the domain to the scales
     const components = clean([...this.components, xAxis, yAxis])
+    this._setScales(...components)
     this._updateScalesDomain(...components)
 
     // Calculate margin required by the axes

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -210,12 +210,20 @@ The specified count is only a hint, the axis can have more or fewer ticks depend
   property="numTicks"/>
 
 ### Display Only Minimum and Maximum Ticks
-Set the `minMaxTicksOnly` property to `true` if you only want to see the two end ticks on the axis:
+Set the `minMaxTicksOnly` property to `true` if you only want to see the two end ticks on the axis.
+
+:::note
+To display the minimum and maximum ticks only when the chart width is limited (this behavior is enabed my default),
+you can use the `minMaxTicksOnlyWhenWidthIsLess` property (defaults to 250px). This helps avoid clutter in smaller visualizations while still
+providing essential information.
+:::
+
 <XYWrapperWithInput
   {...defaultProps()}
   inputType="checkbox"
   defaultValue={true}
   property="minMaxTicksOnly"/>
+
 
 ### Set Ticks Explicitly
 You can customize the ticks displayed by providing the _Axis_ component with a number array.
@@ -226,6 +234,21 @@ function tickValues() {
 })
 ```
 <XYWrapper {...defaultProps()} tickValues={[0,2,4,6,8]} hiddenProps={{x:d=>d.x}}/>
+
+### Hide Overlapping Ticks `1.5.0`
+To prevent overlapping tick labels on the axis, you can use the `tickTextHideOverlapping`
+property. When enabled, it hides any tick labels that would otherwise overlap with
+one another based on a simple bounding box collision detection algorithm. This
+ensures cleaner, more legible axes, particularly in cases where the available space
+is limited or when displaying many ticks.
+
+:::note
+The algorithm used for detecting overlaps may not be accurate when a `tickTextAngle` is specified,
+so results can vary depending on tick rotation.
+:::
+
+<XYWrapper {...defaultProps()} numTicks={15} containerProps={{ xDomain: [0, 10000000] }} hiddenProps={{x:d=>d.x}} tickTextHideOverlapping={true}/>
+
 
 ## Displaying Multiple Axes
 More commonly, you will want to display both an x and y axis for your graph. You can display multiple axes in an _XY Container_ like so:


### PR DESCRIPTION
This PR implements a feature that automatically hides overlapping Axis labels. The overlapping detection has only a single iteration, so overlap is still possible, but I think it's a reasonable trade off. We can tweak that later if needed.

https://github.com/user-attachments/assets/fe4e16c9-e41b-4860-9f25-fecca0b0ddb2

Another important thing here, is that I've fixed the problem with wrong auto margins on the first render leading to tick labels go off screen.

### Before

<img width="733" alt="SCR-20241018-lrxm" src="https://github.com/user-attachments/assets/c59d5d8b-566a-4036-8101-9258b5bd657a">

### After
<img width="713" alt="SCR-20241018-lrvg" src="https://github.com/user-attachments/assets/c75920f5-c3d6-4e51-ae9a-7dfca32f927d">

## Docs update
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/38064b56-3ba7-4216-a365-209f9a607b89">
