### PR TITLE
Core | Types | UnovisText: Making `fontSize` optional

### DIFF
--- a/packages/ts/src/styles/index.ts
+++ b/packages/ts/src/styles/index.ts
@@ -9,6 +9,7 @@ export const UNOVIS_FONT_WH_RATIO_DEFAULT: number = globalThis?.UNOVIS_FONT_W2H_
 export const UNOVIS_TEXT_SEPARATOR_DEFAULT: string[] = globalThis?.UNOVIS_TEXT_SEPARATOR_DEFAULT || [' ', '-', '.', ',']
 export const UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT: string = globalThis?.UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT || '-'
 export const UNOVIS_TEXT_DEFAULT: UnovisText = globalThis?.UNOVIS_TEXT_DEFAULT || {
+  // If you change these defaults, don't forget to update the values in the `UnovisText` type in `types/text.ts`
   text: '',
   fontSize: 12,
   fontFamily: 'var(--vis-font-family)',

--- a/packages/ts/src/types/text.ts
+++ b/packages/ts/src/types/text.ts
@@ -24,19 +24,19 @@ export enum TextAlign {
 export type UnovisText = {
   // The text content to be displayed.
   text: string;
-  // The font size of the text in pixels.
-  fontSize: number;
+  // The font size of the text in pixels (optional). Default: `12`.
+  fontSize?: number;
   // The font family of the text (optional). Default: `'var(--vis-font-family)'`.
   fontFamily?: string;
-  // The font weight of the text (optional)`.
+  // The font weight of the text (optional).
   fontWeight?: number;
   // The color of the text (optional).
   color?: string;
-  // The line height scaling factor for the text (optional).
+  // The line height scaling factor for the text (optional). Default: `1.25`.
   lineHeight?: number;
-  // The top margin of the text block in pixels (optional).
+  // The top margin of the text block in pixels (optional). Default: `0`.
   marginTop?: number;
-  // The bottom margin of the text block in pixels (optional).
+  // The bottom margin of the text block in pixels (optional). Default: `0`.
   marginBottom?: number;
   // The font width-to-height ratio (optional).
   fontWidthToHeightRatio?: number;
@@ -75,4 +75,3 @@ export type UnovisTextOptions = {
 export type UnovisTextFrameOptions = UnovisTextOptions & {
   height?: number;
 }
-

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -225,7 +225,7 @@ export function estimateStringPixelLength (
  * @param {(string | number)} [fontSize] - The font size of the string.
  * @returns {number} The precise length of the string in pixels.
  */
-export function getPreciseStringLengthPx (str: string, fontFamily?: string, fontSize?: string | number): number {
+export function getPreciseStringLengthPx (str: string, fontFamily: string, fontSize: string | number): number {
   const svgNS = 'http://www.w3.org/2000/svg'
   const svg = document.createElementNS(svgNS, 'svg')
   const text = document.createElementNS(svgNS, 'text')
@@ -300,6 +300,9 @@ function breakTextIntoLines (
 ): string[] {
   const text = `${textBlock.text}`
   if (!text) return []
+  const fontSize = textBlock.fontSize ?? UNOVIS_TEXT_DEFAULT.fontSize
+  const fontFamily = textBlock.fontFamily ?? UNOVIS_TEXT_DEFAULT.fontFamily
+  const fontWidthToHeightRatio: number | undefined = textBlock.fontWidthToHeightRatio ?? UNOVIS_TEXT_DEFAULT.fontWidthToHeightRatio
   const separators = Array.isArray(separator) ? separator : [separator]
 
   const splitByNewLine = text.split('\n')
@@ -311,8 +314,8 @@ function breakTextIntoLines (
     let line = ''
     for (let i = 0; i < words.length; i += 1) {
       const textLengthPx = fastMode
-        ? estimateStringPixelLength(line + words[i], textBlock.fontSize, textBlock.fontWidthToHeightRatio)
-        : getPreciseStringLengthPx(line + words[i], textBlock.fontFamily, textBlock.fontSize)
+        ? estimateStringPixelLength(line + words[i], fontSize, fontWidthToHeightRatio)
+        : getPreciseStringLengthPx(line + words[i], fontFamily, fontSize)
 
       if (textLengthPx < width || i === 0) {
         line += words[i]
@@ -326,16 +329,16 @@ function breakTextIntoLines (
       if (wordBreak) {
         while (line.trim().length > minCharactersOnLine) {
           const subLineLengthPx = fastMode
-            ? estimateStringPixelLength(line, textBlock.fontSize, textBlock.fontWidthToHeightRatio)
-            : getPreciseStringLengthPx(line, textBlock.fontFamily, textBlock.fontSize)
+            ? estimateStringPixelLength(line, fontSize, fontWidthToHeightRatio)
+            : getPreciseStringLengthPx(line, fontFamily, fontSize)
 
           if (subLineLengthPx > width) {
             let breakIndex = (line.trim()).length - minCharactersOnLine // Place at least `minCharactersOnLine` characters onto the next line
             while (breakIndex > 0) {
               const subLine = `${line.substring(0, breakIndex)}${UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT}` // Use hyphen when force breaking words
               const subLinePx = fastMode
-                ? estimateStringPixelLength(subLine, textBlock.fontSize, textBlock.fontWidthToHeightRatio)
-                : getPreciseStringLengthPx(subLine, textBlock.fontFamily, textBlock.fontSize)
+                ? estimateStringPixelLength(subLine, fontSize, fontWidthToHeightRatio)
+                : getPreciseStringLengthPx(subLine, fontFamily, fontSize)
 
               // If the subline is less than the width, or just one character left, break the line
               if (subLinePx <= width || breakIndex === 1) {

--- a/packages/website/docs/auxiliary/Annotations.mdx
+++ b/packages/website/docs/auxiliary/Annotations.mdx
@@ -157,7 +157,7 @@ type UnovisText = {
   // The text content to be displayed.
   text: string;
   // The font size of the text in pixels.
-  fontSize: number;
+  fontSize?: number;
   // The font family of the text.
   fontFamily?: string;
   // The font weight of the text.


### PR DESCRIPTION
Successor of #582

I think that making `fontSize` in `UnovisText` optional, and not requiring it in any of the text function, is a more elegant way to solve the problem.