### PR TITLE
Core: Fix the nullish coalescing operator in `_updateScalesRange`

### DIFF
--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -341,8 +341,8 @@ export class XYContainer<Datum> extends ContainerCore {
 
     // Set initial scale range
     const isYDirectionSouth = config.yDirection === Direction.South
-    const xRange: [number, number] = [config.padding.left ?? 0, this.width - config.padding.right ?? 0]
-    const yRange: [number, number] = [this.height - config.padding.bottom ?? 0, config.padding.top ?? 0]
+    const xRange: [number, number] = [config.padding.left ?? 0, this.width - (config.padding.right ?? 0)]
+    const yRange: [number, number] = [this.height - (config.padding.bottom ?? 0), config.padding.top ?? 0]
     if (isYDirectionSouth) yRange.reverse()
 
     for (const c of components) {


### PR DESCRIPTION
I got this interesting warning when playing around with the project build.

```
src/containers/xy-container/index.ts: The "??" operator here will always return the left operand
```

And the compiler was right. In case `config.padding.bottom` will be `undefined`, subtraction will get NaN. The operator will be applied to the result of the subtraction but not the `config.padding.bottom`. So the fix was easy, just wrapping up with paratheses.