### PR TITLE
Component | Scatter: Only resolve label overlap when needed

### DIFF
--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -147,7 +147,18 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
     removePoints(points.exit<ScatterPoint<Datum>>(), this.xScale, this.yScale, duration)
 
     // Take care of overlapping labels
-    this._resolveLabelOverlap()
+    if (this._hasLabels()) {
+      this._resolveLabelOverlap()
+    }
+  }
+
+  private _hasLabels (): boolean {
+    // If label config is not defined, no labels will be shown
+    if (!this.config.label) return false
+
+    // Check if any point in the flattened data has a label
+    const pointDataFlat: ScatterPoint<Datum>[] = flatten(this._pointData)
+    return pointDataFlat.some(d => d._point.label)
   }
 
   private _resolveLabelOverlap (): void {


### PR DESCRIPTION
Closes #564 

**Technical note:** The check if (this.config.label) alone isn't sufficient because:                                                                                      

 * The label config could be defined, but it might return empty/null values for all data points. For example, if the label accessor function is defined as `d => d.label` but none of the data points actually have a label property or all have empty values.                                       
 * By checking if any point actually has a label `(pointDataFlat.some(d => d._point.label))`, we avoid unnecessary label overlap resolution calculations when no labels will be displayed, even though the label accessor is configured.