### PR TITLE
Misc | Release: Fix update version script

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -57,6 +57,7 @@
     "vue": "^3"
   },
   "devDependencies": {
+    "@unovis/ts": "workspace:*",
     "@unovis/shared": "workspace:*",
     "@antfu/eslint-config": "^3.9.1",
     "@rollup/plugin-node-resolve": "^13.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,10 +746,6 @@ importers:
         version: 4.2.2(rollup@2.79.2)
 
   packages/vue:
-    dependencies:
-      '@unovis/ts':
-        specifier: 1.6.4
-        version: 1.6.4
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^3.9.1
@@ -760,6 +756,9 @@ importers:
       '@unovis/shared':
         specifier: workspace:*
         version: link:../shared
+      '@unovis/ts':
+        specifier: workspace:*
+        version: link:../ts
       '@vitejs/plugin-vue':
         specifier: ^5.2.3
         version: 5.2.4(vite@6.4.1(@types/node@17.0.45)(jiti@2.6.1)(less@4.5.1)(sass@1.97.2)(stylus@0.59.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.27(typescript@5.6.3))
@@ -4457,9 +4456,6 @@ packages:
 
   '@unovis/graphlibrary@2.2.0-2':
     resolution: {integrity: sha512-HeEzpd/vDyWiIJt0rnh+2ICXUIuF2N0+Z9OJJiKg0DB+eFUcD+bk+9QPhYHwkFwfxdjDA9fHi1DZ/O/bbV58Nw==}
-
-  '@unovis/ts@1.6.4':
-    resolution: {integrity: sha512-LH8AqYuiVxMcm/SP/VsBKfBa6tu37CJapcn8qeRATZvtYuh8RBDnXr3ejwJyEUvIYJzbPuHOEQo9WIDre9CK1Q==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -18467,79 +18463,6 @@ snapshots:
   '@unovis/graphlibrary@2.2.0-2':
     dependencies:
       lodash-es: 4.17.23
-
-  '@unovis/ts@1.6.4':
-    dependencies:
-      '@emotion/css': 11.13.5
-      '@juggle/resize-observer': 3.4.0
-      '@types/d3': 7.4.3
-      '@types/d3-array': 3.2.2
-      '@types/d3-axis': 3.0.6
-      '@types/d3-brush': 3.0.6
-      '@types/d3-chord': 3.0.6
-      '@types/d3-collection': 1.0.13
-      '@types/d3-color': 3.1.3
-      '@types/d3-drag': 3.0.7
-      '@types/d3-ease': 3.0.2
-      '@types/d3-force': 3.0.10
-      '@types/d3-geo': 3.1.0
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-path': 3.1.1
-      '@types/d3-sankey': 0.12.5
-      '@types/d3-scale': 4.0.9
-      '@types/d3-selection': 3.0.11
-      '@types/d3-shape': 3.1.8
-      '@types/d3-timer': 3.0.2
-      '@types/d3-transition': 3.0.9
-      '@types/d3-zoom': 3.0.8
-      '@types/dagre': 0.7.53
-      '@types/geojson': 7946.0.16
-      '@types/leaflet': 1.7.6
-      '@types/supercluster': 5.0.3
-      '@types/three': 0.135.0
-      '@types/throttle-debounce': 5.0.2
-      '@types/topojson': 3.2.6
-      '@types/topojson-client': 3.1.5
-      '@types/topojson-specification': 1.0.5
-      '@unovis/dagre-layout': 0.8.8-2
-      '@unovis/graphlibrary': 2.2.0-2
-      d3: 7.9.0
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-brush: 3.0.0
-      d3-chord: 3.0.1
-      d3-collection: 1.0.7
-      d3-color: 3.1.0
-      d3-drag: 3.0.0
-      d3-ease: 3.0.1
-      d3-force: 3.0.0
-      d3-geo: 3.1.1
-      d3-geo-projection: 4.0.0
-      d3-hierarchy: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-interpolate-path: 2.3.0
-      d3-path: 3.1.0
-      d3-sankey: 0.12.3
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-timer: 3.0.1
-      d3-transition: 3.0.1(d3-selection@3.0.0)
-      d3-zoom: 3.0.0
-      elkjs: 0.10.2
-      geojson: 0.5.0
-      leaflet: 1.7.1
-      maplibre-gl: 2.4.0
-      striptags: 3.2.0
-      supercluster: 7.1.5
-      three: 0.135.0
-      throttle-debounce: 5.0.2
-      topojson-client: 3.1.0
-      tslib: 2.8.1
-      typescript: 4.2.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true

--- a/update-version.sh
+++ b/update-version.sh
@@ -4,7 +4,10 @@ read new_version
 echo Updating version to $new_version
 
 current_version=$(node -e "console.log(require('./package.json').version)")
-pnpm version ${new_version} --workspaces
-perl -pi -e "s/\"version\": \"${current_version}\"/\"version\": \"${new_version}\"/g" package.json
+# Update version in all package.json files
+perl -pi -e "s/\"version\": \"${current_version}\"/\"version\": \"${new_version}\"/g" package.json packages/*/package.json
+# Update website and dev package versions (not in workspaces but should match)
+perl -pi -e "s/\"version\": \"[^\"]*\"/\"version\": \"${new_version}\"/g" packages/website/package.json packages/dev/package.json
+# Update @unovis/ts peer dependencies to the new version
 perl -pi -e "s/\"\@unovis\/ts\": \"${current_version}\"/\"\@unovis\/ts\": \"${new_version}\"/g" packages/*/package.json
 pnpm install --ignore-scripts


### PR DESCRIPTION
This PR fixes two issues:

- [ ] Version update was missing for `/dev` and `/website` since it was not part of the `workspace`
- [ ] `pnpm version ${new_version} --workspaces` this line doesn't understand `workspace:*` and tries to pull the latest(unpublished) version from npm. So instead of using pnpm, we just call perl. 