### PR TITLE
Component | Crosshair: Update shouldShow check

### DIFF
--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -145,8 +145,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     }
 
     const tooltip = config.tooltip ?? this.tooltip
-    const tooltipShouldShow = config.skipRangeCheck ? !!this._xPx : shouldShow
-    if (tooltipShouldShow && tooltip && this._isContainerInViewport()) {
+    if (shouldShow && tooltip && this._isContainerInViewport()) {
       const container = tooltip.getContainer() || this.container.node()
       const isContainerBody = tooltip.isContainerBody()
 


### PR DESCRIPTION
This is an update for https://github.com/f5/unovis/pull/648/files
Which I think create issue when `skipRangeCheck` is set up `true`, but you also have real mouse `xPx`, your tooltip will always trigger.


https://github.com/user-attachments/assets/11bf3b98-8a32-4b62-9e83-4cc739a85adb

