### PR TITLE
Component | Axis: Improve axis rendering performances

### DIFF
--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -40,7 +40,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   private _requiredMargin: Spacing
   private _defaultNumTicks = 3
   private _collideTickLabelsAnimFrameId: ReturnType<typeof requestAnimationFrame>
-  private _textStyle: {
+  private _tickTextStyleCached: {
     fontSize: number;
     fontFamily: string;
     fontWidthToHeightRatio: number;
@@ -285,9 +285,9 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         wordBreak: config.tickTextForceWordBreak,
       }
 
-      if (!this._textStyle) {
+      if (!this._tickTextStyleCached) {
         const styleDeclaration = getComputedStyle(textElement)
-        this._textStyle = {
+        this._tickTextStyleCached = {
           fontSize: Number.parseFloat(styleDeclaration.fontSize),
           fontFamily: styleDeclaration.fontFamily,
           fontWidthToHeightRatio: getFontWidthToHeightRatio(),
@@ -296,16 +296,11 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
       if (config.tickTextFitMode === FitMode.Trim) {
         const textElementSelection = select<SVGTextElement, string>(textElement).text(text)
-        trimSVGText(textElementSelection, textMaxWidth, config.tickTextTrimType as TrimMode, true, this._textStyle.fontSize, 0.58)
+        trimSVGText(textElementSelection, textMaxWidth, config.tickTextTrimType as TrimMode, true, this._tickTextStyleCached.fontSize, 0.58)
         text = select<SVGTextElement, string>(textElement).text()
       }
 
-      const textBlock: UnovisText = {
-        text,
-        fontFamily: this._textStyle.fontFamily,
-        fontSize: this._textStyle.fontSize,
-        fontWidthToHeightRatio: this._textStyle.fontWidthToHeightRatio,
-      }
+      const textBlock: UnovisText = { text, ...this._tickTextStyleCached }
       renderTextToSvgTextElement(textElement, textBlock, textOptions, false)
     })
 


### PR DESCRIPTION
### Problem 
I've found a page with 9 XY charts to be slow at render. It's seems to be due to multiple calls of `window.getComputedStyle()` when rendering the text of each tick label (this triggers a reflow / recalc).

### Solution
Put the computed style of the first tick label in an object (`_textStyle`). For each future labels, the cached style will be applied. I've also added `fontWidthToHeightRatio` because it was recalculated in in `utils/text` functions multiple times.

### Attachments
Before ~4s:
<img width="1454" height="362" alt="image" src="https://github.com/user-attachments/assets/ca9f1cc9-1c63-462b-9530-af5ca8f0f22a" />

After ~1s:
<img width="1264" height="493" alt="image" src="https://github.com/user-attachments/assets/1d810c12-89c5-403f-864a-e6f23f77be14" />
