### PR TITLE
Component | Timeline: Calculate `absoluteContentHeight` using `rowHeight`

### DIFF
--- a/packages/dev/src/examples/xy-components/timeline/timeline-tooltip/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-tooltip/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { VisXYContainer, VisTimeline, VisAxis, VisTooltip } from '@unovis/react'
-import { Timeline, TimelineRowLabel } from '@unovis/ts'
+import { Position, Timeline, TimelineRowLabel } from '@unovis/ts'
 
 import { TimeDataRecord, generateTimeSeries } from '@src/utils/data'
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
@@ -9,11 +9,23 @@ export const title = 'Tooltip and Scrolling'
 export const subTitle = 'Generated Data'
 
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
-  const data = generateTimeSeries(25, 10, 10).map((d, i) => ({
+  const [data, setData] = useState(() => generateTimeSeries(45, 20, 10).map((d, i) => ({
     ...d,
-  }))
+  })))
+
+  const regenerateData = (): void => {
+    const numLines = Math.floor(Math.random() * 20) + 10
+    const numRows = Math.ceil(Math.random() * 10)
+    setData(generateTimeSeries(numLines, numRows, 10).map((d, i) => ({
+      ...d,
+    })))
+  }
+
   return (<>
-    <VisXYContainer<TimeDataRecord> data={data} height={300}>
+    <div style={{ marginBottom: '1rem' }}>
+      <button onClick={regenerateData}>Generate New Data</button>
+    </div>
+    <VisXYContainer<TimeDataRecord> data={data} height={600}>
       <VisTimeline
         lineRow={(d: TimeDataRecord) => d.type as string}
         x={(d: TimeDataRecord) => d.timestamp}
@@ -22,12 +34,13 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
         showRowLabels
         duration={props.duration}
       />
-      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => new Date(x).toDateString()} duration={props.duration}/>
-      <VisTooltip triggers={{
-        [Timeline.selectors.line]: (d: TimeDataRecord) =>
-          `${(new Date(d.timestamp)).toDateString()} — ${(new Date(d.timestamp + d.length)).toDateString()}`,
-        [Timeline.selectors.row]: (l: TimelineRowLabel<TimeDataRecord>) => `Timeline Row ${l.label}`,
-      }}/>
+      <VisAxis type='x' numTicks={3} tickFormat={(tick: number | Date) => new Date(tick).toDateString()} duration={props.duration}/>
+      <VisTooltip
+        triggers={{
+          [Timeline.selectors.line]: (d: TimeDataRecord) =>
+            `${(new Date(d.timestamp)).toDateString()} — ${(new Date(d.timestamp + d.length)).toDateString()}`,
+          [Timeline.selectors.row]: (l: TimelineRowLabel<TimeDataRecord> | undefined) => `Timeline Row ${l?.label || ''}`,
+        }}/>
     </VisXYContainer>
   </>
   )

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -125,7 +125,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
   get bleed (): Spacing {
     const { config, datamodel: { data } } = this
     const rowLabels = this._getRowLabels(data)
-    const rowHeight = config.rowHeight || (this._height / rowLabels.length)
+    const rowHeight = config.rowHeight || (this._height / (rowLabels.length || 1))
     const hasIcons = rowLabels.some(l => l.iconHref)
     const maxIconSize = max(rowLabels.map(l => l.iconSize || 0))
 
@@ -206,7 +206,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
     const yHeight = Math.abs(yRange[1] - yRange[0])
     const rowLabels = this._getRowLabels(data)
     const numRowLabels = rowLabels.length
-    const rowHeight = config.rowHeight || (yHeight / numRowLabels)
+    const rowHeight = config.rowHeight || (yHeight / (numRowLabels || 1))
 
     const yOrdinalScale = scaleOrdinal<string, number>()
       .range(arrayOfIndices(numRowLabels))
@@ -417,8 +417,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
       .remove()
 
     // Scroll Bar
-    const contentBBox = this._rowsGroup.node().getBBox() // We determine content size using the rects group because lines are animated
-    const absoluteContentHeight = contentBBox.height
+    const absoluteContentHeight = recordTypes.length * rowHeight
     this._scrollbarHeight = yHeight * yHeight / absoluteContentHeight || 0
     this._maxScroll = Math.max(absoluteContentHeight - yHeight, 0)
 


### PR DESCRIPTION
Fixes #586

https://github.com/user-attachments/assets/1107bedf-9cf0-4765-87db-e991ea969176