### PR TITLE
TS: Replacing deprecated JSX.Element with React.ReactNode

### DIFF
--- a/packages/react/autogen/component.ts
+++ b/packages/react/autogen/component.ts
@@ -23,7 +23,7 @@ export function getComponentCode (
     c.destroy()
   }`
   return `// !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 ${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n')}
 
 // Utils
@@ -40,7 +40,7 @@ export type Vis${componentName}Props${genericsDefStr} = ${componentName}ConfigIn
 export const Vis${componentName}Selectors = ${componentName}.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function Vis${componentName}FC${genericsDefStr} (props: Vis${componentName}Props${genericsStr}, fRef: ForwardedRef<Vis${componentName}Ref${genericsStr}>): JSX.Element {
+function Vis${componentName}FC${genericsDefStr} (props: Vis${componentName}Props${genericsStr}, fRef: ForwardedRef<Vis${componentName}Ref${genericsStr}>): ReactElement {
   const ref = useRef<${refType}>(null)
   const ${isStandAlone ? `[component, setComponent] = useState<${componentType}>()` : `componentRef = useRef<${componentType} | undefined>(undefined)`}
 
@@ -54,7 +54,7 @@ function Vis${componentName}FC${genericsDefStr} (props: Vis${componentName}Props
     'componentRef.current = c',
     'element.__component__ = c',
   ]).join('\n  ')}
-  
+
     return () => ${onDestroy}
   }, [])
 

