### PR TITLE
fix: make fontSize optional

### DIFF
--- a/packages/ts/src/components/annotations/types.ts
+++ b/packages/ts/src/components/annotations/types.ts
@@ -1,9 +1,9 @@
-import { LengthUnit } from 'types/misc'
+import { LengthUnit, WithOptional } from 'types/misc'
 import { UnovisText, UnovisTextOptions } from 'types/text'
 
 
 export type AnnotationItem = Omit<UnovisTextOptions, 'x'|'y'|'width'> & {
-  content: string | UnovisText | UnovisText[];
+  content: string | WithOptional<UnovisText, 'fontSize'> | WithOptional<UnovisText, 'fontSize'>[];
   subject?: AnnotationSubject;
   x?: LengthUnit;
   y?: LengthUnit;

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -24,8 +24,8 @@ export enum TextAlign {
 export type UnovisText = {
   // The text content to be displayed.
   text: string;
-  // The font size of the text in pixels.
-  fontSize: number;
+  // The font size of the text in pixels (optional).
+  fontSize?: number;
   // The font family of the text (optional). Default: `'var(--vis-font-family)'`.
   fontFamily?: string;
   // The font weight of the text (optional)`.

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -24,8 +24,8 @@ export enum TextAlign {
 export type UnovisText = {
   // The text content to be displayed.
   text: string;
-  // The font size of the text in pixels (optional).
-  fontSize?: number;
+  // The font size of the text in pixels.
+  fontSize: number;
   // The font family of the text (optional). Default: `'var(--vis-font-family)'`.
   fontFamily?: string;
   // The font weight of the text (optional)`.

--- a/packages/website/docs/auxiliary/Annotations.mdx
+++ b/packages/website/docs/auxiliary/Annotations.mdx
@@ -157,7 +157,7 @@ type UnovisText = {
   // The text content to be displayed.
   text: string;
   // The font size of the text in pixels.
-  fontSize: number;
+  fontSize?: number;
   // The font family of the text.
   fontFamily?: string;
   // The font weight of the text.

--- a/packages/website/docs/auxiliary/Annotations.mdx
+++ b/packages/website/docs/auxiliary/Annotations.mdx
@@ -60,7 +60,7 @@ include **content** (the text) and an optional **subject** (the highlighted area
 ```ts
 type AnnotationItem = {
   // Base properties
-  content: string | UnovisText | UnovisText[];
+  content: string | WithOptional<UnovisText, 'fontSize'> | WithOptional<UnovisText, 'fontSize'>[];
   subject?: AnnotationSubject;
 
   // Position and size properties
@@ -157,7 +157,7 @@ type UnovisText = {
   // The text content to be displayed.
   text: string;
   // The font size of the text in pixels.
-  fontSize?: number;
+  fontSize: number;
   // The font family of the text.
   fontFamily?: string;
   // The font weight of the text.


### PR DESCRIPTION
[According to the docs](https://unovis.dev/docs/auxiliary/Annotations#styled-text), `fontSize` is an optional property. This should be reflected in the types as well.