### PR TITLE
Component | Annotation: Add calc() support to annotation position

### DIFF
--- a/packages/dev/src/examples/auxiliary/annotations/basic-annotations/index.tsx
+++ b/packages/dev/src/examples/auxiliary/annotations/basic-annotations/index.tsx
@@ -37,8 +37,8 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
             { text: `Mean: ~${(acc.total / data.length).toFixed(2)}`, fontSize: 14 },
           ],
         }, {
-          x: '102%',
-          y: yScale(acc.min),
+          x: 'calc(100% - 10px + (60px - 70px))', // 100% - 20px
+          y: '5px',
           content: 'Min',
           verticalAlign: 'middle',
           textAlign: 'left',

--- a/packages/ts/src/utils/misc.ts
+++ b/packages/ts/src/utils/misc.ts
@@ -57,10 +57,87 @@ export function getHref<T> (d: T, identifier: StringAccessor<T>): string {
   return id ? `url(#${id})` : null
 }
 
+function evaluateSimpleExpression (expr: string): number {
+  // Handle multiplication and division first (higher precedence)
+  // Keep applying until no more operations are found
+  while (/(-?\d+(?:\.\d+)?)\s*([*/])\s*(-?\d+(?:\.\d+)?)/.test(expr)) {
+    expr = expr.replace(/(-?\d+(?:\.\d+)?)\s*([*/])\s*(-?\d+(?:\.\d+)?)/, (_, a, op, b) => {
+      const numA = parseFloat(a)
+      const numB = parseFloat(b)
+      return String(op === '*' ? numA * numB : numA / numB)
+    })
+  }
+
+  // Handle addition and subtraction (lower precedence)
+  // Keep applying until no more operations are found
+  while (/(-?\d+(?:\.\d+)?)\s*([+-])\s*(-?\d+(?:\.\d+)?)/.test(expr)) {
+    expr = expr.replace(/(-?\d+(?:\.\d+)?)\s*([+-])\s*(-?\d+(?:\.\d+)?)/, (_, a, op, b) => {
+      const numA = parseFloat(a)
+      const numB = parseFloat(b)
+      return String(op === '+' ? numA + numB : numA - numB)
+    })
+  }
+
+  const result = parseFloat(expr)
+  if (isNaN(result)) throw new Error(`Invalid expression: ${expr}`)
+  return result
+}
+
+function evaluateCalcExpression (expression: string, basis: number): number {
+  try {
+    // Replace percentages and pixels with resolved values
+    let expr = expression
+      .replace(/(\d+(?:\.\d+)?)%/g, (_, num) => String((basis * parseFloat(num)) / 100))
+      .replace(/(\d+(?:\.\d+)?)px/g, '$1')
+      .replace(/\s+/g, '')
+
+    // Validate parentheses pairs before processing
+    let parenCount = 0
+    for (const char of expr) {
+      if (char === '(') parenCount++
+      else if (char === ')') parenCount--
+      if (parenCount < 0) throw new Error('Mismatched parentheses: closing parenthesis without opening')
+    }
+    if (parenCount !== 0) throw new Error('Mismatched parentheses: unclosed opening parenthesis')
+
+    // Check for invalid characters (only allow numbers, operators, decimal points, and parentheses)
+    if (!/^[0-9+\-*/.() ]+$/.test(expr)) throw new Error('Invalid characters in expression')
+
+    // Check for empty parentheses
+    if (/\(\s*\)/.test(expr)) throw new Error('Empty parentheses not allowed')
+
+    // Simple regex-based evaluation for basic expressions
+    // Handles: number, number+number, number-number, number*number, number/number
+    // And simple parentheses: (expression)
+
+    // Evaluate parentheses first
+    let iterations = 0
+    const maxIterations = 100 // Prevent infinite loops
+    while (expr.includes('(') && iterations < maxIterations) {
+      const prevExpr = expr
+      expr = expr.replace(/\(([^()]+)\)/g, (_, inner) => String(evaluateSimpleExpression(inner)))
+      if (expr === prevExpr) throw new Error('Unable to resolve parentheses')
+      iterations++
+    }
+
+    if (iterations >= maxIterations) throw new Error('Expression too complex or contains infinite recursion')
+    if (expr.includes('(') || expr.includes(')')) throw new Error('Unresolved parentheses remain')
+
+    return evaluateSimpleExpression(expr)
+  } catch (error) {
+    console.warn(`Failed to evaluate calc() expression: ${expression}`, error)
+    return 0
+  }
+}
+
 export function parseUnit (value: LengthUnit, basis = 0): number {
   if (!value) return 0
   else if (typeof value === 'number') return value
-  else if (value.endsWith('%')) return basis * parseFloat(value) / 100
+  else if (typeof value === 'string' && value.startsWith('calc(') && value.endsWith(')')) {
+    // Parse calc() expression
+    const expression = value.slice(5, -1).trim() // Remove 'calc(' and ')'
+    return evaluateCalcExpression(expression, basis)
+  } else if (value.endsWith('%')) return basis * parseFloat(value) / 100
   else if (value.endsWith('px')) return parseFloat(value)
   else return parseFloat(value) || 0
 }


### PR DESCRIPTION
There is a need to have the annotation to always display at a certain location of the chart (right top corner, i.e.) when you don't have access to the chart's width / height. 

This PR adds support for `calc()` like what css has. `Min` in this case will always stay in the top right corner.
This implementation supports `calc(100% - (20px + 30px + 10px))`


https://github.com/user-attachments/assets/b28c1cc3-0a84-41ec-83d2-5b50fc4f0dd7



