### PR TITLE
Component | Tooltip: Add show/hide delay and improve hover behavior

### DIFF
--- a/packages/angular/src/components/line/line.component.ts
+++ b/packages/angular/src/components/line/line.component.ts
@@ -126,7 +126,7 @@ export class VisLineComponent<Datum> implements LineConfigInterface<Datum>, Afte
    * You can customize the line's appearance with `--vis-line-gapfill-stroke-dasharray`
    * and `--vis-line-gapfill-stroke-opacity` CSS variables.
    * Default: `false` */
-  @Input() interpolateMissingData: boolean
+  @Input() interpolateMissingData?: boolean
   @Input() data: Datum[]
 
   component: Line<Datum> | undefined

--- a/packages/angular/src/components/tooltip/tooltip.component.ts
+++ b/packages/angular/src/components/tooltip/tooltip.component.ts
@@ -16,12 +16,10 @@ export class VisTooltipComponent implements TooltipConfigInterface, AfterViewIni
   /** Container to where the Tooltip component should be inserted. Default: `undefined` */
   @Input() container?: HTMLElement
 
-  /** Follow the mouse cursor. If `true`, the tooltip can't be hovered over
-   * even when `allowHover` is set to `true`. Default: `true` */
+  /** Follow the mouse cursor. Default: `true` */
   @Input() followCursor?: boolean
 
-  /** Allow the tooltip to be hovered over and interacted with when `followCursor` is set to `false`.
-   * Default: `true` */
+  /** Allow the tooltip to be hovered over and interacted with. Default: `false` */
   @Input() allowHover?: boolean
 
   /** Horizontal placement of the tooltip. Default: `Position.Auto` */
@@ -80,6 +78,12 @@ export class VisTooltipComponent implements TooltipConfigInterface, AfterViewIni
   /** Custom class name for the tooltip. Default: `undefined` */
   @Input() className?: string
 
+  /** Hide delay in milliseconds. Default: `undefined` */
+  @Input() hideDelay?: number
+
+  /** Show delay in milliseconds. Default: `undefined` */
+  @Input() showDelay?: number
+
   component: Tooltip | undefined
   public componentContainer: ContainerCore | undefined
 
