### PR TITLE
Component | Tooltip: Fix Tooltip retains previous content when empty string or undefined is returned

### DIFF
--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -283,8 +283,8 @@ export class Tooltip {
     if (html instanceof HTMLElement) {
       const node = this.div.select(':first-child').node()
       if (node !== html) this.div.html('').append(() => html)
-    } else if (html) {
-      this.div.html(html)
+    } else if (html !== null) {
+      this.div.html(html || '')
     }
 
     this.div


### PR DESCRIPTION
ref: https://github.com/f5/unovis/issues/661


