### PR TITLE
Component | Axis: Correct dominantBaseline for Y axis

### DIFF
--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -316,7 +316,8 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       }
 
       const textBlock: UnovisText = { text, ...this._tickTextStyleCached }
-      renderTextToSvgTextElement(textElement, textBlock, textOptions, 'central')
+      const dominantBaseline = config.type === AxisType.X ? 'central' : 'hanging'
+      renderTextToSvgTextElement(textElement, textBlock, textOptions, dominantBaseline)
     })
 
     selection

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -508,6 +508,9 @@ export function renderTextToSvgTextElement (
   textElement: SVGTextElement,
   text: UnovisText | UnovisText[],
   options: UnovisTextOptions,
+  // Dominant baseline sets alignment for a line of text, whereas
+  // the `options.verticalAlign` property sets alignment for the entire text block
+  // shifting it vertically, irrespective of the dominant baseline.
   dominantBaseline?: string
 ): void {
   const wrappedText = getWrappedText(text, options.width, undefined, options.fastMode, options.separator, options.wordBreak)


### PR DESCRIPTION
Fixes Y axis tick labels positioing

### Before (Not centered)
<img width="813" height="262" alt="SCR-20260120-lqmu" src="https://github.com/user-attachments/assets/0e0c1371-9c81-478a-b2a9-1a2ad8fe3bcd" />

### After (Centered)
<img width="882" height="250" alt="SCR-20260120-lqjy" src="https://github.com/user-attachments/assets/d00922b8-edcd-4fb4-86d3-9f820287872f" />
