### PR TITLE
Component | Timeline: Correct bleed calculation when `showEmptySegmentsCorrectPosition` is `true`

### DIFF
--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -171,8 +171,13 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
       const firstItemHeight = this._getLineWidth(firstItem, firstItemIdx, rowHeight)
       const lastItemHeight = this._getLineWidth(lastItem, lastItemIdx, rowHeight)
 
-      if ((firstItemEnd - firstItemStart) / fullTimeRange * this._width < firstItemHeight) lineBleed[0] = firstItemHeight / 2
-      if ((lastItemEnd - lastItemStart) / fullTimeRange * this._width < lastItemHeight) lineBleed[1] = lastItemHeight / 2
+      if ((firstItemEnd - firstItemStart) / fullTimeRange * this._width < firstItemHeight) {
+        lineBleed[0] = config.showEmptySegmentsCorrectPosition ? firstItemHeight / 2 : 0
+      }
+
+      if ((lastItemEnd - lastItemStart) / fullTimeRange * this._width < lastItemHeight) {
+        lineBleed[1] = config.showEmptySegmentsCorrectPosition ? lastItemHeight / 2 : lastItemHeight
+      }
     }
     this._lineBleed = lineBleed
 


### PR DESCRIPTION
There was a small bug in the bleed calculations, leading to the last segment going off-screen.

### Before
<img width="580" height="267" alt="SCR-20250908-mlcs" src="https://github.com/user-attachments/assets/8e921126-3a84-4cf8-bc4e-c9af1c2ff577" />


### After
<img width="577" height="268" alt="SCR-20250908-mkrf" src="https://github.com/user-attachments/assets/af655164-664f-45ee-ac8f-cfbe0bb829c6" />
