### PR TITLE
Docs: Fix import statements from examples

### DIFF
--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -303,7 +303,7 @@ The _Axis_ component supports additional styling via CSS variables that you can 
 
 ## Events
 ```ts
-import { Axis } from '@unovis/ts`
+import { Axis } from '@unovis/ts'
 
 events = {
   [Axis.selectors.tick]: {

--- a/packages/website/docs/xy-charts/GroupedBar.mdx
+++ b/packages/website/docs/xy-charts/GroupedBar.mdx
@@ -77,7 +77,7 @@ Read our guide about using ordinal/categorical values with _XY Components_ [here
 
 ## Events
 ```ts
-import { GroupedBar } from '@unovis/ts`
+import { GroupedBar } from '@unovis/ts'
 ...
 events = {
     [GroupedBar.selectors.bar]: {

--- a/packages/website/docs/xy-charts/Line.mdx
+++ b/packages/website/docs/xy-charts/Line.mdx
@@ -72,7 +72,7 @@ Consider the following example, where the dataset contains `undefined` values ov
 
 ## Events
 ```ts
-import { Line } from '@unovis/ts`
+import { Line } from '@unovis/ts'
 ...
 const events = {
   [Line.selectors.line]: {

--- a/packages/website/docs/xy-charts/Scatter.mdx
+++ b/packages/website/docs/xy-charts/Scatter.mdx
@@ -86,7 +86,7 @@ over a point by providing a `cursor` accessor function.
 
 ## Events
 ```ts
-import { Scatter } from '@unovis/ts`
+import { Scatter } from '@unovis/ts'
 ...
 events = {
     [Scatter.selectors.point]: {

--- a/packages/website/docs/xy-charts/StackedBar.mdx
+++ b/packages/website/docs/xy-charts/StackedBar.mdx
@@ -97,7 +97,7 @@ Read our guide about using ordinal/categorical values with _XY Components_ [here
 
 ## Events
 ```ts
-import { StackedBar } from '@unovis/ts`
+import { StackedBar } from '@unovis/ts'
 ...
 events = {
     [StackedBar.selectors.bar]: {


### PR DESCRIPTION
In some places, it is used backtick instead of a single quote for closing the import statement