### PR TITLE
Timeline: Configurable positioning of small rounded segments

### DIFF
--- a/packages/angular/src/components/timeline/timeline.component.ts
+++ b/packages/angular/src/components/timeline/timeline.component.ts
@@ -154,8 +154,14 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   /** Configurable Timeline item cursor when hovering over. Default: `undefined` */
   @Input() lineCursor?: StringAccessor<Datum>
 
-  /** Sets the minimum line length to 1 pixel for better visibility of small values. Default: `false` */
+  /** Sets the minimum line length to 1 pixel for better visibility of small values.
+   * When `lineCap` is set to `true`, the segment will be rendered as a circle.
+   * Default: `false` */
   @Input() showEmptySegments?: boolean
+
+  /** Center small segments when `showEmptySegments` and `lineCap` are set to `true`.
+   * Default: `true` */
+  @Input() showEmptySegmentsCorrectPosition?: boolean
 
   /** Timeline row height. Default: `22` */
   @Input() rowHeight?: number
@@ -225,8 +231,8 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   }
 
   private getConfig (): TimelineConfigInterface<Datum> {
-    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
-    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
+    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
+    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
     const keys = Object.keys(config) as (keyof TimelineConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/timeline/timeline-empty-segments/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-empty-segments/index.tsx
@@ -9,6 +9,7 @@ export const subTitle = 'Small and Negative Lengths'
 
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
   const [showEmptySegments, toggleEmptySegments] = React.useState(true)
+  const [showEmptySegmentsCorrectPosition, toggleEmptySegmentsCorrectPosition] = React.useState(true)
   const [lineCap, setLineCap] = React.useState(false)
   const data = useMemo(() => generateTimeSeries(50).map((d, i) => ({
     ...d,
@@ -19,12 +20,17 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
   return (<>
     <div><input type='checkbox' checked={showEmptySegments} onChange={e => toggleEmptySegments(e.target.checked)}/><label>Show empty segments</label></div>
     <div><input type='checkbox' checked={lineCap} onChange={e => setLineCap(e.target.checked)}/><label>Rounded corners</label></div>
+    <div>
+      <input type='checkbox' checked={showEmptySegmentsCorrectPosition} onChange={e => toggleEmptySegmentsCorrectPosition(e.target.checked)}/>
+      <label>Center empty segments (only small segments with rounded corners)</label>
+    </div>
     <VisXYContainer<TimeDataRecord> data={data} height={200}>
       <VisTimeline
         lineRow={(d: TimeDataRecord) => d.type as string}
         x={(d: TimeDataRecord) => d.timestamp}
         rowHeight={50}
         showEmptySegments={showEmptySegments}
+        showEmptySegmentsCorrectPosition={showEmptySegmentsCorrectPosition}
         showRowLabels
         duration={props.duration}
         lineCap={lineCap}

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -49,8 +49,13 @@ export interface TimelineConfigInterface<Datum> extends WithOptional<XYComponent
   lineEndIconArrangement?: GenericAccessor<Arrangement | `${Arrangement}`, Datum>;
   /** Configurable Timeline item cursor when hovering over. Default: `undefined` */
   lineCursor?: StringAccessor<Datum>;
-  /** Sets the minimum line length to 1 pixel for better visibility of small values. Default: `false` */
+  /** Sets the minimum line length to 1 pixel for better visibility of small values.
+   * When `lineCap` is set to `true`, the segment will be rendered as a circle.
+   * Default: `false` */
   showEmptySegments?: boolean;
+  /** Center small segments when `showEmptySegments` and `lineCap` are set to `true`.
+   * Default: `true` */
+  showEmptySegmentsCorrectPosition?: boolean;
 
   /** Timeline row height. Default: `22` */
   rowHeight?: number;
@@ -114,6 +119,7 @@ export const TimelineDefaultConfig: TimelineConfigInterface<unknown> = {
   lineCap: false,
   lineCursor: undefined,
   showEmptySegments: false,
+  showEmptySegmentsCorrectPosition: true,
   lineStartIcon: undefined,
   lineStartIconColor: undefined,
   lineStartIconSize: undefined,

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -483,13 +483,14 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
         console.warn('Unovis | Timeline: Line segments should not have negative lengths. Setting to 0.')
       }
 
-      const isLineTooShort = config.showEmptySegments && config.lineCap && (lineLength < lineWidth)
       const lineLengthCorrected = config.showEmptySegments
         ? Math.max(config.lineCap ? lineWidth : 1, lineLength)
         : Math.max(0, lineLength)
 
       const x = xScale(getNumber(d, config.x, i))
       const y = yStart + rowOrdinalScale(this._getRecordKey(d, i)) * rowHeight + (rowHeight - lineWidth) / 2
+
+      const isLineTooShort = config.showEmptySegments && config.showEmptySegmentsCorrectPosition && config.lineCap && (lineLength < lineWidth)
       const xOffset = isLineTooShort ? -(lineLengthCorrected - lineLength) / 2 : 0
 
       return {

--- a/packages/website/docs/xy-charts/Timeline.mdx
+++ b/packages/website/docs/xy-charts/Timeline.mdx
@@ -94,6 +94,13 @@ Set `showEmptySegments` to `true` if you want to display lines that are `undefin
 
 <XYWrapperWithInput {...emptyProps} lineCap={true} property="showEmptySegments" inputType="checkbox" defaultValue={true}/>
 
+#### Empty segments positioning
+When both `showEmptySegments` and `lineCap` are set to `true`, you can control the positioning of small segments using
+the `showEmptySegmentsCorrectPosition` property. When set to `true` (default), small segments will be centered at their
+actual position. When set to `false`, small segments will be aligned to the left of their position.
+
+<XYWrapperWithInput {...emptyProps} lineCap={true} showEmptySegments={true} property="showEmptySegmentsCorrectPosition" inputType="checkbox" defaultValue={true}/>
+
 ### Line Width
 You can also change the line thickness with the `lineWidth` property, which determines how much
 vertical space each _Timeline_ item occupies.


### PR DESCRIPTION
There can be situations where you might not want to center small segments. Adding a config property to control this: `showEmptySegmentsCorrectPosition` (`true` by default). 

<img width="1284" height="553" alt="SCR-20250819-ncxn" src="https://github.com/user-attachments/assets/db5fcee7-e517-43a7-98eb-958d1791583b" />


https://github.com/user-attachments/assets/b86c1639-4abd-44d3-a6e8-bc738b54df2e

