### PR TITLE
Fix: XYLabels not rendering issue

### DIFF
--- a/packages/ts/src/components/xy-labels/index.ts
+++ b/packages/ts/src/components/xy-labels/index.ts
@@ -59,7 +59,7 @@ export class XYLabels<Datum> extends XYComponentCore<Datum, XYLabelsConfigInterf
     const { config, datamodel } = this
 
     const xRange = this.xScale.range() as [number, number]
-    const yRange = this.xScale.range() as [number, number]
+    const yRange = this.yScale.range() as [number, number]
 
     const labels = datamodel.data?.reduce<XYLabel<Datum>[]>((acc, d) => {
       const xPositioning = getValue<Datum, XYLabelPositioning>(d, config.xPositioning)

--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -329,7 +329,7 @@ export function filterDataByRange<Datum> (data: Datum[], range: [number, number]
 }
 
 export function isNumberWithinRange (value: number, range: [number, number]): boolean {
-  return (value >= range[0]) && (value <= range[1])
+  return (value >= range[0] && value <= range[1]) || (value >= range[1] && value <= range[0])
 }
 
 export const ensureArray = <T>(value: T | T[] | null): T[] => {


### PR DESCRIPTION
This PR resolves two issues:

- **_getDataToRender** – yRange now correctly derives from this.yScale.range() instead of this.xScale.range().

- **isNumberWithinRange** – Handle when range is inverted