--- a/packages/react/src/components/annotations/index.tsx
+++ b/packages/react/src/components/annotations/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Annotations, AnnotationsConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -19,7 +19,7 @@ export type VisAnnotationsProps = AnnotationsConfigInterface & {
 export const VisAnnotationsSelectors = Annotations.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisAnnotationsFC (props: VisAnnotationsProps, fRef: ForwardedRef<VisAnnotationsRef>): JSX.Element {
+function VisAnnotationsFC (props: VisAnnotationsProps, fRef: ForwardedRef<VisAnnotationsRef>): ReactElement {
   const ref = useRef<VisComponentElement<Annotations>>(null)
   const componentRef = useRef<Annotations | undefined>(undefined)
 

--- a/packages/react/src/components/area/index.tsx
+++ b/packages/react/src/components/area/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Area, AreaConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisAreaProps<Datum> = AreaConfigInterface<Datum> & {
 export const VisAreaSelectors = Area.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisAreaFC<Datum> (props: VisAreaProps<Datum>, fRef: ForwardedRef<VisAreaRef<Datum>>): JSX.Element {
+function VisAreaFC<Datum> (props: VisAreaProps<Datum>, fRef: ForwardedRef<VisAreaRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Area<Datum>>>(null)
   const componentRef = useRef<Area<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/axis/index.tsx
+++ b/packages/react/src/components/axis/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Axis, AxisConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisAxisProps<Datum> = AxisConfigInterface<Datum> & {
 export const VisAxisSelectors = Axis.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisAxisFC<Datum> (props: VisAxisProps<Datum>, fRef: ForwardedRef<VisAxisRef<Datum>>): JSX.Element {
+function VisAxisFC<Datum> (props: VisAxisProps<Datum>, fRef: ForwardedRef<VisAxisRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Axis<Datum>>>(null)
   const componentRef = useRef<Axis<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/brush/index.tsx
+++ b/packages/react/src/components/brush/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Brush, BrushConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisBrushProps<Datum> = BrushConfigInterface<Datum> & {
 export const VisBrushSelectors = Brush.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisBrushFC<Datum> (props: VisBrushProps<Datum>, fRef: ForwardedRef<VisBrushRef<Datum>>): JSX.Element {
+function VisBrushFC<Datum> (props: VisBrushProps<Datum>, fRef: ForwardedRef<VisBrushRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Brush<Datum>>>(null)
   const componentRef = useRef<Brush<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/chord-diagram/index.tsx
+++ b/packages/react/src/components/chord-diagram/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { ChordDiagram, ChordDiagramConfigInterface, ChordInputNode, ChordInputLink } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisChordDiagramProps<N extends ChordInputNode, L extends ChordInputL
 export const VisChordDiagramSelectors = ChordDiagram.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisChordDiagramFC<N extends ChordInputNode, L extends ChordInputLink> (props: VisChordDiagramProps<N, L>, fRef: ForwardedRef<VisChordDiagramRef<N, L>>): JSX.Element {
+function VisChordDiagramFC<N extends ChordInputNode, L extends ChordInputLink> (props: VisChordDiagramProps<N, L>, fRef: ForwardedRef<VisChordDiagramRef<N, L>>): ReactElement {
   const ref = useRef<VisComponentElement<ChordDiagram<N, L>>>(null)
   const componentRef = useRef<ChordDiagram<N, L> | undefined>(undefined)
 

--- a/packages/react/src/components/crosshair/index.tsx
+++ b/packages/react/src/components/crosshair/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Crosshair, CrosshairConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisCrosshairProps<Datum> = CrosshairConfigInterface<Datum> & {
 export const VisCrosshairSelectors = Crosshair.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisCrosshairFC<Datum> (props: VisCrosshairProps<Datum>, fRef: ForwardedRef<VisCrosshairRef<Datum>>): JSX.Element {
+function VisCrosshairFC<Datum> (props: VisCrosshairProps<Datum>, fRef: ForwardedRef<VisCrosshairRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Crosshair<Datum>>>(null)
   const componentRef = useRef<Crosshair<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/donut/index.tsx
+++ b/packages/react/src/components/donut/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Donut, DonutConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisDonutProps<Datum> = DonutConfigInterface<Datum> & {
 export const VisDonutSelectors = Donut.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisDonutFC<Datum> (props: VisDonutProps<Datum>, fRef: ForwardedRef<VisDonutRef<Datum>>): JSX.Element {
+function VisDonutFC<Datum> (props: VisDonutProps<Datum>, fRef: ForwardedRef<VisDonutRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Donut<Datum>>>(null)
   const componentRef = useRef<Donut<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/free-brush/index.tsx
+++ b/packages/react/src/components/free-brush/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { FreeBrush, FreeBrushConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisFreeBrushProps<Datum> = FreeBrushConfigInterface<Datum> & {
 export const VisFreeBrushSelectors = FreeBrush.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisFreeBrushFC<Datum> (props: VisFreeBrushProps<Datum>, fRef: ForwardedRef<VisFreeBrushRef<Datum>>): JSX.Element {
+function VisFreeBrushFC<Datum> (props: VisFreeBrushProps<Datum>, fRef: ForwardedRef<VisFreeBrushRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<FreeBrush<Datum>>>(null)
   const componentRef = useRef<FreeBrush<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/graph/index.tsx
+++ b/packages/react/src/components/graph/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Graph, GraphConfigInterface, GraphInputNode, GraphInputLink } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisGraphProps<N extends GraphInputNode, L extends GraphInputLink> = 
 export const VisGraphSelectors = Graph.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisGraphFC<N extends GraphInputNode, L extends GraphInputLink> (props: VisGraphProps<N, L>, fRef: ForwardedRef<VisGraphRef<N, L>>): JSX.Element {
+function VisGraphFC<N extends GraphInputNode, L extends GraphInputLink> (props: VisGraphProps<N, L>, fRef: ForwardedRef<VisGraphRef<N, L>>): ReactElement {
   const ref = useRef<VisComponentElement<Graph<N, L>>>(null)
   const componentRef = useRef<Graph<N, L> | undefined>(undefined)
 

--- a/packages/react/src/components/grouped-bar/index.tsx
+++ b/packages/react/src/components/grouped-bar/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { GroupedBar, GroupedBarConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisGroupedBarProps<Datum> = GroupedBarConfigInterface<Datum> & {
 export const VisGroupedBarSelectors = GroupedBar.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisGroupedBarFC<Datum> (props: VisGroupedBarProps<Datum>, fRef: ForwardedRef<VisGroupedBarRef<Datum>>): JSX.Element {
+function VisGroupedBarFC<Datum> (props: VisGroupedBarProps<Datum>, fRef: ForwardedRef<VisGroupedBarRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<GroupedBar<Datum>>>(null)
   const componentRef = useRef<GroupedBar<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/line/index.tsx
+++ b/packages/react/src/components/line/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Line, LineConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisLineProps<Datum> = LineConfigInterface<Datum> & {
 export const VisLineSelectors = Line.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisLineFC<Datum> (props: VisLineProps<Datum>, fRef: ForwardedRef<VisLineRef<Datum>>): JSX.Element {
+function VisLineFC<Datum> (props: VisLineProps<Datum>, fRef: ForwardedRef<VisLineRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Line<Datum>>>(null)
   const componentRef = useRef<Line<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/nested-donut/index.tsx
+++ b/packages/react/src/components/nested-donut/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { NestedDonut, NestedDonutConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisNestedDonutProps<Datum> = NestedDonutConfigInterface<Datum> & {
 export const VisNestedDonutSelectors = NestedDonut.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisNestedDonutFC<Datum> (props: VisNestedDonutProps<Datum>, fRef: ForwardedRef<VisNestedDonutRef<Datum>>): JSX.Element {
+function VisNestedDonutFC<Datum> (props: VisNestedDonutProps<Datum>, fRef: ForwardedRef<VisNestedDonutRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<NestedDonut<Datum>>>(null)
   const componentRef = useRef<NestedDonut<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/sankey/index.tsx
+++ b/packages/react/src/components/sankey/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Sankey, SankeyConfigInterface, SankeyInputNode, SankeyInputLink } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisSankeyProps<N extends SankeyInputNode, L extends SankeyInputLink>
 export const VisSankeySelectors = Sankey.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisSankeyFC<N extends SankeyInputNode, L extends SankeyInputLink> (props: VisSankeyProps<N, L>, fRef: ForwardedRef<VisSankeyRef<N, L>>): JSX.Element {
+function VisSankeyFC<N extends SankeyInputNode, L extends SankeyInputLink> (props: VisSankeyProps<N, L>, fRef: ForwardedRef<VisSankeyRef<N, L>>): ReactElement {
   const ref = useRef<VisComponentElement<Sankey<N, L>>>(null)
   const componentRef = useRef<Sankey<N, L> | undefined>(undefined)
 

--- a/packages/react/src/components/scatter/index.tsx
+++ b/packages/react/src/components/scatter/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Scatter, ScatterConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisScatterProps<Datum> = ScatterConfigInterface<Datum> & {
 export const VisScatterSelectors = Scatter.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisScatterFC<Datum> (props: VisScatterProps<Datum>, fRef: ForwardedRef<VisScatterRef<Datum>>): JSX.Element {
+function VisScatterFC<Datum> (props: VisScatterProps<Datum>, fRef: ForwardedRef<VisScatterRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Scatter<Datum>>>(null)
   const componentRef = useRef<Scatter<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/stacked-bar/index.tsx
+++ b/packages/react/src/components/stacked-bar/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { StackedBar, StackedBarConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisStackedBarProps<Datum> = StackedBarConfigInterface<Datum> & {
 export const VisStackedBarSelectors = StackedBar.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisStackedBarFC<Datum> (props: VisStackedBarProps<Datum>, fRef: ForwardedRef<VisStackedBarRef<Datum>>): JSX.Element {
+function VisStackedBarFC<Datum> (props: VisStackedBarProps<Datum>, fRef: ForwardedRef<VisStackedBarRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<StackedBar<Datum>>>(null)
   const componentRef = useRef<StackedBar<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/timeline/index.tsx
+++ b/packages/react/src/components/timeline/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Timeline, TimelineConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisTimelineProps<Datum> = TimelineConfigInterface<Datum> & {
 export const VisTimelineSelectors = Timeline.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisTimelineFC<Datum> (props: VisTimelineProps<Datum>, fRef: ForwardedRef<VisTimelineRef<Datum>>): JSX.Element {
+function VisTimelineFC<Datum> (props: VisTimelineProps<Datum>, fRef: ForwardedRef<VisTimelineRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<Timeline<Datum>>>(null)
   const componentRef = useRef<Timeline<Datum> | undefined>(undefined)
 

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { Tooltip, TooltipConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -19,7 +19,7 @@ export type VisTooltipProps = TooltipConfigInterface & {
 export const VisTooltipSelectors = Tooltip.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisTooltipFC (props: VisTooltipProps, fRef: ForwardedRef<VisTooltipRef>): JSX.Element {
+function VisTooltipFC (props: VisTooltipProps, fRef: ForwardedRef<VisTooltipRef>): ReactElement {
   const ref = useRef<VisComponentElement<Tooltip>>(null)
   const componentRef = useRef<Tooltip | undefined>(undefined)
 

--- a/packages/react/src/components/topojson-map/index.tsx
+++ b/packages/react/src/components/topojson-map/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { TopoJSONMap, TopoJSONMapConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisTopoJSONMapProps<AreaDatum, PointDatum, LinkDatum> = TopoJSONMapC
 export const VisTopoJSONMapSelectors = TopoJSONMap.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisTopoJSONMapFC<AreaDatum, PointDatum, LinkDatum> (props: VisTopoJSONMapProps<AreaDatum, PointDatum, LinkDatum>, fRef: ForwardedRef<VisTopoJSONMapRef<AreaDatum, PointDatum, LinkDatum>>): JSX.Element {
+function VisTopoJSONMapFC<AreaDatum, PointDatum, LinkDatum> (props: VisTopoJSONMapProps<AreaDatum, PointDatum, LinkDatum>, fRef: ForwardedRef<VisTopoJSONMapRef<AreaDatum, PointDatum, LinkDatum>>): ReactElement {
   const ref = useRef<VisComponentElement<TopoJSONMap<AreaDatum, PointDatum, LinkDatum>>>(null)
   const componentRef = useRef<TopoJSONMap<AreaDatum, PointDatum, LinkDatum> | undefined>(undefined)
 

--- a/packages/react/src/components/xy-labels/index.tsx
+++ b/packages/react/src/components/xy-labels/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { XYLabels, XYLabelsConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -20,7 +20,7 @@ export type VisXYLabelsProps<Datum> = XYLabelsConfigInterface<Datum> & {
 export const VisXYLabelsSelectors = XYLabels.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisXYLabelsFC<Datum> (props: VisXYLabelsProps<Datum>, fRef: ForwardedRef<VisXYLabelsRef<Datum>>): JSX.Element {
+function VisXYLabelsFC<Datum> (props: VisXYLabelsProps<Datum>, fRef: ForwardedRef<VisXYLabelsRef<Datum>>): ReactElement {
   const ref = useRef<VisComponentElement<XYLabels<Datum>>>(null)
   const componentRef = useRef<XYLabels<Datum> | undefined>(undefined)
 

--- a/packages/react/src/html-components/bullet-legend/index.tsx
+++ b/packages/react/src/html-components/bullet-legend/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { BulletLegend, BulletLegendConfigInterface } from '@unovis/ts'
 
 // Utils
@@ -17,7 +17,7 @@ export type VisBulletLegendProps = BulletLegendConfigInterface & {
 export const VisBulletLegendSelectors = BulletLegend.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisBulletLegendFC (props: VisBulletLegendProps, fRef: ForwardedRef<VisBulletLegendRef>): JSX.Element {
+function VisBulletLegendFC (props: VisBulletLegendProps, fRef: ForwardedRef<VisBulletLegendRef>): ReactElement {
   const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<BulletLegend>()
 
@@ -34,7 +34,7 @@ function VisBulletLegendFC (props: VisBulletLegendProps, fRef: ForwardedRef<VisB
     component?.update(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
   return <div className={props.className} ref={ref} />
 }
 

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { LeafletFlowMap, LeafletFlowMapConfigInterface, GenericDataRecord } from '@unovis/ts'
 
 // Utils
@@ -18,7 +18,7 @@ export type VisLeafletFlowMapProps<PointDatum extends GenericDataRecord, FlowDat
 export const VisLeafletFlowMapSelectors = LeafletFlowMap.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisLeafletFlowMapFC<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> (props: VisLeafletFlowMapProps<PointDatum, FlowDatum>, fRef: ForwardedRef<VisLeafletFlowMapRef<PointDatum, FlowDatum>>): JSX.Element {
+function VisLeafletFlowMapFC<PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord> (props: VisLeafletFlowMapProps<PointDatum, FlowDatum>, fRef: ForwardedRef<VisLeafletFlowMapRef<PointDatum, FlowDatum>>): ReactElement {
   const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<LeafletFlowMap<PointDatum, FlowDatum>>()
 
@@ -36,7 +36,7 @@ function VisLeafletFlowMapFC<PointDatum extends GenericDataRecord, FlowDatum ext
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
   return <div className={props.className} ref={ref} />
 }
 

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -1,5 +1,5 @@
 // !!! This code was automatically generated. You should not change it !!!
-import React, { ForwardedRef, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
+import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
 import { LeafletMap, LeafletMapConfigInterface, GenericDataRecord } from '@unovis/ts'
 
 // Utils
@@ -18,7 +18,7 @@ export type VisLeafletMapProps<Datum extends GenericDataRecord> = LeafletMapConf
 export const VisLeafletMapSelectors = LeafletMap.selectors
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function VisLeafletMapFC<Datum extends GenericDataRecord> (props: VisLeafletMapProps<Datum>, fRef: ForwardedRef<VisLeafletMapRef<Datum>>): JSX.Element {
+function VisLeafletMapFC<Datum extends GenericDataRecord> (props: VisLeafletMapProps<Datum>, fRef: ForwardedRef<VisLeafletMapRef<Datum>>): ReactElement {
   const ref = useRef<HTMLDivElement>(null)
   const [component, setComponent] = useState<LeafletMap<Datum>>()
 
@@ -36,7 +36,7 @@ function VisLeafletMapFC<Datum extends GenericDataRecord> (props: VisLeafletMapP
     component?.setConfig(props)
   })
 
-  useImperativeHandle(fRef, () => ({ get component () { return component } }), [component])
+  useImperativeHandle(fRef, () => ({ get component () { return component } }), [])
   return <div className={props.className} ref={ref} />
 }
 


### PR DESCRIPTION
Noticed that #538 was replaced `JSX.Element` with `React.ReactNode`.  But the generated components from _ts_ folder still has `React.ReactNode`.