### PR TITLE
Component | Treemap: Fix update transition

### DIFF
--- a/packages/ts/src/components/treemap/index.ts
+++ b/packages/ts/src/components/treemap/index.ts
@@ -292,12 +292,9 @@ export class Treemap<Datum> extends ComponentCore<Datum[], TreemapConfigInterfac
       }
     })
 
-    // Transition group position
+    // Transition group position and text opacity (fade-in)
     smartTransition(mergedTiles.select(`g.${s.labelGroup}`), duration)
       .attr('transform', d => `translate(${d.x0 + config.labelOffsetX},${d.y0 + config.labelOffsetY})`)
-
-    // Transition text opacity only (fade-in)
-    smartTransition(mergedTiles.select(`g.${s.labelGroup}`), duration)
       .style('opacity', 1)
 
     // Hide labels that don't meet criteria


### PR DESCRIPTION
`smartTransition` is known to interrupt existing opacity transitions, this change fixes transitions on label groups.