### PR TITLE
Component | Leaflet Map: Don't throttle wheel event

### DIFF
--- a/packages/ts/src/components/leaflet-map/modules/map.ts
+++ b/packages/ts/src/components/leaflet-map/modules/map.ts
@@ -12,7 +12,7 @@ import { LeafletMapConfigInterface } from '../config'
 // Local Types
 
 // Utils
-import { constraintMapView, mapboxglWheelEventThrottled } from '../renderer/mapboxgl-utils'
+import { constraintMapView, mapboxglWheelEvent } from '../renderer/mapboxgl-utils'
 
 // Styles
 import * as s from '../style'
@@ -135,7 +135,7 @@ export async function setupMap<T extends GenericDataRecord> (mapContainer: HTMLE
 
       select(mapContainer).on('wheel', (event: WheelEvent) => {
         event.preventDefault()
-        mapboxglWheelEventThrottled(leafletMap, layer as (L.Layer & { getMaplibreMap(): Map }), event)
+        mapboxglWheelEvent(leafletMap, layer as (L.Layer & { getMaplibreMap(): Map }), event)
       })
       break
     case LeafletMapRenderer.Raster:

--- a/packages/ts/src/components/leaflet-map/renderer/mapboxgl-utils.ts
+++ b/packages/ts/src/components/leaflet-map/renderer/mapboxgl-utils.ts
@@ -43,5 +43,4 @@ export function mapboxglWheelEvent (
   map.setZoomAround(xy, zoom + 1, { animate: false })
 }
 
-export const mapboxglWheelEventThrottled = throttle(mapboxglWheelEvent, 32)
 export const constraintMapViewThrottled = throttle(constraintMapView, 1000)


### PR DESCRIPTION
Currently, the map zoom via mouse/trackpad is very slow on 120Hz screens (i.e., on all modern Macs). This happens because we throttle the wheel event handler, while 120Hz screens tend to produce more zoom events with a smaller delta, and we simply drop them. This PR removes throttling, which fixes the issue.

The issue is hard to see on video, but it's very noticeable when you interact with the map yourself.

### Before

https://github.com/user-attachments/assets/70e2f475-3ac8-4815-b567-54a180dfb5a3


### After

https://github.com/user-attachments/assets/600ad7ba-88fe-41f0-8bea-83e4f123f0ba

