### PR TITLE
Revert "Component | Axis: Better `tickFormat` typing"

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -110,7 +110,7 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   @Input() minMaxTicksOnlyWhenWidthIsLess?: number
 
   /** Tick label formatter function. Default: `undefined` */
-  @Input() tickFormat?: ((tick: number, i: number, ticks: number[]) => string) | ((tick: Date, i: number, ticks: Date[]) => string)
+  @Input() tickFormat?: ((tick: number | Date, i: number, ticks: number[] | Date[]) => string)
 
   /** Explicitly set tick values. Default: `undefined` */
   @Input() tickValues?: number[]

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -34,7 +34,7 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
    * Default: `250` */
   minMaxTicksOnlyWhenWidthIsLess?: number;
   /** Tick label formatter function. Default: `undefined` */
-  tickFormat?: ((tick: number, i: number, ticks: number[]) => string) | ((tick: Date, i: number, ticks: Date[]) => string);
+  tickFormat?: ((tick: number | Date, i: number, ticks: number[] | Date[]) => string);
   /** Explicitly set tick values. Default: `undefined` */
   tickValues?: number[];
   /** Set the approximate number of axis ticks (will be passed to D3's axis constructor). Default: `undefined` */

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -220,7 +220,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     tickText.nodes().forEach(node => interrupt(node))
 
     tickText.each((value: number | Date, i: number, elements: ArrayLike<SVGTextElement>) => {
-      let text = config.tickFormat?.(value as (number & Date), i, tickValues as (number & Date)[]) ?? `${value}`
+      let text = config.tickFormat?.(value, i, tickValues) ?? `${value}`
       const textElement = elements[i] as SVGTextElement
       const textMaxWidth = config.tickTextWidth || (config.type === AxisType.X ? this._containerWidth / (ticks.size() + 1) : this._containerWidth / 5)
       const styleDeclaration = getComputedStyle(textElement)


### PR DESCRIPTION
Reverts f5/unovis#526

cc @rokotyan 