### PR TITLE
Component | Donut: Half Donut

### DIFF
--- a/packages/angular/src/components/donut/donut.component.ts
+++ b/packages/angular/src/components/donut/donut.component.ts
@@ -110,6 +110,12 @@ export class VisDonutComponent<Datum> implements DonutConfigInterface<Datum>, Af
 
   /** Background angle range. When undefined, the value will be taken from `angleRange`. Default: `undefined` */
   @Input() backgroundAngleRange?: [number, number]
+
+  /** Central label and sub-label horizontal offset in pixels. Default: `undefined` */
+  @Input() centralLabelOffsetX?: number
+
+  /** Central label and sub-label vertical offset in pixels. Default: `undefined` */
+  @Input() centralLabelOffsetY?: number
   @Input() data: Datum[]
 
   component: Donut<Datum> | undefined
@@ -131,8 +137,8 @@ export class VisDonutComponent<Datum> implements DonutConfigInterface<Datum>, Af
   }
 
   private getConfig (): DonutConfigInterface<Datum> {
-    const { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange } = this
-    const config = { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange }
+    const { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY } = this
+    const config = { duration, events, attributes, id, value, angleRange, padAngle, sortFunction, cornerRadius, color, radius, arcWidth, centralLabel, centralSubLabel, centralSubLabelWrap, showEmptySegments, emptySegmentAngle, showBackground, backgroundAngleRange, centralLabelOffsetX, centralLabelOffsetY }
     const keys = Object.keys(config) as (keyof DonutConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-full-height/index.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { DONUT_HALF_ANGLE_RANGES } from '@unovis/ts'
+
+export const title = 'Half Donut: Full Height'
+export const subTitle = 'Testing the resize behavior'
+export const component = (): JSX.Element => {
+  const data = [3, 2, 5, 4, 0, 1]
+
+  const [currentAngleRange, setCurrentAngleRange] = useState(DONUT_HALF_ANGLE_RANGES[0])
+
+  // Cycle through the half-donut angle ranges for testing
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentAngleRange((prev: [number, number]) => {
+        const currentIndex = DONUT_HALF_ANGLE_RANGES.indexOf(prev)
+        return DONUT_HALF_ANGLE_RANGES[(currentIndex + 1) % DONUT_HALF_ANGLE_RANGES.length]
+      })
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [])
+
+  return (
+    <VisSingleContainer style={{ height: '100%' }} >
+      <VisDonut
+        value={d => d}
+        data={data}
+        padAngle={0.02}
+        duration={0}
+        arcWidth={80}
+        angleRange={currentAngleRange}
+        centralLabel="Central Label"
+        centralSubLabel="Sub-label"
+      />
+    </VisSingleContainer>
+  )
+}

--- a/packages/dev/src/examples/misc/donut/half-donut-with-labels/index.tsx
+++ b/packages/dev/src/examples/misc/donut/half-donut-with-labels/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { VisSingleContainer, VisDonut } from '@unovis/react'
+import { DONUT_HALF_ANGLE_RANGE_TOP } from '@unovis/ts'
+
+export const title = 'Half Donut: Labels'
+export const subTitle = 'Testing the label offsets'
+export const component = (): JSX.Element => {
+  const data = [3, 2, 5, 4, 0, 1]
+
+  return (
+    <VisSingleContainer style={{ height: '100%' }} >
+      <VisDonut
+        value={d => d}
+        data={data}
+        padAngle={0.02}
+        duration={0}
+        arcWidth={80}
+        angleRange={DONUT_HALF_ANGLE_RANGE_TOP}
+        centralLabel='Central Label'
+        centralSubLabel='Central Sub Label'
+        centralLabelOffsetY={-24}
+      />
+    </VisSingleContainer>
+  )
+}

--- a/packages/ts/src/components.ts
+++ b/packages/ts/src/components.ts
@@ -31,6 +31,9 @@ export { XYLabels } from './components/xy-labels'
 export { NestedDonut } from './components/nested-donut'
 export { Annotations } from 'components/annotations'
 
+// Constants
+export * from './components/donut/constants'
+
 // Config Interfaces
 export type { LineConfigInterface } from './components/line/config'
 export type { StackedBarConfigInterface } from './components/stacked-bar/config'

--- a/packages/ts/src/components/donut/config.ts
+++ b/packages/ts/src/components/donut/config.ts
@@ -42,6 +42,12 @@ export interface DonutConfigInterface<Datum> extends ComponentConfigInterface {
   showBackground?: boolean;
   /** Background angle range. When undefined, the value will be taken from `angleRange`. Default: `undefined` */
   backgroundAngleRange?: [number, number];
+
+  /** Central label and sub-label horizontal offset in pixels. Default: `undefined` */
+  centralLabelOffsetX?: number;
+
+  /** Central label and sub-label vertical offset in pixels. Default: `undefined` */
+  centralLabelOffsetY?: number;
 }
 
 export const DonutDefaultConfig: DonutConfigInterface<unknown> = {
@@ -62,4 +68,6 @@ export const DonutDefaultConfig: DonutConfigInterface<unknown> = {
   emptySegmentAngle: 0.5 * Math.PI / 180,
   showBackground: true,
   backgroundAngleRange: undefined,
+  centralLabelOffsetX: undefined,
+  centralLabelOffsetY: undefined,
 }

--- a/packages/ts/src/components/donut/constants.ts
+++ b/packages/ts/src/components/donut/constants.ts
@@ -1,0 +1,11 @@
+export const DONUT_HALF_ANGLE_RANGES = Array.from({ length: 4 }, (_, i): [number, number] => {
+  const offset = -Math.PI / 2 + i * Math.PI / 2
+  return [offset, offset + Math.PI]
+})
+
+export const [
+  DONUT_HALF_ANGLE_RANGE_TOP,
+  DONUT_HALF_ANGLE_RANGE_RIGHT,
+  DONUT_HALF_ANGLE_RANGE_BOTTOM,
+  DONUT_HALF_ANGLE_RANGE_LEFT,
+] = DONUT_HALF_ANGLE_RANGES

--- a/packages/website/docs/misc/Donut.mdx
+++ b/packages/website/docs/misc/Donut.mdx
@@ -5,6 +5,12 @@ description: Learn how to configure a Donut chart
 import CodeBlock from '@theme/CodeBlock'
 import { PropsTable } from '@site/src/components/PropsTable'
 import { DocWrapper, InputWrapper } from '../wrappers'
+import {
+  DONUT_HALF_ANGLE_RANGE_TOP,
+  DONUT_HALF_ANGLE_RANGE_RIGHT,
+  DONUT_HALF_ANGLE_RANGE_BOTTOM,
+  DONUT_HALF_ANGLE_RANGE_LEFT
+} from '@unovis/ts'
 
 export const donutProps = () => ({
   name: "Donut",
@@ -27,11 +33,44 @@ the `centralSubLabelWrap` property to `false`), while the main label is supposed
   implemented.
 <DocWrapper {...donutProps()} centralLabel="Label" centralSubLabel="Long sub-label wraps onto the next line"/>
 
+### Label Position
+You can adjust the position of both the central label and sub-label using offset properties:
+
+#### Horizontal Offset
+Use `centralLabelOffsetX` to move the labels left or right (negative values move left, positive values move right):
+<DocWrapper {...donutProps()}
+  centralLabel="Offset Label"
+  centralSubLabel="Moved horizontally"
+  centralLabelOffsetX={20}
+/>
+
+#### Vertical Offset
+Use `centralLabelOffsetY` to move the labels up or down (negative values move up, positive values move down):
+<DocWrapper {...donutProps()}
+  centralLabel="Offset Label"
+  centralSubLabel="Moved vertically"
+  centralLabelOffsetY={-15}
+/>
+
+
+You can combine both offsets to position the labels exactly where you need them.
 
 ## Angle Range
 By default, a _Donut_ will populate values in the angle range `[0, 2π]`. You can adjust your _Donut_'s `angleRange` property to a `[a,b]` of type `[number, number]`
 where a[0] = the starting position and a[1] = the ending position (in radians). A common example might be when you want an incomplete/semi circle:
 <DocWrapper {...donutProps()} angleRange={[1, Math.PI]}/>
+
+### Half Donut Charts
+For convenience, Unovis provides preset angle ranges to create half donut charts in different orientations. You can import these constants from `@unovis/ts`:
+
+```ts
+import {
+  DONUT_HALF_ANGLE_RANGE_TOP,
+  DONUT_HALF_ANGLE_RANGE_RIGHT,
+  DONUT_HALF_ANGLE_RANGE_BOTTOM,
+  DONUT_HALF_ANGLE_RANGE_LEFT
+} from '@unovis/ts'
+```
 
 ## Sorting
 By default, each _segment_ is placed in order of appearance within your `data` array, from


### PR DESCRIPTION
Adds support for half donut including:

 * Scaling to fit the geometry in the container
 * Applying label offsets automatically if `centralLabelsOffsetY` and `centralLabelsOffsetX` are not defined

<img width="982" alt="image" src="https://github.com/user-attachments/assets/59b312be-367d-49f3-99d6-3877e9348bdf" />

<img width="984" alt="image" src="https://github.com/user-attachments/assets/8e0efb27-cd31-4120-9f4a-e4c3266e8750" />

<img width="980" alt="image" src="https://github.com/user-attachments/assets/02da24dd-4a70-4ddd-bb2e-78b36abcf840" />

<img width="985" alt="image" src="https://github.com/user-attachments/assets/823e0ab2-e54a-41c1-81dc-9c11e30994fd" />
