### PR TITLE
Component | Axis: Fix autoMargin _getYTickTextTranslate undefined issue

### DIFF
--- a/packages/dev/src/examples/xy-components/grouped-bar/basic-grouped-bar/index.tsx
+++ b/packages/dev/src/examples/xy-components/grouped-bar/basic-grouped-bar/index.tsx
@@ -15,12 +15,24 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
   ]
 
   return (
-    <VisXYContainer<XYDataRecord> ariaLabel='A simple example of a Grouped Bar chart' data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }} xDomain={[-1, 15]}>
-      <VisGroupedBar x={d => d.x} y={accessors} duration={props.duration}/>
-      <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} duration={props.duration}/>
-      <VisAxis type='y' tickFormat={(y: number) => `${y}`} duration={props.duration}/>
-      <VisCrosshair template={(d: XYDataRecord) => `${d.x}`}/>
-      <VisTooltip ref={tooltipRef}/>
-    </VisXYContainer>
+    <>
+      <div>AutoMargin True</div>
+      <VisXYContainer<XYDataRecord> ariaLabel='A simple example of a Grouped Bar chart' data={generateXYDataRecords(15)} xDomain={[-1, 15]}>
+        <VisGroupedBar x={d => d.x} y={accessors} duration={props.duration}/>
+        <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} duration={props.duration}/>
+        <VisAxis type='y' tickFormat={(y: number) => `${y}`} duration={props.duration} />
+        <VisCrosshair template={(d: XYDataRecord) => `${d.x}`}/>
+        <VisTooltip ref={tooltipRef}/>
+      </VisXYContainer>
+
+      <div style={{ marginTop: 20 }}>AutoMargin False</div>
+      <VisXYContainer<XYDataRecord> ariaLabel='A simple example of a Grouped Bar chart' data={generateXYDataRecords(15)} margin={{ top: 5, right: 10, left: 30, bottom: 40 }} xDomain={[-1, 15]} autoMargin={false}>
+        <VisGroupedBar x={d => d.x} y={accessors} duration={props.duration}/>
+        <VisAxis type='x' numTicks={15} tickFormat={(x: number) => `${x}`} duration={props.duration}/>
+        <VisAxis type='y' tickFormat={(y: number) => `${y}`} duration={props.duration} position='left' numTicks={6} tickPadding={8} tickTextWidth={50} tickTextAngle={0} tickTextAlign='center' tickLine={false} gridLine={true} domainLine={true} />
+        <VisCrosshair template={(d: XYDataRecord) => `${d.x}`}/>
+        <VisTooltip ref={tooltipRef}/>
+      </VisXYContainer>
+    </>
   )
 }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -530,8 +530,13 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   }
 
   private _getYTickTextTranslate (textAlign: TextAlign, axisPosition: Position = Position.Left): number {
-    const defaultTickTextSpacingPx = 9 // Default in D3
-    const width = this._axisRawBBox.width - defaultTickTextSpacingPx
+    /*
+      Default in D3 is 9, tickPadding is the spacing in pixels between the tick and it's label. Default: `8`
+    */
+    const defaultTickTextSpacingPx = this.config.tickPadding + 1
+
+    // this._axisRawBBox will be undefined when autoMargin is undefined
+    const width = (this._axisRawBBox?.width ?? this.axisGroup.node()?.getBBox().width ?? 0) - defaultTickTextSpacingPx
 
     switch (textAlign) {
       case TextAlign.Left: return axisPosition === Position.Left ? width * -1 : 0


### PR DESCRIPTION
This is an attempt to fix this: https://github.com/f5/unovis/issues/632

<img width="1514" height="671" alt="Screenshot 2025-09-09 at 2 11 26 PM" src="https://github.com/user-attachments/assets/1fc52259-f573-4768-a61d-be814f020989" />
