### PR TITLE
Misc: Add script to update peerDependencies during bumpp

### DIFF
--- a/bump.config.ts
+++ b/bump.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   printCommits: false,
   ignoreScripts: true,
   recursive: true,
+  execute: 'sh update-peerDependencies.sh',
 })

--- a/update-peerDependencies.sh
+++ b/update-peerDependencies.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e  # Exit on error
+
+ROOT_PACKAGE_JSON="package.json"
+
+# Get the current version from the root package.json
+CURRENT_VERSION=$(node -e "console.log(require('./$ROOT_PACKAGE_JSON').version)")
+
+# If the version is empty, exit with an error
+if [[ -z "$CURRENT_VERSION" ]]; then
+    echo "Error: Could not determine the current version from $ROOT_PACKAGE_JSON"
+    exit 1
+fi
+
+echo "Current version is $CURRENT_VERSION"
+
+perl -pi -e "s/\"\@unovis\/ts\": \"(?!\*).*?\"/\"\@unovis\/ts\": \"${CURRENT_VERSION}\"/g" packages/*/package.json
+
+# Reinstall dependencies silently
+npm install --ignore-scripts --silent
+
+echo "Updated peerDependencies @unovis/ts to version $CURRENT_VERSION in all child package.json files under packages."


### PR DESCRIPTION
The peerDependencies don't get updated automatically after the [bumpp integration](https://github.com/f5/unovis/pull/489/files). 

This fix added a script to run as part of bumpp to fix the issue. 

To test: run `npm run version` and see if all version fields are updated, including peerDependencies in all related package.json files. 

Cc @50rayn @rokotyan 