### PR TITLE
Container | XYContainer: YDirection south doesn't work with crosshair

### DIFF
--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -136,7 +136,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       : clamp(xPx, xRange[0], xRange[1])
 
     const isCrosshairWithinXRange = (xPx >= xRange[0]) && (xPx <= xRange[1])
-    const isCrosshairWithinYRange = (this._yPx >= yRange[1]) && (this._yPx <= yRange[0])
+    const isCrosshairWithinYRange = (this._yPx >= Math.min(yRange[0], yRange[1])) && (this._yPx <= Math.max(yRange[0], yRange[1]))
     let shouldShow = this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange
 
     // If the crosshair is far from the mouse pointer (usually when `snapToData` is `true` and data resolution is low), hide it


### PR DESCRIPTION
This PR address this https://github.com/f5/unovis/issues/638


https://github.com/user-attachments/assets/a725012d-cb46-4164-a5f0-7e8c36f387af
