### PR TITLE
Website | Release: Note update, Remove Svelte 5 from package.json

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "@unovis/ts": "1.4.4",
-    "svelte": "^3.48.0 || ^4.0.0 || ^5.0.0"
+    "svelte": "^3.48.0 || ^4.0.0 "
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.4",

--- a/packages/website/releases/1.5.md
+++ b/packages/website/releases/1.5.md
@@ -8,16 +8,16 @@ date: 2024-12-04T10:00
 ---
 
 Version `1.5` of _Unovis_ has arrived! This release is packed with enhancements,
-including full support for Solid; compatibility with Svelte 5 and React 19;
+including full support for Solid; compatibility with React 19 and Angular 19;
 many Graph component tweaks; exciting new features; and numerous bug fixes.
 
 ## Release Highlights
 ### 🎉 Solid Support
 _Unovis_ now works with Solid — one of the most performant JSX frameworks. Thanks to [@hngngn](https://github.com/hngngn) for this amazing [contribution](https://github.com/f5/unovis/pull/469)!
 
-### 🎊 Svelte 5 and React 19
-Also _Unovis_ now support Svelte 5 and React 19.
-Thanks [@pingu-codes](https://github.com/pingu-codes) for helping us solve problems with the Svelte integration.
+### 🎊  React 19 and Angular 19
+_Unovis_ now also support Angular 19 and React 19. <br />
+Calling for Svelte 5 support contribution ([discussion](https://github.com/f5/unovis/issues/500))! Huge thanks to [@pingu-codes](https://github.com/pingu-codes) for your incredible help with Svelte support! 🚀.
 
 ### 🔗 Graph
 <video muted  autoPlay loop style={{ width: "100%" }} src="https://github.com/user-attachments/assets/1cb5c9f5-8717-4865-9e19-dc80d6bb6d8a"/>
@@ -36,7 +36,7 @@ A ton of new features were added to _Graph_:
 
 - Multiple node selection ([docs](https://unovis.dev/docs/networks-and-flows/Graph#multiple-node-drag)).
 
-- Pass precalculated layout within _Graph_ nodes ([docs](https://unovis.dev/docs/networks-and-flows/Graph#precalculated)).
+- Enable _Graph_ nodes to accept precalculated layout data  ([docs](https://unovis.dev/docs/networks-and-flows/Graph#precalculated)).
 
 
 ### 🪧 Tooltip


### PR DESCRIPTION
Update Svelte 5 related information in first paragraph and highlights. 
![Screenshot 2024-12-11 at 1 10 16 PM](https://github.com/user-attachments/assets/2ec4b915-9d90-4dbc-8f0e-714216828c63)
![Screenshot 2024-12-11 at 1 10 37 PM](https://github.com/user-attachments/assets/def81079-ddc2-4e39-9b47-96fa83857d60)