@@ -93,8 +97,8 @@ export class VisTooltipComponent implements TooltipConfigInterface, AfterViewIni
   }
 
   private getConfig (): TooltipConfigInterface {
-    const { components, container, followCursor, allowHover, horizontalPlacement, horizontalShift, verticalPlacement, verticalShift, triggers, attributes, className } = this
-    const config = { components, container, followCursor, allowHover, horizontalPlacement, horizontalShift, verticalPlacement, verticalShift, triggers, attributes, className }
+    const { components, container, followCursor, allowHover, horizontalPlacement, horizontalShift, verticalPlacement, verticalShift, triggers, attributes, className, hideDelay, showDelay } = this
+    const config = { components, container, followCursor, allowHover, horizontalPlacement, horizontalShift, verticalPlacement, verticalShift, triggers, attributes, className, hideDelay, showDelay }
     const keys = Object.keys(config) as (keyof TooltipConfigInterface)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/auxiliary/tooltip/tooltip-show-hide-delay/index.tsx
+++ b/packages/dev/src/examples/auxiliary/tooltip/tooltip-show-hide-delay/index.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo } from 'react'
+import { Scatter } from '@unovis/ts'
+import { VisXYContainer, VisScatter, VisTooltip } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { randomNumberGenerator } from '@src/utils/data'
+
+export const title = 'Tooltip Show & Hide Delay'
+export const subTitle = 'Follow cursor, hoverable'
+
+export const component = (props: ExampleViewerDurationProps): JSX.Element => {
+  const data = useMemo(() => Array.from({ length: 15 }, (_, i) => ({
+    x: i + 10 * randomNumberGenerator(),
+    y: randomNumberGenerator() * 10,
+    size: 50 * randomNumberGenerator(),
+  })), [])
+
+  type XYDataRecord = typeof data[0]
+  return (<>
+    <VisXYContainer<XYDataRecord> data={data} height={400} duration={props.duration}>
+      <VisScatter
+        x={(d: XYDataRecord) => d.x}
+        y={(d: XYDataRecord) => d.y}
+        size={d => d.size}
+        duration={props.duration}
+      />
+      <VisTooltip
+        followCursor={true}
+        allowHover={true}
+        verticalShift={0}
+        showDelay={100}
+        hideDelay={300}
+        triggers={{
+          [Scatter.selectors.point]: () => `
+              This tooltip follows the cursor,<br/> but you can hover over it
+          `,
+        }}
+      />
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/dev/src/examples/auxiliary/tooltip/tooltip-stick-position/index.tsx
+++ b/packages/dev/src/examples/auxiliary/tooltip/tooltip-stick-position/index.tsx
@@ -33,6 +33,7 @@ export const TooltipComponent = (props: VisTooltipDurationProps): JSX.Element =>
               You can hover over this tooltip
           `,
         }}
+        allowHover={true}
         {...props}
       />
       <VisAxis type='x' />

--- a/packages/ts/src/components/tooltip/config.ts
+++ b/packages/ts/src/components/tooltip/config.ts
@@ -9,11 +9,9 @@ export interface TooltipConfigInterface {
   components?: ComponentCore<unknown>[];
   /** Container to where the Tooltip component should be inserted. Default: `undefined` */
   container?: HTMLElement;
-  /** Follow the mouse cursor. If `true`, the tooltip can't be hovered over
-   * even when `allowHover` is set to `true`. Default: `true` */
+  /** Follow the mouse cursor. Default: `true` */
   followCursor?: boolean;
-  /** Allow the tooltip to be hovered over and interacted with when `followCursor` is set to `false`.
-   * Default: `true` */
+  /** Allow the tooltip to be hovered over and interacted with. Default: `false` */
   allowHover?: boolean;
   /** Horizontal placement of the tooltip. Default: `Position.Auto` */
   horizontalPlacement?: Position | string | undefined;
@@ -64,13 +62,17 @@ export interface TooltipConfigInterface {
   attributes?: { [attr: string]: string | number | boolean };
   /** Custom class name for the tooltip. Default: `undefined` */
   className?: string;
+  /** Hide delay in milliseconds. Default: `undefined` */
+  hideDelay?: number;
+  /** Show delay in milliseconds. Default: `undefined` */
+  showDelay?: number;
 }
 
 export const TooltipDefaultConfig: TooltipConfigInterface = {
   components: [],
   container: undefined,
   followCursor: true,
-  allowHover: true,
+  allowHover: false,
   horizontalPlacement: Position.Auto,
   horizontalShift: 0,
   verticalPlacement: Position.Top,
@@ -78,5 +80,7 @@ export const TooltipDefaultConfig: TooltipConfigInterface = {
   attributes: {},
   triggers: {},
   className: undefined,
+  showDelay: undefined,
+  hideDelay: undefined,
 }
 

--- a/packages/website/docs/auxiliary/Tooltip.mdx
+++ b/packages/website/docs/auxiliary/Tooltip.mdx
@@ -199,18 +199,28 @@ property to `false`.
 </BrowserOnly>
 
 ## Hoverable Content
-_Tooltip_'s content will become hoverable when you set the `followCursor` property to `false`.
+_Tooltip_'s content will become hoverable when you set the `allowHover` property to `true`.
 This will keep the content in view when hovering over the tooltip itself. This can be useful for interacting with
 text, links, or other elements in the tooltip. If you want to disable this behavior, you can set the `allowHover`
 property to `false`.
 
 Here is an example with a _Line_ chart a clickable link on hover:
 
-<Tooltip {...tooltipProps("Line", { lineWidth: 4 })}
-  followCursor={false}
+<Tooltip {...tooltipProps("Line", { lineWidth: 6 })}
+  allowHover={true}
   triggers={{
     "[Line.selectors.line]": () => 'Visit <a href="https://unovis.dev" target="_blank">our website</a>'
   }}/>
+
+## Display Delays
+You can control when the tooltip appears and disappears by setting delay timers:
+
+- `showDelay`: Adds a delay in milliseconds before the tooltip appears
+- `hideDelay`: Adds a delay in milliseconds before the tooltip disappears
+
+This is useful for preventing tooltip flicker when users quickly move their mouse across multiple elements, or to ensure the tooltip stays visible long enough to be read.
+
+<Tooltip {...tooltipProps("Line", { lineWidth: 6 })} showDelay={500} hideDelay={1000} triggers={{ "[Line.selectors.line]": () => 'This tooltip waits 500ms to appear and 1000ms to disappear' }}/>
 
 ## Manual Configuration
 


### PR DESCRIPTION
- Add `showDelay` and `hideDelay` config options to control tooltip timing
- ⚠️ Change default `allowHover` to `false` for better default behavior (we've introduced this feature recently so I find this small breaking change acceptable, though it's not a good practice)
- Fix hover behavior to work independently from `followCursor` setting
- Add internal timeout management for delayed show/hide
- Hide the tooltip on component initialization
- Clean up timeouts on tooltip destruction



https://github.com/user-attachments/assets/d1580e8b-777a-4ebc-a239-7c63ed059212


https://github.com/user-attachments/assets/f6bda592-2825-4bcb-bf6a-fa0fe0bd7e93



