### PR TITLE
Core | Containers: Add onRenderComplete callback

### DIFF
--- a/packages/ts/src/containers/single-container/config.ts
+++ b/packages/ts/src/containers/single-container/config.ts
@@ -4,6 +4,9 @@ import { ComponentCore } from 'core/component'
 import { Tooltip } from 'components/tooltip'
 import { Annotations } from 'components/annotations'
 
+// Types
+import { Spacing } from 'types/spacing'
+
 export interface SingleContainerConfigInterface<Datum> extends ContainerConfigInterface {
   /** Visualization component. Default: `undefined` */
   component?: ComponentCore<Datum>;
@@ -11,6 +14,15 @@ export interface SingleContainerConfigInterface<Datum> extends ContainerConfigIn
   tooltip?: Tooltip;
   /** Annotations component. Default: `undefined` */
   annotations?: Annotations | undefined;
+  /** Callback function to be called when the chart rendering is complete. Default: `undefined` */
+  onRenderComplete?: (
+    svgNode: SVGSVGElement,
+    margin: Spacing,
+    containerWidth: number,
+    containerHeight: number,
+    componentWidth: number,
+    componentHeight: number,
+  ) => void;
 }
 
 export const SingleContainerDefaultConfig: SingleContainerConfigInterface<unknown> = {

--- a/packages/ts/src/containers/single-container/index.ts
+++ b/packages/ts/src/containers/single-container/index.ts
@@ -113,6 +113,7 @@ export class SingleContainer<Data> extends ContainerCore {
     config.annotations?.render(duration)
 
     if (config.tooltip) config.tooltip.update()
+    config.onRenderComplete?.(this.svg.node(), config.margin, this.containerWidth, this.containerHeight, this.width, this.height)
   }
 
   // Re-defining the `render()` function to handle different sizing techniques (`Sizing.Extend` and `Sizing.FitWidth`)

--- a/packages/ts/src/containers/xy-container/config.ts
+++ b/packages/ts/src/containers/xy-container/config.ts
@@ -11,6 +11,7 @@ import { Crosshair } from 'components/crosshair'
 // Types
 import { ContinuousScale } from 'types/scale'
 import { Direction } from 'types/direction'
+import { Spacing } from 'types/spacing'
 
 export interface XYContainerConfigInterface<Datum> extends ContainerConfigInterface {
   /** An array of visualization components. Default: `[]` */
@@ -91,6 +92,16 @@ export interface XYContainerConfigInterface<Datum> extends ContainerConfigInterf
   annotations?: Annotations | undefined;
   /** Extend the clip path by the specified number of pixels. Default: `2` */
   clipPathExtend?: number;
+  /** Callback function to be called when the chart rendering is complete. Default: `undefined` */
+  onRenderComplete?: (
+    svgNode: SVGSVGElement,
+    margin: Spacing,
+    bleed: Spacing,
+    containerWidth: number,
+    containerHeight: number,
+    componentWidth: number,
+    componentHeight: number,
+  ) => void;
 }
 
 

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -293,6 +293,7 @@ export class XYContainer<Datum> extends ContainerCore {
     config.annotations?.render()
 
     this._firstRender = false
+    config.onRenderComplete?.(this.svg.node(), margin, this._getBleed(this.components), this.containerWidth, this.containerHeight, this.width, this.height)
   }
 
   private _updateScales<T extends XYComponentCore<Datum>> (...components: T[]): void {
@@ -365,13 +366,7 @@ export class XYContainer<Datum> extends ContainerCore {
     }
 
     // Get and combine bleed
-    const bleed = components.map(c => c.bleed).reduce((bleed, b) => {
-      for (const key of Object.keys(bleed)) {
-        const k = key as keyof Spacing
-        if (bleed[k] < b[k]) bleed[k] = b[k]
-      }
-      return bleed
-    }, { top: 0, bottom: 0, left: 0, right: 0 })
+    const bleed = this._getBleed(components)
 
     // Update scale range
     for (const c of components) {
@@ -436,6 +431,16 @@ export class XYContainer<Datum> extends ContainerCore {
       left: margin.left + this._axisMargin.left,
       right: margin.right + this._axisMargin.right,
     }
+  }
+
+  private _getBleed<T extends XYComponentCore<Datum>> (components: T[]): Spacing {
+    return components.map(c => c.bleed).reduce((bleed, b) => {
+      for (const key of Object.keys(bleed)) {
+        const k = key as keyof Spacing
+        if (bleed[k] < b[k]) bleed[k] = b[k]
+      }
+      return bleed
+    }, { top: 0, bottom: 0, left: 0, right: 0 })
   }
 
   public destroy (): void {


### PR DESCRIPTION
Introduce a callback in the container configuration to notify when a chart's rendering is complete.

- Add onRenderComplete to ContainerConfigInterface with appropriate types.
- Invoke the callback in SingleContainer and XYContainer render methods after rendering.

@lee00678 We've been using this feature for a while now, but I forgot to create a PR to the upstream