### PR TITLE
Website: Update website upload yml

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -34,7 +34,7 @@ jobs:
       - run: mv packages/website/build _site
       - run: cp _site/index.html _site/404.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The upload artifact version we use is deprecated: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/. This caused the CI pipeline to fail. 

Updated the version. 