### PR TITLE
Vue | Map: Reactive data

### DIFF
--- a/packages/vue/autogen/component.ts
+++ b/packages/vue/autogen/component.ts
@@ -61,7 +61,7 @@ watch(config, (curr, prev) => {
     component.value?.${componentName === 'BulletLegend' ? 'update' : 'setConfig'}(config.value)
   }
 })
-${propDefs?.length && !isStandAlone ? `\nwatch(data, () => {
+${propDefs?.length ? `\nwatch(data, () => {
   component.value?.setData(data.value)
 })` : ''}
 

--- a/packages/vue/src/html-components/leaflet-flow-map/index.vue
+++ b/packages/vue/src/html-components/leaflet-flow-map/index.vue
@@ -37,6 +37,9 @@ watch(config, (curr, prev) => {
   }
 })
 
+watch(data, () => {
+  component.value?.setData(data.value)
+})
 
 defineExpose({
   component

--- a/packages/vue/src/html-components/leaflet-map/index.vue
+++ b/packages/vue/src/html-components/leaflet-map/index.vue
@@ -37,6 +37,9 @@ watch(config, (curr, prev) => {
   }
 })
 
+watch(data, () => {
+  component.value?.setData(data.value)
+})
 
 defineExpose({
   component


### PR DESCRIPTION
Removes the `isStandAlone` check when generating watch data, allowing map data to be reactive.