### PR TITLE
Component | Area: Different min height implementation

### DIFF
--- a/packages/angular/src/components/area/area.component.ts
+++ b/packages/angular/src/components/area/area.component.ts
@@ -111,11 +111,14 @@ export class VisAreaComponent<Datum> implements AreaConfigInterface<Datum>, Afte
   /** Optional area cursor. String or accessor function. Default: `null` */
   @Input() cursor?: StringAccessor<Datum[]>
 
-  /** If an area is smaller than 1px, extend it to have 1px height.
+  /** If an area is smaller than 1px, extend it to have 1px height. Default: `false` */
+  @Input() minHeight1Px?: boolean
+
+  /** Minimum height of the area, use carefully.
    * This setting is useful when some of the area values are zeros or very small so visually they become
    * practically invisible, but you want to show that the data behind them exists and they're not just empty segments.
-   * Default: `false` */
-  @Input() minHeight1Px?: boolean
+   * Default: `undefined` */
+  @Input() minHeight?: number
   @Input() data: Datum[]
 
   component: Area<Datum> | undefined
@@ -137,8 +140,8 @@ export class VisAreaComponent<Datum> implements AreaConfigInterface<Datum>, Afte
   }
 
   private getConfig (): AreaConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, curveType, baseline, opacity, cursor, minHeight1Px } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, curveType, baseline, opacity, cursor, minHeight1Px }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, curveType, baseline, opacity, cursor, minHeight1Px, minHeight } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, curveType, baseline, opacity, cursor, minHeight1Px, minHeight }
     const keys = Object.keys(config) as (keyof AreaConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/area/min-height-area/index.tsx
+++ b/packages/dev/src/examples/xy-components/area/min-height-area/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { VisXYContainer, VisArea, VisAxis } from '@unovis/react'
+
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Area Min Height'
+export const subTitle = 'Negative stacking'
+export const component = (props: ExampleViewerDurationProps): React.ReactElement => {
+  const accessors = [
+    (d: XYDataRecord) => d.y,
+    (d: XYDataRecord) => d.y1,
+    (d: XYDataRecord) => d.y2,
+  ]
+
+  // Generate data with some very small values
+  const data = generateXYDataRecords(15).map((d, i) => ({
+    ...d,
+    y: i > 3 ? -0.0001 : -d.y, // Make some values very small
+    y1: i > 4 ? -0.0001 : -(d.y1 ?? 0),
+    y2: i > 5 ? -0.0001 : -(d.y2 ?? 0),
+  }))
+
+  return (
+    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }}>
+      <VisArea
+        x={d => d.x}
+        y={accessors}
+        duration={props.duration}
+        minHeight={5} // Set minimum height
+      />
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
+    </VisXYContainer>
+  )
+}

--- a/packages/ts/src/components/area/config.ts
+++ b/packages/ts/src/components/area/config.ts
@@ -15,11 +15,15 @@ export interface AreaConfigInterface<Datum> extends XYComponentConfigInterface<D
   opacity?: NumericAccessor<Datum[]>;
   /** Optional area cursor. String or accessor function. Default: `null` */
   cursor?: StringAccessor<Datum[]>;
