### PR TITLE
React | HTML Components: Adding `component` dependency to `useImperativeHandle`

### DIFF
--- a/packages/react/src/html-components/bullet-legend/index.tsx
+++ b/packages/react/src/html-components/bullet-legend/index.tsx
@@ -34,7 +34,7 @@ function VisBulletLegendFC (props: VisBulletLegendProps, fRef: ForwardedRef<VisB
     component?.update(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
   return <div className={props.className} ref={ref} />
 }
 

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -36,7 +36,7 @@ function VisLeafletFlowMapFC<PointDatum extends GenericDataRecord, FlowDatum ext
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
   return <div className={props.className} ref={ref} />
 }
 

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -36,7 +36,7 @@ function VisLeafletMapFC<Datum extends GenericDataRecord> (props: VisLeafletMapP
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
   return <div className={props.className} ref={ref} />
 }
 


### PR DESCRIPTION
Fixes #472

Updated dependencies for the `useImperativeHandle` hook to include the `component` in its dependency array. This ensures that references to the component are correctly updated whenever it changes, leading to improved synchronization and reliability in the component's behavior.

