### PR TITLE
Component | Brush: Configurable brush height extension

### DIFF
--- a/packages/angular/src/components/brush/brush.component.ts
+++ b/packages/angular/src/components/brush/brush.component.ts
@@ -91,6 +91,10 @@ export class VisBrushComponent<Datum> implements BrushConfigInterface<Datum>, Af
 
   /** Constraint Brush selection to a minimal length in data units. Default: `undefined` */
   @Input() selectionMinLength?: number
+
+  /** Extend the brush height by the specified number of pixels. This can be convenient when you have thick lines
+   * at the bottom of the chart and you want to ensure they stay fully covered by the brush. Default: `0` */
+  @Input() brushHeightExtend?: number
   @Input() data: Datum[]
 
   component: Brush<Datum> | undefined
@@ -112,8 +116,8 @@ export class VisBrushComponent<Datum> implements BrushConfigInterface<Datum>, Af
   }
 
   private getConfig (): BrushConfigInterface<Datum> {
-    const { duration, events, attributes, onBrush, onBrushStart, onBrushMove, onBrushEnd, handleWidth, selection, draggable, handlePosition, selectionMinLength } = this
-    const config = { duration, events, attributes, onBrush, onBrushStart, onBrushMove, onBrushEnd, handleWidth, selection, draggable, handlePosition, selectionMinLength }
+    const { duration, events, attributes, onBrush, onBrushStart, onBrushMove, onBrushEnd, handleWidth, selection, draggable, handlePosition, selectionMinLength, brushHeightExtend } = this
+    const config = { duration, events, attributes, onBrush, onBrushStart, onBrushMove, onBrushEnd, handleWidth, selection, draggable, handlePosition, selectionMinLength, brushHeightExtend }
     const keys = Object.keys(config) as (keyof BrushConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/brush/brush-line-chart/index.tsx
+++ b/packages/dev/src/examples/xy-components/brush/brush-line-chart/index.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+import { VisXYContainer, VisLine, VisAxis, VisBrush } from '@unovis/react'
+import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Brush & Line Chart'
+export const subTitle = 'Using brushHeightExtend'
+
+const data = generateXYDataRecords(50).map((d, i) => ({
+  ...d,
+  y: i < 15 ? 0 : 15,
+}))
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [brushHeightExtend, setBrushHeightExtend] = useState(4)
+
+  return (
+    <div>
+      <div style={{ marginBottom: 10 }}>
+        <label>
+          brushHeightExtend: {brushHeightExtend}
+          <input
+            type="range"
+            min={0}
+            max={5}
+            step={1}
+            value={brushHeightExtend}
+            onChange={e => setBrushHeightExtend(Number(e.target.value))}
+            style={{ marginLeft: 10, width: 200 }}
+          />
+        </label>
+      </div>
+      <VisXYContainer<XYDataRecord> data={data} height={300} clipPathExtend={4}>
+        <VisLine<XYDataRecord> x={d => d.x} y={d => d.y} duration={props.duration} lineWidth={8}/>
+        <VisBrush
+          draggable={true}
+          duration={0}
+          brushHeightExtend={brushHeightExtend}
+        />
+        <VisAxis type='x' tickTextHideOverlapping={true} duration={props.duration} />
+        <VisAxis type='y' duration={props.duration} />
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/ts/src/components/brush/config.ts
+++ b/packages/ts/src/components/brush/config.ts
@@ -32,6 +32,9 @@ export interface BrushConfigInterface<Datum> extends Partial<XYComponentConfigIn
   handlePosition?: Arrangement.Inside | Arrangement.Outside | string;
   /** Constraint Brush selection to a minimal length in data units. Default: `undefined` */
   selectionMinLength?: number;
+  /** Extend the brush height by the specified number of pixels. This can be convenient when you have thick lines
+   * at the bottom of the chart and you want to ensure they stay fully covered by the brush. Default: `0` */
+  brushHeightExtend?: number;
 }
 
 export const BrushDefaultConfig: BrushConfigInterface<unknown> = {
@@ -49,4 +52,5 @@ export const BrushDefaultConfig: BrushConfigInterface<unknown> = {
   draggable: false,
   handlePosition: Arrangement.Inside,
   selectionMinLength: undefined,
+  brushHeightExtend: 0,
 }

--- a/packages/ts/src/components/brush/index.ts
+++ b/packages/ts/src/components/brush/index.ts
@@ -23,13 +23,13 @@ import * as s from './style'
 export class Brush<Datum> extends XYComponentCore<Datum, BrushConfigInterface<Datum>> {
   static selectors = s
   protected _defaultConfig = BrushDefaultConfig as BrushConfigInterface<Datum>
-  clippable = false // Don't apply clipping path to this component. See XYContainer
+  public clippable = false // Don't apply clipping path to this component. See XYContainer
   public config: BrushConfigInterface<Datum> = this._defaultConfig
-  brush: Selection<SVGGElement, unknown, SVGGElement, unknown>
-  unselectedRange: Selection<SVGRectElement, BrushHandleType, SVGGElement, unknown>
-  handleLines: Selection<SVGLineElement, BrushHandleType, SVGGElement, unknown>
-  brushBehaviour: BrushBehavior<unknown> = brushX()
-  events = {
+  public brush: Selection<SVGGElement, unknown, SVGGElement, unknown>
+  public unselectedRange: Selection<SVGRectElement, BrushHandleType, SVGGElement, unknown>
+  public handleLines: Selection<SVGLineElement, BrushHandleType, SVGGElement, unknown>
+  public brushBehaviour: BrushBehavior<unknown> = brushX()
+  public events = {
     [Brush.selectors.brush]: {},
   }
 
@@ -62,9 +62,10 @@ export class Brush<Datum> extends XYComponentCore<Datum, BrushConfigInterface<Da
     const { brushBehaviour, config } = this
     const duration = isNumber(customDuration) ? customDuration : config.duration
     const xScale = this.xScale
+    const height = this._getBrushHeight()
 
     brushBehaviour
-      .extent([[0, 0], [this._width, this._height]])
+      .extent([[0, 0], [this._width, height]])
       .on('start', this._onBrushStart.bind(this))
       .on('brush', this._onBrushMove.bind(this))
       .on('end', this._onBrushEnd.bind(this))
@@ -73,7 +74,7 @@ export class Brush<Datum> extends XYComponentCore<Datum, BrushConfigInterface<Da
       .call(brushBehaviour)
       .classed('non-draggable', !config.draggable)
 
-    const yRange = [this._height, 0]
+    const yRange = [height, 0]
     const h = yRange[0] - yRange[1]
 
     this.g.selectAll('.handle')
@@ -120,11 +121,15 @@ export class Brush<Datum> extends XYComponentCore<Datum, BrushConfigInterface<Da
     this._positionHandles(s)
 
     // D3 sets brush handle height to be too long, so we need to update it
-    const yRange = [this._height, 0]
+    const yRange = [this._getBrushHeight(), 0]
     const h = yRange[0] - yRange[1]
     this.g.selectAll('.handle')
       .attr('y', yRange[1])
       .attr('height', h)
+  }
+
+  private _getBrushHeight (): number {
+    return this._height + this.config.brushHeightExtend
   }
 
   private _positionHandles (s: [number, number]): void {

--- a/packages/website/docs/auxiliary/Brush.mdx
+++ b/packages/website/docs/auxiliary/Brush.mdx
@@ -84,6 +84,23 @@ By default, setting the desired the range relies on moving both start and end _B
 `handleWidth` sets the width in pixels of the _Brush_'s handle:
 <XYWrapperWithInput {...brushProps()} property="handleWidth" inputType="range" defaultValue={20}/>
 
+### Brush Height Extend
+`brushHeightExtend` extends the brush height by the specified number of pixels. This can be useful when you have
+thick lines at the bottom of the chart and want to ensure they stay fully covered by the brush.
+<XYWrapperWithInput {...brushProps()}
+    components={[
+      axis('x'),
+      { name: 'Line',props: { x: d => d.x, y: (d, i) => i < 15 ? 0 : 15, lineWidth: 8}, key: "components" },
+      ]
+    }
+    selection={[3,6]}
+    containerProps={{ clipPathExtend: 4 }}
+    property="brushHeightExtend"
+    inputType="range"
+    inputProps={{ min: 0, max: 5 }}
+    defaultValue={4}
+/>
+
 ### Selection
 You can change the appearance of the selection by changing the corresponding CSS variables.
 For example, here's how you can modify the appearance of the selected and unselected areas:


### PR DESCRIPTION
Currently when Brush is use with Line, and the line is at 0, a part of it won't be covered by the brush: 
<img width="786" height="101" alt="image" src="https://github.com/user-attachments/assets/fe7de5fd-9290-459a-89b2-ef3cdee545e7" />.

The happens because we allow the line to go outside of the plotting area a little for better visual appearance, but the Brush component is sized precisely.

This PR adds a property that allows to extend the height of the brush.

- New config property `brushHeightExtend` (similar to `clipPathExtend` in XYContainer)
- Angular wrapper generated
- New Dev Example

  https://github.com/user-attachments/assets/586cd422-0411-4c3d-b908-4428f3162b7b

- Updated Docs

  https://github.com/user-attachments/assets/481aa6c4-10d1-48b2-bc4a-0ac1b5643803

