### PR TITLE
Solid | Bug: Component destroy method on XY Container.

### DIFF
--- a/packages/solid/src/containers/xy-container/index.tsx
+++ b/packages/solid/src/containers/xy-container/index.tsx
@@ -105,7 +105,7 @@ export function VisXYContainer<Datum>(props: VisXYContainerProps<Datum>) {
       produce((c) => {
         switch (key) {
           case 'component':
-            c.components?.filter((i) => !i.isDestroyed())
+            c.components = c.components?.filter((i) => !i.isDestroyed())
             break
           case 'axis':
             // @ts-expect-error -- ts does not happy with the type


### PR DESCRIPTION
There's bug when a component is being destroyed (https://github.com/f5/unovis/pull/558). The filtered items should be assigned back to `c.components`

https://github.com/user-attachments/assets/b177e5e8-37de-4fa3-a206-e9ce67df055e

After fix:

https://github.com/user-attachments/assets/ef8651bd-a11a-4505-9fc0-4c2a84d8daad

cc @hngngn 