### PR TITLE
Container |  Single container: Resize component after update

### DIFF
--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -151,7 +151,19 @@ export class SingleContainer<Data> extends ContainerCore {
     // Schedule the actual rendering in the next frame
     cancelAnimationFrame(this._renderAnimationFrameId)
     this._renderAnimationFrameId = requestAnimationFrame(() => {
-      this._preRender()
+      if (config.sizing !== Sizing.Extend && config.sizing !== Sizing.FitWidth) {
+        const svgWidth = parseInt(this.svg.attr('width'))
+        const svgHeight = parseInt(this.svg.attr('height'))
+        const availableWidth = svgWidth - config.margin.left - config.margin.right
+        const availableHeight = svgHeight - config.margin.top - config.margin.bottom
+
+        this.component.setSize(availableWidth, availableHeight, svgWidth, svgHeight)
+        if (this.config.annotations) {
+          this.config.annotations.setSize(availableWidth, availableHeight, svgWidth, svgHeight)
+        }
+      } else {
+        this._preRender()
+      }
       this._render(duration)
     })
   }


### PR DESCRIPTION
There's an issue with container resizing. If you resize on the container level, sometimes the component doesn't get resized which will cause some component getting cut off.

In the below video, the donut should resize based on the updated single container value. But a component resize is not being triggered. 

https://github.com/user-attachments/assets/03b7888a-730a-41c3-a5ad-ca89bede6cc0


This is by no means a good fix, I just want to provide some directions which would hopefully make the issue more clear.
