### PR TITLE
Website | StackedBar | Orientation: Snippet using XYWrapper instead of XYWrapperWithInput

### DIFF
--- a/packages/website/docs/xy-charts/StackedBar.mdx
+++ b/packages/website/docs/xy-charts/StackedBar.mdx
@@ -28,7 +28,7 @@ _Stacked Bar_ can accept an array of y accessors to display values as a stack of
 
 ## Orientation
 _Stacked Bar_ supports horizontal and vertical orientation.
-<XYWrapper {...stackedBarProps()} y={[d => d.y, d => d.y1, d => d.y2]} height={250} showAxes property="orientation" inputType="select" options={["horizontal","vertical"]}/>
+<XYWrapperWithInput {...stackedBarProps()} y={[d => d.y, d => d.y1, d => d.y2]} height={250} showAxes property="orientation" inputType="select" options={["horizontal","vertical"]}/>
 
 ## Rounded Corners
 You can apply rounded corners to the top bar in your _Stacked Bar_ component using the `roundedCorners` property, which accepts


### PR DESCRIPTION
found this #426 bug at [this page](https://unovis.dev/docs/xy-charts/StackedBar#orientation)

current:
<img width="1202" height="706" alt="20250822_11h46m27s_grim" src="https://github.com/user-attachments/assets/98ede439-48b1-48d3-aac7-f6de92ac9958" />

what it should be:
<img width="1189" height="561" alt="20250822_11h49m47s_grim" src="https://github.com/user-attachments/assets/dada58fe-fde7-444c-afb0-c10d7b4a6490" />