-  /** If an area is smaller than 1px, extend it to have 1px height.
+  /** If an area is smaller than 1px, extend it to have 1px height. Default: `false`
+   * @deprecated Use minHeight instead
+   */
+  minHeight1Px?: boolean;
+  /** Minimum height of the area, use carefully.
    * This setting is useful when some of the area values are zeros or very small so visually they become
    * practically invisible, but you want to show that the data behind them exists and they're not just empty segments.
-   * Default: `false` */
-  minHeight1Px?: boolean;
+   * Default: `undefined` */
+  minHeight?: number;
 }
 
 export const AreaDefaultConfig: AreaConfigInterface<unknown> = {
@@ -30,4 +34,5 @@ export const AreaDefaultConfig: AreaConfigInterface<unknown> = {
   opacity: 1,
   cursor: null,
   minHeight1Px: false,
+  minHeight: undefined,
 }

--- a/packages/ts/src/components/area/index.ts
+++ b/packages/ts/src/components/area/index.ts
@@ -53,10 +53,7 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
     this._areaGen = area<AreaDatum>()
       .x(d => d.x)
       .y0(d => d.y0)
-      .y1(d => {
-        const isSmallerThanPixel = Math.abs(d.y1 - d.y0) < 1
-        return d.y1 - ((isSmallerThanPixel && config.minHeight1Px) ? 1 : 0)
-      })
+      .y1(d => d.y1)
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       .curve(curveGen)
@@ -66,13 +63,34 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
 
     const stacked = getStackedData(data, config.baseline, yAccessors, this._prevNegative)
     this._prevNegative = stacked.map(s => !!s.isMostlyNegative)
+    const minHeightCumulativeArray: number[] = []
     const stackedData: AreaDatum[][] = stacked.map(
       arr => arr.map(
-        (d, j) => ({
-          y0: this.yScale(d[0]),
-          y1: this.yScale(d[1]),
-          x: areaDataX[j],
-        })
+        (d, j) => {
+          const x = areaDataX[j]
+          const y0 = this.yScale(d[0])
+          const y1 = this.yScale(d[1])
+          const isNegativeArea = y1 > y0
+
+          // Get cumulative adjustment and apply in the correct direction
+          const cumulative = minHeightCumulativeArray[j] || 0
+          const adjustedY0 = isNegativeArea ? y0 + cumulative : y0 - cumulative
+          const adjustedY1 = isNegativeArea ? y1 + cumulative : y1 - cumulative
+
+          // Calculate height adjustment if needed
+          let heightAdjustment = 0
+          if ((config.minHeight || config.minHeight1Px) &&
+              Math.abs(adjustedY1 - adjustedY0) < (config.minHeight ?? 1)) {
+            heightAdjustment = (config.minHeight ?? 1) - Math.abs(adjustedY1 - adjustedY0)
+            minHeightCumulativeArray[j] = cumulative + heightAdjustment
+          }
+
+          return {
+            x,
+            y0: adjustedY0,
+            y1: isNegativeArea ? adjustedY1 + heightAdjustment : adjustedY1 - heightAdjustment,
+          }
+        }
       )
     )
 

--- a/packages/website/docs/xy-charts/Area.mdx
+++ b/packages/website/docs/xy-charts/Area.mdx
@@ -58,11 +58,11 @@ accessor. A common configuration is to utilize the data's index:
 <XYWrapper {...areaProps()} showContext="full" y={[(d) => d.y, (d) => d.y1, (d) => d.y2]} color={(d, i) => ['red', 'green', 'blue'][i]}/>
 
 ## Dealing with small values
-If your data has small or zero values leading to some parts of the area to become invisible, you can force those area segments to have 1px height
-despite their actual value by setting `minHeight1Px` to `true`. This can be useful if you want to visually emphasize that the data behind the chart
-is defined but just very small.
+If your data has small or zero values leading to some parts of the area to become invisible, you can use the `minHeight` property to set a minimum height for the area. This can be useful if you want to visually emphasize that the data behind the chart is defined but just very small.
 
-<XYWrapperWithInput {...areaProps()}  y={[(d) => d.y < 9 ? 0 : d.y]} property="minHeight1Px" inputType="checkbox" defaultValue={true} showAxes/>
+> **Note:** Use the `minHeight` property carefully as it modifies the visual representation of the data without changing the underlying values. The Crosshair component will still show circles at the original data values, not at the visually extended area height.
+
+<XYWrapperWithInput {...areaProps()}  y={[(d) => d.y < 9 ? 0 : d.y]} property="minHeight" inputType="number" defaultValue={1} showAxes/>
 
 ## Events
 


### PR DESCRIPTION
New `minHeight` config, deprecating `minHeight1Px`.

- Introduced `minHeight` property for minimum area height, defaulting to undefined.
- Updated area generation logic to accommodate new `minHeight` configuration.
- Deprecated `minHeight1Px` in favor of `minHeight` for better clarity and functionality.

### Dev Example
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/8480c092-87fd-45df-a3e3-da6f75729a7b" />

### Updated Docs:
<img width="1363" alt="SCR-20250408-ijic" src="https://github.com/user-attachments/assets/6aecf1a0-b5e9-4d9b-9cdf-cfc0de34b385" />
