### PR TITLE
Component | Crosshair: Make data and leftNearestDatumIndex optional

### DIFF
--- a/packages/dev/src/examples/xy-components/crosshair/free-crosshair/index.tsx
+++ b/packages/dev/src/examples/xy-components/crosshair/free-crosshair/index.tsx
@@ -66,7 +66,7 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
 
   // Custom template function that shows interpolated values
   // eslint-disable-next-line padded-blocks
-  const template = (d: XYDataRecord | undefined, xVal: number | Date, data: XYDataRecord[], leftNearestDatumIndex: number): string => {
+  const template = (d: XYDataRecord | undefined, xVal: number | Date, data?: XYDataRecord[], leftNearestDatumIndex?: number): string => {
     // eslint-disable-next-line no-console
     console.log('X Value:', (+xVal).toFixed(1), 'Left Index:', leftNearestDatumIndex)
 

--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -29,7 +29,7 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
   /** Tooltip template accessor. The function is supposed to return either a valid HTML string or an HTMLElement.
    * When `snapToData` is `false`, `datum` will be `undefined` but `data` and `leftNearestDatumIndex` will be provided.
    * Default: `d => ''` */
-  template?: (datum: Datum, x: number | Date, data: Datum[], leftNearestDatumIndex: number) => string | HTMLElement;
+  template?: (datum: Datum, x: number | Date, data?: Datum[], leftNearestDatumIndex?: number) => string | HTMLElement;
   /** Hide Crosshair when the corresponding datum element is far from mouse pointer. Default: `true` */
   hideWhenFarFromPointer?: boolean;
   /** Distance in pixels to check in the hideWhenFarFromPointer condition. Default: `100` */
@@ -46,7 +46,7 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
    * It has to return an array of the `CrosshairCircle` objects: `{ y: number; color: string; opacity?: number }[]`.
    * Default: `undefined`
   */
-  getCircles?: (x: number | Date, data: Datum[], yScale: ContinuousScale, leftNearestDatumIndex: number) => CrosshairCircle[];
+  getCircles?: (x: number | Date, data: Datum[], yScale: ContinuousScale, leftNearestDatumIndex?: number) => CrosshairCircle[];
   /** Callback function that is called when the crosshair is moved:
    * - `x` is the horizontal position of the crosshair in the data space;
    * - `datum` is the nearest datum to the crosshair;
@@ -66,7 +66,7 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   baseline: null,
   duration: 100,
   tooltip: undefined,
-  template: <Datum>(d: Datum, x: number | Date, data: Datum[], leftNearestDatumIndex: number): string => '',
+  template: <Datum>(d: Datum, x: number | Date, data?: Datum[], leftNearestDatumIndex?: number): string => '',
   hideWhenFarFromPointer: true,
   hideWhenFarFromPointerDistance: 100,
   snapToData: true,


### PR DESCRIPTION
Make `data` and `leftNearestDatumIndex` optional, follow the previous behavior. 