### PR TITLE
Half Donut

### DIFF
--- a/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
@@ -29,6 +29,8 @@ export const component = (): JSX.Element => {
         duration={0}
         arcWidth={80}
         angleRange={currentAngleRange}
+        centralLabel="Central Label"
+        centralSubLabel="Sub-label"
       />
     </VisSingleContainer>
   )

--- a/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { DONUT_HALF_ANGLE_RANGES } from '@unovis/ts'
+
+export const title = 'Half Donut: Full Height'
+export const subTitle = 'Testing the resize behavior'
+export const component = (): JSX.Element => {
+  const data = [3, 2, 5, 4, 0, 1]
+
+  const [currentAngleRange, setCurrentAngleRange] = useState(DONUT_HALF_ANGLE_RANGES[0])
+
+  // Cycle through the half-donut angle ranges for testing
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentAngleRange((prev: [number, number]) => {
+        const currentIndex = DONUT_HALF_ANGLE_RANGES.indexOf(prev)
+        return DONUT_HALF_ANGLE_RANGES[(currentIndex + 1) % DONUT_HALF_ANGLE_RANGES.length]
+      })
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <VisSingleContainer style={{ height: '100%' }} >
+      <VisDonut
+        value={d => d}
+        data={data}
+        padAngle={0.02}
+        duration={0}
+        arcWidth={80}
+        angleRange={currentAngleRange}
+      />
+    </VisSingleContainer>
+  )
+}

--- a/packages/ts/src/components.ts
+++ b/packages/ts/src/components.ts
@@ -25,7 +25,14 @@ export { LeafletFlowMap } from './components/leaflet-flow-map'
 export { ChordDiagram } from './components/chord-diagram'
 export { Graph } from './components/graph'
 export { VisControls } from './components/vis-controls'
-export { Donut } from './components/donut'
+export {
+  Donut,
+  DONUT_HALF_ANGLE_RANGE_TOP,
+  DONUT_HALF_ANGLE_RANGE_RIGHT,
+  DONUT_HALF_ANGLE_RANGE_BOTTOM,
+  DONUT_HALF_ANGLE_RANGE_LEFT,
+  DONUT_HALF_ANGLE_RANGES,
+} from './components/donut'
 export { FreeBrush } from './components/free-brush'
 export { XYLabels } from './components/xy-labels'
 export { NestedDonut } from './components/nested-donut'

--- a/packages/ts/src/components/donut/config.ts
+++ b/packages/ts/src/components/donut/config.ts
@@ -42,6 +42,12 @@ export interface DonutConfigInterface<Datum> extends ComponentConfigInterface {
   showBackground?: boolean;
   /** Background angle range. When undefined, the value will be taken from `angleRange`. Default: `undefined` */
   backgroundAngleRange?: [number, number];
+
+  /** Vertical offset of the half-donut label. */
+  halfDonutLabelOffsetY?: number;
+
+  /** Horizontal offset of the half-donut label. */
+  halfDonutLabelOffsetX?: number;
 }
 
 export const DonutDefaultConfig: DonutConfigInterface<unknown> = {

--- a/packages/ts/src/components/donut/index.ts
+++ b/packages/ts/src/components/donut/index.ts
@@ -38,6 +38,9 @@ export const [
   DONUT_HALF_ANGLE_RANGE_LEFT,
 ] = DONUT_HALF_ANGLE_RANGES
 
+const DONUT_HALF_LABEL_OFFSET_Y_DEFAULT = 20
+const DONUT_HALF_LABEL_OFFSET_X_DEFAULT = 60
+
 export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Datum>> {
   static selectors = s
   protected _defaultConfig = DonutDefaultConfig as DonutConfigInterface<Datum>
@@ -110,6 +113,15 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
     const translateX = this._width / 2 + (isHalfDonutLeft ? outerRadius / 2 : isHalfDonutRight ? -outerRadius / 2 : 0)
     const translate = `translate(${translateX},${translateY})`
 
+    const {
+      halfDonutLabelOffsetY = DONUT_HALF_LABEL_OFFSET_Y_DEFAULT,
+      halfDonutLabelOffsetX = DONUT_HALF_LABEL_OFFSET_X_DEFAULT,
+    } = config
+
+    const labelTranslateY = isHalfDonutTop ? -halfDonutLabelOffsetY : isHalfDonutBottom ? halfDonutLabelOffsetY : 0
+    const labelTranslateX = isHalfDonutLeft ? -halfDonutLabelOffsetX : isHalfDonutRight ? halfDonutLabelOffsetX : 0
+    const labelTranslate = `translate(${translateX + labelTranslateX},${translateY + labelTranslateY})`
+
     this.arcGroup.attr('transform', translate)
 
     this.arcGen
@@ -162,12 +174,12 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
 
     // Label
     this.centralLabel
-      .attr('transform', translate)
+      .attr('transform', labelTranslate)
       .attr('dy', config.centralSubLabel ? '-0.55em' : null)
       .text(config.centralLabel ?? null)
 
     this.centralSubLabel
-      .attr('transform', translate)
+      .attr('transform', labelTranslate)
       .attr('dy', config.centralLabel ? '0.55em' : null)
       .text(config.centralSubLabel ?? null)
 


### PR DESCRIPTION
This PR introduces support for a "half donut" chart.

Related:

 * https://github.com/ExaForce/unovis/pull/3

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/e979be46-e783-4be4-b416-6a2c7244d8a1">

<img width="1170" alt="image" src="https://github.com/user-attachments/assets/30c47a78-5605-4616-8151-cd3bdc63927d">

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/ab25f279-d7ec-4c26-be7e-c336f1555ce7">

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/f3479a18-cfb6-4036-935a-cb0cace701ef">

Summary of changes:

 * Export constants that define half donut angle ranges
 * Add a new example that cycles through orientations (top, right, bottom, left) and also lets you resize dynamically  (height > width, height < width)
 * Make the scaling work for all 8 cases (top, right, bottom, left) X (height > width, height < width)

Based on a previous attempt in

 * https://github.com/f5/unovis/pull/444/files