### PR TITLE
Website | Release: Add 1.5 release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://user-images.githubusercontent.com/755708/205744216-5e9efd10-794b-4ce1-9a
 Learn more about _Unovis_ on [unovis.dev](https://unovis.dev)
 
 ## Quick Start
-You can install the core of the library `@unovis/ts` and framework-specific packages (if you use React, Angular, or Svelte) from NPM:
+You can install the core of the library `@unovis/ts` and framework-specific packages (if you use React, Angular, Svelte, Vue or Solid) from NPM:
 
 ```bash
 npm install -P @unovis/ts @unovis/<react|angular|svelte|vue|solid>
@@ -41,7 +41,7 @@ export function BasicLineChart (): JSX.Element {
   )
 }
 ```
-Looking for Angular, Svelte, Vue, or TypeScript examples? Check out the [Quick Start](https://unovis.dev/docs/quick-start) page on our website.
+Looking for Angular, Svelte, Vue, Solid or TypeScript examples? Check out the [Quick Start](https://unovis.dev/docs/quick-start) page on our website.
 
 ## Examples and Documentation
 [![Unovis Examples](examples.png)](https://unovis.dev/gallery)

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -47,5 +47,5 @@ module.exports = {
       },
     },
   ],
-  helpUrl: 'https://github.com/f5/unovis/pull/375',
+  helpUrl: 'https://unovis.dev/contributing/pull-requests#commit-messages',
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/angular",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.4.4",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/react",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.4.4",
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/shared",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.4.4",
   "repository": {
     "type": "git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/svelte",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.4.4",
   "repository": {
     "type": "git",

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/ts",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.4.4",
   "repository": {
     "type": "git",

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -235,7 +235,7 @@ function tickValues() {
 ```
 <XYWrapper {...defaultProps()} tickValues={[0,2,4,6,8]} hiddenProps={{x:d=>d.x}}/>
 
-### Hide Overlapping Ticks `1.5.0`
+### Hide Overlapping Ticks `1.5`
 To prevent overlapping tick labels on the axis, you can use the `tickTextHideOverlapping`
 property. When enabled, it hides any tick labels that would otherwise overlap with
 one another based on a simple bounding box collision detection algorithm. This

--- a/packages/website/docs/auxiliary/Tooltip.mdx
+++ b/packages/website/docs/auxiliary/Tooltip.mdx
@@ -191,7 +191,7 @@ Works only with `verticalPlacement` set to `Position.Top` or `Position.Bottom`.
 
 ## Follow Cursor
 By default, the _Tooltip_ will follow the cursor when hovering over the chart elements.
-If you want the tooltip to be anchored to the hoevered element, you can set the `followCursor`
+If you want the tooltip to be anchored to the hovered element, you can set the `followCursor`
 property to `false`.
 
 <BrowserOnly fallback={<div>Loading...</div>}>

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -288,7 +288,7 @@ The disabled state appearance can be redefined with these CSS variables:
 --vis-dark-graph-node-side-label-background-greyout-color: #f1f4f7;
 ```
 
-### Custom Rendering `1.5.0`
+### Custom Rendering `1.5`
 The _Graph_ component offers extensive customization options for node rendering, allowing you to define how
 nodes are displayed at various stages of their lifecycle — such as on entering, updating, zooming, and exiting.
 You can inject custom rendering functions using the following configuration properties:
@@ -362,12 +362,12 @@ Providing an accessor function to `linkArrow` will turn on arrows display on lin
 `GraphLinkArrowStyle.Single` (`"single"` or simply `true`) or `GraphLinkArrowStyle.Double` (`"double"`) or `null`.
 <GraphDoc hiddenProps={linkHiddenProps} linkArrow={() => sample([undefined, 'single', 'double'])} />
 
-### Labels `Updated in 1.5.0`
+### Labels `Updated in 1.5`
 Links can have textual or custom SVG labels. When the label is short (two characters or less) or an SVG href, it'll be rendered with a circular
 background similarly to node's [side labels](Graph#on-the-side). Longer labels will have a rectangular background.
 To enable link labels you'll need to provide a function for `linkLabel` returning a `GraphLinkLabel` object to display.
 
-To use custom SVG as labels (available in _Unovis_ 1.5.0), you'll first need to define it in your container [SVG defs](http://localhost:9300/docs/containers/Single_Container#svg-defs)
+To use custom SVG as labels (available in _Unovis_ 1.5), you'll first need to define it in your container [SVG defs](http://localhost:9300/docs/containers/Single_Container#svg-defs)
 and provide the `href` to your custom SVG definition using the `text` property of your label. In this case the `fontSize`
 property will control the size of your custom SVG label.
 
@@ -590,7 +590,7 @@ Note: if you selected `GraphLayoutType.Precalculated` but fail to pass in `x` an
 ### Non-connected nodes aside
 If you want non-connected graph nodes to be placed below the layout, set `layoutNonConnectedAside` to `true`.
 
-### Post-Layout Customization `1.5.0`
+### Post-Layout Customization `1.5`
 The `Graph` component includes a `onLayoutCalculated` callback, which provides an opportunity to adjust
 the positions or properties of nodes and links after the layout has been calculated. This can be
 useful if you need to make final tweaks or apply additional logic once the layout is determined.
@@ -858,7 +858,7 @@ onNodeSelectionBrush: (selectedNodes: GraphNode<N, L>[], event: D3BrushEvent<SVG
 onNodeSelectionDrag: (selectedNodes: GraphNode<N, L>[], event: D3DragEvent<SVGGElement, GraphNode<N, L>, unknown>) => void;
 ```
 
-## Post-Render Customization `1.5.0`
+## Post-Render Customization `1.5`
 The _Graph_ component provides an `onRenderComplete` callback function that allows you to add custom
 elements to the graph’s canvas after the rendering is fully complete. This function is especially
 useful for layering additional elements or annotations on top of the existing nodes and links.

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -158,11 +158,11 @@ const config = {
         searchPagePath: 'search',
       },
       announcementBar: {
-        id: 'version-1.4-announcement',
+        id: 'version-1.5-announcement',
         content:
-          '✨ Chart Annotations, new Graph features, Bullet Legend shapes and more in <a rel="noopener noreferrer" href="/releases/1.4">Unovis 1.4</a>',
-        backgroundColor: '#fafbfc',
-        textColor: '#091E42',
+          '❄️ Solid support; Graph, Axis, Legend updates; Sticky Tooltip; Discord; and more in <a rel="noopener noreferrer" href="/releases/1.5">Unovis 1.5</a>',
+        backgroundColor: '#2680EB',
+        textColor: '#fff',
         isCloseable: false,
       },
     }),

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unovis/website",
-  "description": "Modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript",
+  "description": "Modular data visualization framework for React, Angular, Svelte, Vue, Solid, and vanilla TypeScript or JavaScript",
   "version": "1.0.1",
   "repository": {
     "type": "git",

--- a/packages/website/releases/1.5.md
+++ b/packages/website/releases/1.5.md
@@ -1,0 +1,58 @@
+---
+title: Release 1.5
+slug: 1.5
+authors: qliu
+image: https://unovis.dev/img/unovis-social.png
+hide_table_of_contents: false
+date: 2024-12-04T10:00
+---
+
+Version `1.5.0` of _Unovis_ has arrived! This release is packed with enhancements, including full support for Solid, 
+compatibility with Svelte 5, exciting new features, and numerous bug fixes.
+
+## Release Highlights
+### 🎉 Solid Support
+Thanks to [@hngngn](https://github.com/hngngn) for this amazing [contribution](https://github.com/f5/unovis/pull/469)! 
+
+### 🎊 Svelte 5 Support
+Unovis now support Svelte 5. Thanks [@pingu-codes](https://github.com/pingu-codes) for helping us with this integration.  
+
+### 🎨 Graph Updates
+A lot of new features were added to _Graph_: 
+This [PR](https://github.com/f5/unovis/pull/465) added SVGs in link lables ([doc](http://localhost:9300/docs/networks-and-flows/Graph#custom-rendering-150)), 
+<img alt="graph-link-labels" src="https://github.com/user-attachments/assets/bce4456c-4574-4b00-ad4a-ef5451ed4f91"/>
+Zoom start/end callbacks ([doc](http://localhost:9300/docs/networks-and-flows/Graph#zoom-and-pan-callbacks)), Fit view to specific nodes and Post-Layout ([doc](http://localhost:9300/docs/networks-and-flows/Graph#post-layout-customization-150)) and Post-Render Customization ([doc](http://localhost:9300/docs/networks-and-flows/Graph#post-render-customization-150)).
+
+_Graph_ now also supports multiple node selection [PR](https://github.com/f5/unovis/pull/395). Check out the [documentation](https://unovis.dev/docs/networks-and-flows/Graph#multiple-node-drag).
+<img alt="multi-node-selection" src="https://github.com/user-attachments/assets/904a3833-bab0-47d2-b495-8750acb238ef" />
+
+You can also pass in precalculated positions into _Graph_ nodes, rather than generating them randomly. See [documentation](https://unovis.dev/docs/networks-and-flows/Graph#precalculated) here.
+
+### Tooltip Updates
+Tooltip now support sticky position and dynamic content ([PR](https://github.com/f5/unovis/pull/402)). 
+
+
+### Discord Channel
+_Unovis_ now has a [Discord](https://discord.com/invite/5hnmashSaN) channel! Join us to say hi, ask questions, and stay updated with the latest news. 
+
+
+## Other changes
+### Enhancements
+* Testing | Add Cypress and Percy for visual testing [#419](https://github.com/f5/unovis/pull/419)
+* Component | Axis: Hiding overlapping tick labels [#466](https://github.com/f5/unovis/pull/466)
+* Component | Tooltip: Sticky position and support for dynamic content [#402](https://github.com/f5/unovis/pull/402)
+* Component | Bullet Legend: Vertical orientation [#374](https://github.com/f5/unovis/pull/374)
+* Component | Brush: Additional styling options via CSS variables [#392](https://github.com/f5/unovis/pull/392)
+* Component | Axis: Add tick label rotation [#394](https://github.com/f5/unovis/pull/394)
+* Website | Upgrade to Docusaurus V3 [#486](https://github.com/f5/unovis/pull/486)
+* Website | Gallery: Range plot [#390](https://github.com/f5/unovis/pull/390)
+* Website | Gallery: Scatter Plot with Varied Shape [#370](https://github.com/f5/unovis/pull/370)
+* Website | Gallery: Donut Example [#367](https://github.com/f5/unovis/pull/367)
+* Website | Add new composite chart section and dual axis chart [#383](https://github.com/f5/unovis/pull/383)
+* Website | Contribution section [#249](https://github.com/f5/unovis/pull/249)
+
+### Bug Fixes
+* Component | Scatter: MakesizeScale immutable to prevent sizeRange collisions [#411](https://github.com/f5/unovis/pull/411)
+* Component | Scatter: Label rendering fixes [#413](https://github.com/f5/unovis/pull/413)
+* TopoJSON Map Fixes [#425](https://github.com/f5/unovis/pull/425)
+* Core | Bug: Xy-container size rendering fix [#431](https://github.com/f5/unovis/pull/431)

--- a/packages/website/releases/1.5.md
+++ b/packages/website/releases/1.5.md
@@ -1,58 +1,74 @@
 ---
 title: Release 1.5
 slug: 1.5
-authors: qliu
+authors: [qliu, nrokotyan, rbol]
 image: https://unovis.dev/img/unovis-social.png
 hide_table_of_contents: false
 date: 2024-12-04T10:00
 ---
 
-Version `1.5.0` of _Unovis_ has arrived! This release is packed with enhancements, including full support for Solid, 
-compatibility with Svelte 5, exciting new features, and numerous bug fixes.
+Version `1.5` of _Unovis_ has arrived! This release is packed with enhancements,
+including full support for Solid; compatibility with Svelte 5 and React 19;
+many Graph component tweaks; exciting new features; and numerous bug fixes.
 
 ## Release Highlights
 ### 🎉 Solid Support
-Thanks to [@hngngn](https://github.com/hngngn) for this amazing [contribution](https://github.com/f5/unovis/pull/469)! 
+_Unovis_ now works with Solid — one of the most performant JSX frameworks. Thanks to [@hngngn](https://github.com/hngngn) for this amazing [contribution](https://github.com/f5/unovis/pull/469)!
 
-### 🎊 Svelte 5 Support
-Unovis now support Svelte 5. Thanks [@pingu-codes](https://github.com/pingu-codes) for helping us with this integration.  
+### 🎊 Svelte 5 and React 19
+Also _Unovis_ now support Svelte 5 and React 19.
+Thanks [@pingu-codes](https://github.com/pingu-codes) for helping us solve problems with the Svelte integration.
 
-### 🎨 Graph Updates
-A lot of new features were added to _Graph_: 
-This [PR](https://github.com/f5/unovis/pull/465) added SVGs in link lables ([doc](http://localhost:9300/docs/networks-and-flows/Graph#custom-rendering-150)), 
-<img alt="graph-link-labels" src="https://github.com/user-attachments/assets/bce4456c-4574-4b00-ad4a-ef5451ed4f91"/>
-Zoom start/end callbacks ([doc](http://localhost:9300/docs/networks-and-flows/Graph#zoom-and-pan-callbacks)), Fit view to specific nodes and Post-Layout ([doc](http://localhost:9300/docs/networks-and-flows/Graph#post-layout-customization-150)) and Post-Render Customization ([doc](http://localhost:9300/docs/networks-and-flows/Graph#post-render-customization-150)).
+### 🔗 Graph
+<video muted  autoPlay loop style={{ width: "100%" }} src="https://github.com/user-attachments/assets/1cb5c9f5-8717-4865-9e19-dc80d6bb6d8a"/>
 
-_Graph_ now also supports multiple node selection [PR](https://github.com/f5/unovis/pull/395). Check out the [documentation](https://unovis.dev/docs/networks-and-flows/Graph#multiple-node-drag).
-<img alt="multi-node-selection" src="https://github.com/user-attachments/assets/904a3833-bab0-47d2-b495-8750acb238ef" />
+A ton of new features were added to _Graph_:
 
-You can also pass in precalculated positions into _Graph_ nodes, rather than generating them randomly. See [documentation](https://unovis.dev/docs/networks-and-flows/Graph#precalculated) here.
+- Provide your own functions to render nodes allowing you to highly customize how the graph looks ([docs](/docs/networks-and-flows/Graph#custom-rendering-15)).
 
-### Tooltip Updates
-Tooltip now support sticky position and dynamic content ([PR](https://github.com/f5/unovis/pull/402)). 
+- Post-Layout ([docs](/docs/networks-and-flows/Graph#post-layout-customization-15)) and Post-Render Customization ([docs](/docs/networks-and-flows/Graph#post-render-customization-15)) allowing you to modify the layout of the graph on the fly and render additional layers with D3.
+
+- Provide custom SVG icon to link labels ([docs](/docs/networks-and-flows/Graph#labels-updated-in-15)).
+
+- Zoom start/end and node dragging callbacks ([docs](/docs/networks-and-flows/Graph#pan--zoom--drag)).
+
+- Fit view to specific nodes by providing an array of node ids.
+
+- Multiple node selection ([docs](https://unovis.dev/docs/networks-and-flows/Graph#multiple-node-drag)).
+
+- Pass precalculated layout within _Graph_ nodes ([docs](https://unovis.dev/docs/networks-and-flows/Graph#precalculated)).
 
 
-### Discord Channel
-_Unovis_ now has a [Discord](https://discord.com/invite/5hnmashSaN) channel! Join us to say hi, ask questions, and stay updated with the latest news. 
+### 🪧 Tooltip
+<video muted  autoPlay loop style={{ width: "100%" }} src="https://github.com/user-attachments/assets/ca8dbed2-e3bd-48cd-b3f5-f23f4db0b30f"/>
 
+*Tooltip* now can be anchored to the target element, can be hovered over, and supports dynamic content (updates if the content changes) ([docs](/docs/auxiliary/Tooltip#follow-cursor)).
+
+### 📏 Axis
+<video muted  autoPlay loop style={{ width: "100%" }} src="https://github.com/user-attachments/assets/5cf322a5-b9b6-4e0c-94b4-76c35f6175d1"/>
+
+Axis now automatically hides overlapping labels ([docs](/docs/auxiliary/Axis#hide-overlapping-ticks-15)) and supports label rotation ([docs](/docs/auxiliary/Axis#label-rotation)).
+
+### 🔵 Bullet Legend
+You can set the orientation of _Bullet Legend_ to `'vertical'` ([docs](http://localhost:9300/docs/auxiliary/BulletLegend#orientation)).
+
+![](https://github.com/user-attachments/assets/3e0edcb5-42ae-41da-ac11-83c1488d70c5)
+
+### 💬 Discord
+_Unovis_ now has a [Discord](https://discord.com/invite/5hnmashSaN) channel! Join us to say hi, ask questions, and stay updated with the latest news.
 
 ## Other changes
 ### Enhancements
 * Testing | Add Cypress and Percy for visual testing [#419](https://github.com/f5/unovis/pull/419)
-* Component | Axis: Hiding overlapping tick labels [#466](https://github.com/f5/unovis/pull/466)
-* Component | Tooltip: Sticky position and support for dynamic content [#402](https://github.com/f5/unovis/pull/402)
-* Component | Bullet Legend: Vertical orientation [#374](https://github.com/f5/unovis/pull/374)
 * Component | Brush: Additional styling options via CSS variables [#392](https://github.com/f5/unovis/pull/392)
-* Component | Axis: Add tick label rotation [#394](https://github.com/f5/unovis/pull/394)
 * Website | Upgrade to Docusaurus V3 [#486](https://github.com/f5/unovis/pull/486)
 * Website | Gallery: Range plot [#390](https://github.com/f5/unovis/pull/390)
 * Website | Gallery: Scatter Plot with Varied Shape [#370](https://github.com/f5/unovis/pull/370)
 * Website | Gallery: Donut Example [#367](https://github.com/f5/unovis/pull/367)
 * Website | Add new composite chart section and dual axis chart [#383](https://github.com/f5/unovis/pull/383)
-* Website | Contribution section [#249](https://github.com/f5/unovis/pull/249)
 
 ### Bug Fixes
 * Component | Scatter: MakesizeScale immutable to prevent sizeRange collisions [#411](https://github.com/f5/unovis/pull/411)
 * Component | Scatter: Label rendering fixes [#413](https://github.com/f5/unovis/pull/413)
-* TopoJSON Map Fixes [#425](https://github.com/f5/unovis/pull/425)
-* Core | Bug: Xy-container size rendering fix [#431](https://github.com/f5/unovis/pull/431)
+* Component | TopoJSON Map: Various fixes [#425](https://github.com/f5/unovis/pull/425)
+* Core | Bug: XY-container size rendering fix [#431](https://github.com/f5/unovis/pull/431)

--- a/packages/website/src/components/HomepageFeatures/index.tsx
+++ b/packages/website/src/components/HomepageFeatures/index.tsx
@@ -16,7 +16,7 @@ export const FeatureList: FeatureItem[] = [
     image: 'img/unovis-image-1.svg',
     description: (
       <>
-        Use with React, Angular, Svelte,<br /> or without any UI framework.
+        Use with React, Angular, Svelte, Vue, Solid,<br /> or without any UI framework.
       </>
     ),
   },


### PR DESCRIPTION
![Screenshot 2024-12-05 at 2 30 27 PM](https://github.com/user-attachments/assets/0484c25a-eb3f-4ced-ae9f-fcf9445b5fef)
![Screenshot 2024-12-05 at 2 30 34 PM](https://github.com/user-attachments/assets/c15ea419-03f1-492f-a938-81a5208d5c43)
![Screenshot 2024-12-05 at 2 30 40 PM](https://github.com/user-attachments/assets/df014924-3320-4663-9d36-6f692ada3f9a)

@rokotyan let me know if there's anything you want to add/move from `Other changes` into the highlights. 
I'm not sure if the percy test we added is worth being in the highlight session. Probably not?