### PR TITLE
Component | Graph: More Link Particle Flow and Fit View controls

### DIFF
--- a/packages/angular/src/components/graph/graph.component.ts
+++ b/packages/angular/src/components/graph/graph.component.ts
@@ -8,6 +8,8 @@ import {
   GraphInputLink,
   VisEventType,
   VisEventCallback,
+  Spacing,
+  GraphFitViewAlignment,
   GraphLayoutType,
   StringAccessor,
   GraphForceLayoutSettings,
@@ -113,6 +115,12 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   /** Interval to re-render the graph when zooming. Default: `100` */
   @Input() zoomThrottledUpdateNodeThreshold?: number
 
+  /** Padding for the graph when fitting to container. Default: `50` */
+  @Input() fitViewPadding?: Spacing | number
+
+  /** Default alignment when fitting the graph view. Default: `GraphFitViewAlignment.Center` */
+  @Input() fitViewAlign?: GraphFitViewAlignment
+
   /** Type of the graph layout. Default: `GraphLayoutType.Force` */
   @Input() layoutType?: GraphLayoutType | string
 
@@ -210,11 +218,15 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   /** Link flow animation accessor function or constant value. Default: `false` */
   @Input() linkFlow?: BooleanAccessor<L>
 
-  /** Animation duration of the flow (traffic) circles. Default: `20000` */
-  @Input() linkFlowAnimDuration?: number
+  /** Animation duration of the flow (traffic) circles in milliseconds. If `linkFlowParticleSpeed` is provided,
+   * this duration will be calculated based on the link length and particle speed. Default: `20000` */
+  @Input() linkFlowAnimDuration?: NumericAccessor<L>
 
   /** Size of the moving particles that represent traffic flow. Default: `2` */
-  @Input() linkFlowParticleSize?: number
+  @Input() linkFlowParticleSize?: NumericAccessor<L>
+
+  /** Speed of the moving particles in pixels per second. This property takes precedence over `linkFlowAnimDuration`. Default: `undefined` */
+  @Input() linkFlowParticleSpeed?: NumericAccessor<L>
 
   /** Link label accessor function or constant value. Default: `undefined` */
   @Input() linkLabel?: GenericAccessor<GraphCircleLabel | GraphCircleLabel[], L> | undefined
@@ -411,8 +423,8 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   }
 
   private getConfig (): GraphConfigInterface<N, L> {
-    const { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate } = this
-    const config = { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate }
+    const { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate } = this
+    const config = { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate }
     const keys = Object.keys(config) as (keyof GraphConfigInterface<N, L>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react'
-import type { GraphLink, GraphNode } from '@unovis/ts'
+import { GraphFitViewAlignment, GraphLink, GraphNode } from '@unovis/ts'
 import type { VisGraphRef } from '@unovis/react'
 
 import { CustomGraph } from './component'
@@ -13,6 +13,7 @@ export const subTitle = 'User provided rendering functions'
 
 export const component = (): JSX.Element => {
   const [showLinkFlow, setShowLinkFlow] = useState(true)
+  const [fitViewAlignment, setFitViewAlignment] = useState<GraphFitViewAlignment>(GraphFitViewAlignment.Center)
   const graphRef = useRef<VisGraphRef<CustomGraphNode, CustomGraphLink> | null>(null)
 
   const nodes: CustomGraphNode[] = useMemo(() => ([
@@ -66,6 +67,8 @@ export const component = (): JSX.Element => {
         linkFlowParticleSize={useCallback((l: CustomGraphLink) => l.linkFlowParticleSize, [])}
         linkWidth={0}
         linkBandWidth={useCallback((l: CustomGraphLink) => 2 * (l.linkFlowParticleSize ?? 1), [])}
+        fitViewAlign={fitViewAlignment}
+        fitViewPadding={useMemo(() => ({ top: 50, right: 50, bottom: 100, left: 50 }), [])}
       />
       <div className={s.checkboxContainer}>
         <label>
@@ -76,6 +79,17 @@ export const component = (): JSX.Element => {
           />
           Show Link Flow
         </label>
+        <select
+          value={fitViewAlignment}
+          onChange={(e) => setFitViewAlignment(e.target.value as GraphFitViewAlignment)}
+          className={s.graphButton}
+        >
+          {Object.values(GraphFitViewAlignment).map((alignment) => (
+            <option key={alignment} value={alignment}>
+              {alignment.charAt(0).toUpperCase() + alignment.slice(1)}
+            </option>
+          ))}
+        </select>
         <button className={s.graphButton} onClick={() => fitView(['0', '1', '2', '3'])}>Zoom To Identity and Network Nodes</button>
         <button className={s.graphButton} onClick={() => fitView()}>Fit Graph</button>
       </div>

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
@@ -35,11 +35,11 @@ export const component = (): JSX.Element => {
   ]), [])
 
   const links: CustomGraphLink[] = useMemo(() => ([
-    { source: '0', target: '1', showFlow: true },
-    { source: '0', target: '2', showFlow: true },
-    { source: '0', target: '3', showFlow: true },
-    { source: '0', target: '4', showFlow: true },
-    { source: '1', target: '5', showFlow: true },
+    { source: '0', target: '1', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 1.5 },
+    { source: '0', target: '2', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 2 },
+    { source: '0', target: '3', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 3 },
+    { source: '0', target: '4', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 3 },
+    { source: '1', target: '5', showFlow: true, linkFlowAnimDuration: 5000, linkFlowParticleSize: 2.5 },
   ]), [])
 
   // Modifying layout after the calculation
@@ -61,7 +61,8 @@ export const component = (): JSX.Element => {
         height={'100vh'}
         linkFlow={useCallback((l: CustomGraphLink) => showLinkFlow && l.showFlow, [showLinkFlow])}
         onLayoutCalculated={onLayoutCalculated}
-
+        linkFlowAnimDuration={useCallback((l: CustomGraphLink) => l.linkFlowAnimDuration, [])}
+        linkFlowParticleSize={useCallback((l: CustomGraphLink) => l.linkFlowParticleSize, [])}
       />
       <div className={s.checkboxContainer}>
         <label>

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/index.tsx
@@ -35,11 +35,11 @@ export const component = (): JSX.Element => {
   ]), [])
 
   const links: CustomGraphLink[] = useMemo(() => ([
-    { source: '0', target: '1', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 1.5 },
-    { source: '0', target: '2', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 2 },
-    { source: '0', target: '3', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 3 },
-    { source: '0', target: '4', showFlow: true, linkFlowAnimDuration: 10000, linkFlowParticleSize: 3 },
-    { source: '1', target: '5', showFlow: true, linkFlowAnimDuration: 5000, linkFlowParticleSize: 2.5 },
+    { source: '0', target: '1', showFlow: true, linkFlowParticleSize: 1.5, linkFlowParticleSpeed: 15 },
+    { source: '0', target: '2', showFlow: true, linkFlowParticleSize: 2, linkFlowParticleSpeed: 25 },
+    { source: '0', target: '3', showFlow: true, linkFlowParticleSize: 3, linkFlowParticleSpeed: 10 },
+    { source: '0', target: '4', showFlow: true, linkFlowParticleSize: 3, linkFlowParticleSpeed: 30 },
+    { source: '1', target: '5', showFlow: true, linkFlowParticleSize: 2.5, linkFlowParticleSpeed: 20 },
   ]), [])
 
   // Modifying layout after the calculation
@@ -62,7 +62,10 @@ export const component = (): JSX.Element => {
         linkFlow={useCallback((l: CustomGraphLink) => showLinkFlow && l.showFlow, [showLinkFlow])}
         onLayoutCalculated={onLayoutCalculated}
         linkFlowAnimDuration={useCallback((l: CustomGraphLink) => l.linkFlowAnimDuration, [])}
+        linkFlowParticleSpeed={useCallback((l: CustomGraphLink) => l.linkFlowParticleSpeed, [])}
         linkFlowParticleSize={useCallback((l: CustomGraphLink) => l.linkFlowParticleSize, [])}
+        linkWidth={0}
+        linkBandWidth={useCallback((l: CustomGraphLink) => 2 * (l.linkFlowParticleSize ?? 1), [])}
       />
       <div className={s.checkboxContainer}>
         <label>

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/types.ts
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/types.ts
@@ -38,6 +38,8 @@ export type CustomGraphLink<Datum = unknown> = {
   showArrow?: boolean;
   showFlow?: boolean;
   width?: number;
+  linkFlowAnimDuration?: number;
+  linkFlowParticleSize?: number;
 };
 
 export type CustomGraphSwimlane = {

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/types.ts
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-custom-node-rendering/types.ts
@@ -40,6 +40,7 @@ export type CustomGraphLink<Datum = unknown> = {
   width?: number;
   linkFlowAnimDuration?: number;
   linkFlowParticleSize?: number;
+  linkFlowParticleSpeed?: number;
 };
 
 export type CustomGraphSwimlane = {

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -34,7 +34,6 @@ import {
   GraphNodeSelectionHighlightMode,
 } from './types'
 
-
 export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphInputLink> extends ComponentConfigInterface {
   // Zoom and drag
   /** Zoom level constraints. Default: [0.35, 1.25] */
@@ -143,9 +142,9 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   /** Link flow animation accessor function or constant value. Default: `false` */
   linkFlow?: BooleanAccessor<L>;
   /** Animation duration of the flow (traffic) circles. Default: `20000` */
-  linkFlowAnimDuration?: number;
+  linkFlowAnimDuration?: NumericAccessor<L>;
   /** Size of the moving particles that represent traffic flow. Default: `2` */
-  linkFlowParticleSize?: number;
+  linkFlowParticleSize?: NumericAccessor<L>;
   /** Link label accessor function or constant value. Default: `undefined` */
   linkLabel?: GenericAccessor<GraphCircleLabel | GraphCircleLabel[], L> | undefined;
   /** Shift label along the link center a little bit to avoid overlap with the link arrow. Default: `true` */

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -15,6 +15,7 @@ import { ComponentConfigInterface, ComponentDefaultConfig } from 'core/component
 
 // Types
 import { TrimMode } from 'types/text'
+import { Spacing } from 'types/spacing'
 import { GraphInputLink, GraphInputNode, GraphInputData } from 'types/graph'
 import { BooleanAccessor, ColorAccessor, NumericAccessor, StringAccessor, GenericAccessor } from 'types/accessor'
 
@@ -50,6 +51,8 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   disableBrush?: boolean;
   /** Interval to re-render the graph when zooming. Default: `100` */
   zoomThrottledUpdateNodeThreshold?: number;
+  /** Padding for the graph when fitting to container. Default: `50` */
+  fitViewPadding?: Spacing | number;
 
   // Layout general settings
   /** Type of the graph layout. Default: `GraphLayoutType.Force` */
@@ -309,7 +312,7 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   layoutAutofit: true,
   layoutAutofitTolerance: 8.0,
   layoutNonConnectedAside: false,
-
+  fitViewPadding: 50,
   layoutGroupOrder: [],
   layoutParallelSubGroupsPerRow: 1,
   layoutParallelNodesPerColumn: 6,

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -33,6 +33,7 @@ import {
   GraphNode,
   GraphLink,
   GraphNodeSelectionHighlightMode,
+  GraphFitViewAlignment,
 } from './types'
 
 export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphInputLink> extends ComponentConfigInterface {
@@ -53,6 +54,8 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   zoomThrottledUpdateNodeThreshold?: number;
   /** Padding for the graph when fitting to container. Default: `50` */
   fitViewPadding?: Spacing | number;
+  /** Default alignment when fitting the graph view. Default: `GraphFitViewAlignment.Center` */
+  fitViewAlign?: GraphFitViewAlignment;
 
   // Layout general settings
   /** Type of the graph layout. Default: `GraphLayoutType.Force` */
@@ -313,6 +316,8 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   layoutAutofitTolerance: 8.0,
   layoutNonConnectedAside: false,
   fitViewPadding: 50,
+  fitViewAlign: GraphFitViewAlignment.Center,
+
   layoutGroupOrder: [],
   layoutParallelSubGroupsPerRow: 1,
   layoutParallelNodesPerColumn: 6,

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -141,10 +141,13 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   linkDisabled?: BooleanAccessor<L>;
   /** Link flow animation accessor function or constant value. Default: `false` */
   linkFlow?: BooleanAccessor<L>;
-  /** Animation duration of the flow (traffic) circles. Default: `20000` */
+  /** Animation duration of the flow (traffic) circles in milliseconds. If `linkFlowParticleSpeed` is provided,
+   * this duration will be calculated based on the link length and particle speed. Default: `20000` */
   linkFlowAnimDuration?: NumericAccessor<L>;
   /** Size of the moving particles that represent traffic flow. Default: `2` */
   linkFlowParticleSize?: NumericAccessor<L>;
+  /** Speed of the moving particles in pixels per second. This property takes precedence over `linkFlowAnimDuration`. Default: `undefined` */
+  linkFlowParticleSpeed?: NumericAccessor<L>;
   /** Link label accessor function or constant value. Default: `undefined` */
   linkLabel?: GenericAccessor<GraphCircleLabel | GraphCircleLabel[], L> | undefined;
   /** Shift label along the link center a little bit to avoid overlap with the link arrow. Default: `true` */
@@ -336,6 +339,7 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
 
   linkFlowAnimDuration: 20000,
   linkFlowParticleSize: 2,
+  linkFlowParticleSpeed: undefined,
   linkWidth: 1,
   linkStyle: GraphLinkStyle.Solid,
   linkBandWidth: 0,

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -698,9 +698,8 @@ export class Graph<
     const hasLinksWithFlow = links.some((d, i) => getBoolean(d, config.linkFlow, i))
     if (!hasLinksWithFlow) return
 
-    const linkElements = this._linksGroup.selectAll<SVGGElement, GraphLink<N, L>>(`.${linkSelectors.gLink}`)
-    const linksToAnimate = linkElements.filter(d => !d._state.greyout)
-    linksToAnimate.each((l, i, els) => {
+    const linkGroups = this._linksGroup.selectAll<SVGGElement, GraphLink<N, L>>(`.${linkSelectors.gLink}`)
+    linkGroups.each((l, i, els) => {
       let linkFlowAnimDuration = getNumber(l, config.linkFlowAnimDuration, l._indexGlobal)
       const linkFlowParticleSpeed = getNumber(l, config.linkFlowParticleSpeed, l._indexGlobal)
 
@@ -712,7 +711,7 @@ export class Graph<
       }
       l._state.flowAnimTime = (elapsed % linkFlowAnimDuration) / linkFlowAnimDuration
     })
-    animateLinkFlow(linksToAnimate, this.config, this._scale, this._linkPathLengthMap)
+    animateLinkFlow(linkGroups, this.config, this._scale, this._linkPathLengthMap)
   }
 
   private _onZoom (t: ZoomTransform, event?: D3ZoomEvent<SVGGElement, unknown>): void {

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -203,8 +203,10 @@ export class Graph<
   }
 
   get bleed (): Spacing {
-    const extraPadding = 50 // Extra padding to take into account labels and selection outlines
-    return { top: extraPadding, bottom: extraPadding, left: extraPadding, right: extraPadding }
+    const padding = this.config.fitViewPadding // Extra padding to take into account labels and selection outlines
+    return isNumber(padding)
+      ? { top: padding, bottom: padding, left: padding, right: padding }
+      : padding
   }
 
   _render (customDuration?: number): void {
@@ -500,8 +502,8 @@ export class Graph<
       return zoomIdentity
     }
 
-    const xScale = w / (xExtent[1] - xExtent[0] + left + right)
-    const yScale = h / (yExtent[1] - yExtent[0] + top + bottom)
+    const xScale = w / (xExtent[1] - xExtent[0] + (left || 0) + (right || 0))
+    const yScale = h / (yExtent[1] - yExtent[0] + (top || 0) + (bottom || 0))
 
     const clampedScale = clamp(min([xScale, yScale]), zoomScaleExtent[0], zoomScaleExtent[1])
 

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -669,7 +669,15 @@ export class Graph<
     const linkElements = this._linksGroup.selectAll<SVGGElement, GraphLink<N, L>>(`.${linkSelectors.gLink}`)
     const linksToAnimate = linkElements.filter(d => !d._state.greyout)
     linksToAnimate.each((l, i, els) => {
-      const linkFlowAnimDuration = getNumber(l, config.linkFlowAnimDuration, l._indexGlobal)
+      let linkFlowAnimDuration = getNumber(l, config.linkFlowAnimDuration, l._indexGlobal)
+      const linkFlowParticleSpeed = getNumber(l, config.linkFlowParticleSpeed, l._indexGlobal)
+
+      // If particle speed is provided, calculate duration based on link length and speed
+      if (linkFlowParticleSpeed) {
+        const linkPathElement = els[i].querySelector<SVGPathElement>(`.${linkSelectors.linkSupport}`)
+        const pathLength = linkPathElement ? (this._linkPathLengthMap.get(linkPathElement.getAttribute('d')) ?? linkPathElement.getTotalLength()) : 0
+        if (pathLength > 0) linkFlowAnimDuration = (pathLength / linkFlowParticleSpeed) * 1000 // Convert to milliseconds
+      }
       l._state.flowAnimTime = (elapsed % linkFlowAnimDuration) / linkFlowAnimDuration
     })
     animateLinkFlow(linksToAnimate, this.config, this._scale, this._linkPathLengthMap)

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -15,7 +15,7 @@ import { GraphInputLink, GraphInputNode, GraphInputData } from 'types/graph'
 import { Spacing } from 'types/spacing'
 
 // Utils
-import { isNumber, clamp, shallowDiff, isFunction, getBoolean, isPlainObject, isEqual } from 'utils/data'
+import { isNumber, clamp, shallowDiff, isFunction, getBoolean, isPlainObject, isEqual, getNumber } from 'utils/data'
 import { smartTransition } from 'utils/d3'
 
 // Local Types
@@ -661,16 +661,17 @@ export class Graph<
   }
 
   private _onLinkFlowTimerFrame (elapsed = 0): void {
-    const { config: { linkFlow, linkFlowAnimDuration }, datamodel: { links } } = this
+    const { config, datamodel: { links } } = this
 
-    const hasLinksWithFlow = links.some((d, i) => getBoolean(d, linkFlow, i))
+    const hasLinksWithFlow = links.some((d, i) => getBoolean(d, config.linkFlow, i))
     if (!hasLinksWithFlow) return
 
-    const t = (elapsed % linkFlowAnimDuration) / linkFlowAnimDuration
     const linkElements = this._linksGroup.selectAll<SVGGElement, GraphLink<N, L>>(`.${linkSelectors.gLink}`)
-
     const linksToAnimate = linkElements.filter(d => !d._state.greyout)
-    linksToAnimate.each(d => { d._state.flowAnimTime = t })
+    linksToAnimate.each((l, i, els) => {
+      const linkFlowAnimDuration = getNumber(l, config.linkFlowAnimDuration, l._indexGlobal)
+      l._state.flowAnimTime = (elapsed % linkFlowAnimDuration) / linkFlowAnimDuration
+    })
     animateLinkFlow(linksToAnimate, this.config, this._scale, this._linkPathLengthMap)
   }
 

--- a/packages/ts/src/components/graph/modules/link/index.ts
+++ b/packages/ts/src/components/graph/modules/link/index.ts
@@ -180,7 +180,7 @@ export function updateLinks<N extends GraphInputNode, L extends GraphInputLink> 
   getLinkArrowDefId: (arrow: GraphLinkArrowStyle | undefined) => string,
   linkPathLengthMap: Map<string, number>
 ): void {
-  const { linkFlowParticleSize, linkStyle, linkFlow, linkLabel, linkLabelShiftFromCenter } = config
+  const { linkStyle, linkFlow, linkLabel, linkLabelShiftFromCenter } = config
   if (!selection.size()) return
 
   selection
@@ -204,6 +204,7 @@ export function updateLinks<N extends GraphInputNode, L extends GraphInputLink> 
     const linkLabelData = ensureArray(
       getValue<GraphLink<N, L>, GraphCircleLabel | GraphCircleLabel[]>(d, linkLabel, d._indexGlobal)
     )
+    const linkFlowParticleSize = getNumber(d, config.linkFlowParticleSize, d._indexGlobal)
 
     // Particle Flow
     flowGroup
@@ -212,7 +213,7 @@ export function updateLinks<N extends GraphInputNode, L extends GraphInputLink> 
 
     flowGroup
       .selectAll(`.${linkSelectors.flowCircle}`)
-      .attr('r', linkFlowParticleSize / scale)
+      .attr('r', linkFlowParticleSize / Math.sqrt(scale))
       .style('fill', linkColor)
 
     smartTransition(flowGroup, duration)
@@ -387,15 +388,15 @@ export function zoomLinks<N extends GraphInputNode, L extends GraphInputLink> (
   config: GraphConfigInterface<N, L>,
   scale: number
 ): void {
-  const { linkFlowParticleSize } = config
-
   selection.classed(generalSelectors.zoomOutLevel2, scale < ZoomLevel.Level2)
 
   selection.select(`.${linkSelectors.flowGroup}`)
     .style('opacity', scale < ZoomLevel.Level2 ? 0 : 1)
 
-  selection.selectAll(`.${linkSelectors.flowCircle}`)
-    .attr('r', linkFlowParticleSize / scale)
+  selection.each((l, i, els) => {
+    const r = getNumber(l, config.linkFlowParticleSize, l._indexGlobal) / Math.sqrt(scale)
+    select(els[i]).selectAll(`.${linkSelectors.flowCircle}`).attr('r', r)
+  })
 
   const linkElements = selection.selectAll<SVGGElement, GraphLink<N, L>>(`.${linkSelectors.link}`)
   linkElements

--- a/packages/ts/src/components/graph/modules/link/index.ts
+++ b/packages/ts/src/components/graph/modules/link/index.ts
@@ -366,7 +366,7 @@ export function animateLinkFlow<N extends GraphInputNode, L extends GraphInputLi
     const linkGroup = select(element)
     const flowGroup = linkGroup.select(`.${linkSelectors.flowGroup}`)
 
-    const linkPathElement = linkGroup.select<SVGPathElement>(`.${linkSelectors.linkSupport}`).node()
+    const linkPathElement = linkGroup.select<SVGPathElement>(`.${linkSelectors.link}`).node()
     const cachedLinkPathLength = linkPathLengthMap.get(linkPathElement.getAttribute('d'))
     const pathLength = cachedLinkPathLength ?? linkPathElement.getTotalLength()
 

--- a/packages/ts/src/components/graph/modules/link/style.ts
+++ b/packages/ts/src/components/graph/modules/link/style.ts
@@ -19,10 +19,12 @@ export const variables = injectGlobal`
 
     --vis-graph-link-band-opacity: 0.35;
     --vis-graph-link-support-stroke-width: 10px;
+    --vis-graph-link-flow-opacity: 1;
 
     --vis-dark-graph-link-stroke-color: #494b56;
     --vis-dark-graph-link-label-background: #3f3f45;
     --vis-dark-graph-link-label-text-color: var(--vis-graph-link-label-text-color-bright);
+
 
     --vis-graph-link-dominant-baseline: middle;
   }
@@ -95,7 +97,7 @@ export const linkBand = css`
 
 export const flowGroup = css`
   label: flow-group;
-
+  
   pointer-events: none;
 `
 
@@ -103,6 +105,7 @@ export const flowCircle = css`
   label: flow-circle;
 
   fill: var(--vis-graph-link-stroke-color);
+  opacity: var(--vis-graph-link-flow-opacity);
 `
 
 export const linkLabelGroup = css`

--- a/packages/ts/src/components/graph/types.ts
+++ b/packages/ts/src/components/graph/types.ts
@@ -239,3 +239,11 @@ export enum GraphNodeSelectionHighlightMode {
   Greyout ='greyout',
   GreyoutNonConnected ='greyout-non-connected',
 }
+
+export enum GraphFitViewAlignment {
+  Center = 'center',
+  Top = 'top',
+  Bottom = 'bottom',
+  Left = 'left',
+  Right = 'right',
+}

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -299,7 +299,7 @@ You can inject custom rendering functions using the following configuration prop
 - `nodeExitCustomRenderFunction`: Customize how nodes are rendered when they exit the DOM.
 - `nodeOnZoomCustomRenderFunction`: Adjust node rendering dynamically during zooming or panning.
 
-These functions provide access to each node’s data (`datum`), the node’s DOM element selection
+These functions provide access to each node's data (`datum`), the node's DOM element selection
 (`g`), the component configuration (`config`), and the current zoom level (`zoomLevel`).
 This gives you full control to modify elements such as SVG shapes, colors, labels, icons, and more.
 
@@ -398,8 +398,10 @@ to `linkBandWidth`. The opacity of the band can be changed with the `--vis-graph
 
 ### Flying Particles
 Set `linkFlow` to `true` (or provide an accessor function) to turn on flying particles along the links. Configure the
-size of the particles with `linkFlowParticleSize` and `linkFlowAnimDuration` properties.
-<GraphDoc hiddenProps={linkHiddenProps} linkFlow={(l ,i) => i%2} linkFlowParticleSize={3} linkFlowAnimDuration={10000} />
+size of the particles with `linkFlowParticleSize` and animation speed with either `linkFlowAnimDuration` or `linkFlowParticleSpeed` properties.
+
+The `linkFlowParticleSpeed` property (in pixels per second) takes precedence over `linkFlowAnimDuration` when both are provided.
+<GraphDoc hiddenProps={linkHiddenProps} linkFlow={(l ,i) => i%2} linkFlowParticleSize={3} linkFlowParticleSpeed={10} />
 
 ### Multiple Links
 If there are multiple links between two nodes, all of them will be displayed. You can control the spacing between the
@@ -603,7 +605,7 @@ This callback function is triggered with the calculated node and link arrays, al
 inspect and modify their properties directly. For example, you can use this callback to enforce
 specific positioning constraints or adjust node/link styles.
 
-Here’s a basic example that demonstrates how to use the `onLayoutCalculated` callback to adjust node positions:
+Here's a basic example that demonstrates how to use the `onLayoutCalculated` callback to adjust node positions:
 
 ```ts
 const onLayoutCalculated = (nodes: GraphNode<N, L>[], links: GraphLink<N, L>[]) => {
@@ -624,6 +626,10 @@ moved or zoomed the graph there's some level of tolerance after which automatic 
 value can be tweaked with the `layoutAutofitTolerance` property (default value is 8.0):
 * `0` — Stop fitting after any pan or zoom;
 * `Number.POSITIVE_INFINITY` — Always fit;
+
+You can control the padding around the graph when fitting to the container with the `fitViewPadding` property. The default padding is `50` pixels, but you can specify different values for each side using the `Spacing` object type: `{ top, right, bottom, left }`.
+
+Additionally, you can set the alignment of the graph when fitting to the container using the `fitViewAlign` property. The default is `GraphFitViewAlignment.Center`, but you can also use `GraphFitViewAlignment.Top` or other available alignment options.
 
 If you need to re-enable autofit after the graph has been panned or zoomed, you can do so by calling the public
 `resetAutofitState()` method of the component instance.
@@ -805,7 +811,7 @@ You can define custom actions for node dragging with the following callbacks:
 - `onNodeDragEnd`: Invoked when a node drag operation ends.
 
 Each of these callbacks receives the node data and the drag event, allowing for actions such
-as updating other elements based on the dragged node’s position or applying visual effects
+as updating other elements based on the dragged node's position or applying visual effects
 during the drag.
 
 ```ts
@@ -864,7 +870,7 @@ onNodeSelectionDrag: (selectedNodes: GraphNode<N, L>[], event: D3DragEvent<SVGGE
 
 ## Post-Render Customization `1.5`
 The _Graph_ component provides an `onRenderComplete` callback function that allows you to add custom
-elements to the graph’s canvas after the rendering is fully complete. This function is especially
+elements to the graph's canvas after the rendering is fully complete. This function is especially
 useful for layering additional elements or annotations on top of the existing nodes and links.
 
 This callback receives several parameters, including the canvas selection (`g`),arrays of nodes and


### PR DESCRIPTION
- Link Particle Flow size and animation duration can now be configured per link.
- Adding new `linkFlowParticleSpeed` property allowing set particle speed in pixels/s.
- Making Fit View padding and alignment configurable.

https://github.com/user-attachments/assets/a27337f5-937f-41d6-a41a-1423b25994f5

- Using the actual link path for flow animation gives much better transitions when data or layout changes and doesn't seem to have a negative effect on performance.

https://github.com/user-attachments/assets/62477518-e54d-43c3-81c3-3df7ebe5252e

- Updating existing dev examples and docs
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/caa984b0-284b-424e-87ed-13210181ff94" />

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/b080774a-a729-4df5-9eeb-141768d65dc1" />

