### PR TITLE
Component | Axis: Add axis grid line dasharray CSS var to grid line

### DIFF
--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -79,6 +79,7 @@ export const grid = css`
   line {
     stroke: var(--vis-axis-grid-color);
     stroke-width: var(--vis-axis-grid-line-width);
+    stroke-dasharray: var(--vis-axis-grid-line-dasharray);
   }
 `
 


### PR DESCRIPTION
Setting the `--vis-axis-grid-line-dasharray` is currently not working. I did not add it to the actual line element.