### PR TITLE
Component | Graph | Link Labels: Use `color` instead of `fill` for <use> elements

### DIFF
--- a/packages/ts/src/components/graph/modules/link/index.ts
+++ b/packages/ts/src/components/graph/modules/link/index.ts
@@ -292,7 +292,7 @@ export function updateLinks<N extends GraphInputNode, L extends GraphInputLink> 
           .attr('y', -linkLabelDatum._fontSizePx / 2)
           .attr('width', linkLabelDatum._fontSizePx)
           .attr('height', linkLabelDatum._fontSizePx)
-          .style('fill', linkLabelColor)
+          .style('color', linkLabelColor)
       } else {
         linkLabelContent
           .text(linkLabelText)


### PR DESCRIPTION
Otherwise, it's not propagated to the icons.

### Before
<img width="285" height="154" alt="SCR-20251106-maqf" src="https://github.com/user-attachments/assets/fe5fca2c-f712-44a8-a17d-714c588a013a" />

### After
<img width="231" height="153" alt="SCR-20251106-marh" src="https://github.com/user-attachments/assets/8e1df82c-d035-4b8f-9a56-9dcadecf9a94" />
