### PR TITLE
Misc: License files clean up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3263,7 +3263,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -31802,7 +31802,7 @@
         "is-unicode-supported": {
           "version": "1.3.0",
           "bundled": true,
-          "dev": true
+          "extraneous": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "eslint ./ --ext .js,.jsx,.ts,.tsx,.svelte --fix --ignore-path .gitignore",
     "install:clean": "for p in packages/*; do if [ \"$p\" != \"packages/website\" ]; then rm -f \"$p/package-lock.json\"; fi; done; rm -rf packages/*/node_modules; rm -rf node_modules; npm i",
     "postinstall": "sh postinstall.sh",
-    "gather-licenses": "for p in packages/*; do echo \"  📄 Checking licenses for $p\"; npx license-report --package=$p/package.json --config lic-report-config.json --output=table > $p/licences.temp; mv -f $p/licences.temp $p/licences.txt; done",
+    "gather-licenses": "for p in packages/*; do echo \"  📄 Checking licenses for $p\"; npx license-report --package=$p/package.json --config lic-report-config.json --output=table | grep -v -E '@unovis/ts|@unovis/react' > $p/licences.temp; mv -f $p/licences.temp $p/licences.txt; done",
     "version": "sh update-version.sh"
   },
   "devDependencies": {

--- a/packages/angular/licences.txt
+++ b/packages/angular/licences.txt
@@ -22,7 +22,6 @@ rollup                             perpetual       MIT           2.75.5         
 rollup-plugin-typescript2          perpetual       MIT           0.31.2             @ezolenko
 webpack                            perpetual       MIT           5.76.0             Tobias Koppers @sokra
 zone.js                            perpetual       MIT           0.14.0             Brian Ford
-@unovis/ts                         perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 @angular/common                    perpetual       MIT           12.2.17            angular
 @angular/compiler                  perpetual       MIT           12.2.17            angular
 @angular/core                      perpetual       MIT           12.2.17            angular

--- a/packages/dev/licences.txt
+++ b/packages/dev/licences.txt
@@ -1,6 +1,5 @@
 name                                  license period  license type  installed version  author
 ----                                  --------------  ------------  -----------------  ------
-@unovis/react                         perpetual       Apache-2.0    1.4.5              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 fuse.js                               perpetual       Apache-2.0    6.6.2              Kiro Risk kirollos@gmail.com http://kiro.me
 react                                 perpetual       MIT           18.3.1             n/a
 react-dom                             perpetual       MIT           18.3.1             n/a
@@ -24,4 +23,3 @@ typescript-plugin-css-modules         perpetual       MIT           4.2.3       
 webpack                               perpetual       MIT           5.97.0             Tobias Koppers @sokra
 webpack-cli                           perpetual       MIT           5.1.4              n/a
 webpack-dev-server                    perpetual       MIT           4.15.2             Tobias Koppers @sokra
-@unovis/ts                            perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)

--- a/packages/react/licences.txt
+++ b/packages/react/licences.txt
@@ -16,6 +16,5 @@ tsconfig-paths-webpack-plugin      perpetual       MIT           3.5.2          
 tslib                              perpetual       0BSD          2.4.1              Microsoft Corp.
 ttypescript                        perpetual       MIT           1.5.13             cevek
 typescript                         perpetual       Apache-2.0    4.2.4              Microsoft Corp.
-@unovis/ts                         perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 react                              perpetual       MIT           18.3.1             n/a
 react-dom                          perpetual       MIT           18.3.1             n/a

--- a/packages/solid/licences.txt
+++ b/packages/solid/licences.txt
@@ -8,5 +8,4 @@ typescript           perpetual       Apache-2.0    5.6.3              Microsoft 
 vite                 perpetual       MIT           5.4.11             Evan You
 vite-plugin-dts      perpetual       MIT           3.6.0              qmhc
 vite-plugin-solid    perpetual       MIT           2.10.2             Alexandre Mouton-Brady <amoutonbrady@gmail.com>
-@unovis/ts           perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 solid-js             perpetual       MIT           1.9.3              Ryan Carniato

--- a/packages/svelte/licences.txt
+++ b/packages/svelte/licences.txt
@@ -16,5 +16,4 @@ svelte-preprocess             perpetual       MIT           4.10.7             C
 tslib                         perpetual       0BSD          2.4.1              Microsoft Corp.
 ttypescript                   perpetual       MIT           1.5.13             cevek
 typescript                    perpetual       Apache-2.0    4.2.4              Microsoft Corp.
-@unovis/ts                    perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 svelte                        perpetual       MIT           3.50.1             Rich Harris

--- a/packages/vue/licences.txt
+++ b/packages/vue/licences.txt
@@ -16,5 +16,4 @@ vite-plugin-css-injected-by-js  perpetual       MIT           3.3.0             
 vite-plugin-dts                 perpetual       MIT           3.6.0              qmhc
 vue                             perpetual       MIT           3.5.13             Evan You
 vue-tsc                         perpetual       MIT           1.8.19             n/a
-@unovis/ts                      perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
 vue                             perpetual       MIT           3.5.13             Evan You

--- a/packages/website/licences.txt
+++ b/packages/website/licences.txt
@@ -19,5 +19,3 @@ raw-loader                                 perpetual       MIT           4.0.2  
 react                                      perpetual       MIT           18.3.1             n/a
 react-dom                                  perpetual       MIT           18.3.1             n/a
 typescript                                 perpetual       Apache-2.0    5.2.2              Microsoft Corp.
-@unovis/react                              perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)
-@unovis/ts                                 perpetual       Apache-2.0    1.4.4              Nikita Rokotyan, F5 Inc. <nikita@f5.com> (https://rokotyan.com)

--- a/packages/website/package-lock.json
+++ b/packages/website/package-lock.json
@@ -8080,11 +8080,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.65.tgz",
       "integrity": "sha512-PWVzBjghx7/wop6n22vS2MLU8tKGd4Q91aCEGhG/TYmW6PP5OcSXcdnxTe1NNt0T66N8D6jxh4kC8UsdzOGaIw=="
     },
-    "node_modules/elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
-    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -16484,22 +16479,6 @@
         "react": ">=15"
       }
     },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.5.tgz",
-      "integrity": "sha512-CVA94zmfp8m4bSHtWwmANaBR8EPsKy2aZ7KwqhoS4Ftib87F9Kvi7XQhOixypPLMc6kVYgOXvKFuuzZDpHGRPg==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -18410,14 +18389,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
-    },
-    "node_modules/undici": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
-      "engines": {
-        "node": ">=18.17"
-      }
     },
     "node_modules/undici-types": {
       "version": "6.19.8",


### PR DESCRIPTION
Changes in the license files generate unnecessary noise when releasing a new version because of the `@unovis/...` internal version change. 

This PR removes `@unovis/ts` and `@unovis/react` entries form the license files by filtering them out using a grep expression.