### PR TITLE
Component | Graph: Fix node coordinate flickering

### DIFF
--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -427,6 +427,14 @@ export class Graph<
   private async _calculateLayout (): Promise<void> {
     const { config, datamodel } = this
 
+    // FIX: Always ensure nodes have valid x/y positions before layout calculation
+    // This prevents D3 force simulation from initializing nodes at NaN/undefined
+    // which causes the flickering effect and "undefined coordinates" errors
+    for (const node of datamodel.nodes) {
+      if (!node.x || isNaN(node.x)) node.x = this._width / 2
+      if (!node.y || isNaN(node.y)) node.y = this._height / 2
+    }
+
     // If the layout type has changed, we need to reset the node positions if they were fixed before
     if (this._currentLayoutType !== config.layoutType) {
       for (const node of datamodel.nodes) {


### PR DESCRIPTION
## Problem
Nodes flicker to (0,0) or spiral positions during initial render, layout changes, or when adding nodes dynamically. This happens when node coordinates are undefined/NaN.

## Solution
Ensure all nodes have valid x/y coordinates (defaulting to graph center) before layout calculation. This prevents D3's force simulation from initializing nodes at invalid positions.

## Changes
- Added coordinate validation in `_calculateLayout()` before any layout algorithm runs
- Nodes with invalid coordinates are initialized to graph center (`width/2`, `height/2`)

## Testing
- ✅ Initial render
- ✅ Layout switching
- ✅ Dynamic node addition
- ✅ No console errors