### PR TITLE
Component | Crosshair: Add skipRangeCheck prop

### DIFF
--- a/packages/angular/src/components/crosshair/crosshair.component.ts
+++ b/packages/angular/src/components/crosshair/crosshair.component.ts
@@ -150,6 +150,10 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
 
   /** Force the crosshair to show at a specific position. Default: `undefined` */
   @Input() forceShowAt?: number | Date
+
+  /** Skip range checks for crosshair visibility. When true, crosshair will show regardless of position within chart bounds. Default: `false`
+   * This is useful for testing, especially when you only triggers mousemove event but does not have real mouse event. */
+  @Input() skipRangeCheck?: boolean
   @Input() data: Datum[]
 
   component: Crosshair<Datum> | undefined
@@ -171,8 +175,8 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
   }
 
   private getConfig (): CrosshairConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck }
     const keys = Object.keys(config) as (keyof CrosshairConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -58,6 +58,10 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
   onCrosshairMove?: (x?: number | Date, datum?: Datum, datumIndex?: number, event?: MouseEvent | WheelEvent) => void;
   /** Force the crosshair to show at a specific position. Default: `undefined` */
   forceShowAt?: number | Date;
+  /** Skip range checks for crosshair visibility. When true, crosshair will show regardless of position within chart bounds. Default: `false`
+   *  This is useful for testing, especially when you only triggers mousemove event but does not have real mouse event.
+   */
+  skipRangeCheck?: boolean;
 }
 
 export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
@@ -76,5 +80,6 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   strokeWidth: undefined,
   onCrosshairMove: undefined,
   forceShowAt: undefined,
+  skipRangeCheck: false,
 }
 

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -137,7 +137,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
 
     const isCrosshairWithinXRange = (xPx >= xRange[0]) && (xPx <= xRange[1])
     const isCrosshairWithinYRange = (this._yPx >= Math.min(yRange[0], yRange[1])) && (this._yPx <= Math.max(yRange[0], yRange[1]))
-    let shouldShow = this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange
+    let shouldShow = config.skipRangeCheck ? !!this._xPx : (this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange)
 
     // If the crosshair is far from the mouse pointer (usually when `snapToData` is `true` and data resolution is low), hide it
     if (config.hideWhenFarFromPointer && ((Math.abs(xClamped - (+xPx)) >= config.hideWhenFarFromPointerDistance))) {
@@ -145,7 +145,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     }
 
     const tooltip = config.tooltip ?? this.tooltip
-    if (shouldShow && tooltip && this._isContainerInViewport()) {
+    const tooltipShouldShow = config.skipRangeCheck ? !!this._xPx : shouldShow
+    if (tooltipShouldShow && tooltip && this._isContainerInViewport()) {
       const container = tooltip.getContainer() || this.container.node()
       const isContainerBody = tooltip.isContainerBody()
 


### PR DESCRIPTION
Adding `skipRangeCheck` prop to crosshair.

The new function `onCrosshairMove` will always check if mouse is within range. This will cause certain tests to not recognize mouseover events. We are adding this prop for testing purposes.

cc @rokotyan  