### PR TITLE
Component | TopoJSON: Deprecate PointLabelPosition, add PointBottomLabel

### DIFF
--- a/packages/dev/src/examples/maps/topojson/point-shapes/index.tsx
+++ b/packages/dev/src/examples/maps/topojson/point-shapes/index.tsx
@@ -41,7 +41,7 @@ export const component = (): React.ReactNode => {
         <VisTopoJSONMap<any, DataRecord, any>
           topojson={WorldMapTopoJSON}
           pointRingWidth={ringWidth}
-          pointLabel={d => d.id}
+          pointBottomLabel={d => d.id}
           pointShape={d => d.shape}
           pointColor={d => d.pointColor}
           duration={500}

--- a/packages/ts/src/components/topojson-map/config.ts
+++ b/packages/ts/src/components/topojson-map/config.ts
@@ -100,10 +100,20 @@ export interface TopoJSONMapConfigInterface<
   longitude?: NumericAccessor<PointDatum>;
   /** Point latitude accessor function. Default: `d => d.latitude ?? null` */
   latitude?: NumericAccessor<PointDatum>;
-  /** Point label accessor function. Default: `undefined` */
+  /** Point inner label accessor function. Default: `undefined`  */
   pointLabel?: StringAccessor<PointDatum>;
-  /** Point label position. Default: `Position.Bottom` */
+  /** Point inner label color accessor function or constant value.
+   * By default, the label color will be set, depending on the point brightness, either to
+   * `--vis-map-point-label-text-color-dark` or to `--vis-map-point-label-text-color-light` CSS variable.
+   * Default: `undefined`
+  */
+  pointLabelColor?: ColorAccessor<PointDatum>;
+  /** Point label position. Default: `MapPointLabelPosition.Center`
+   * @deprecated Point labels are now always centered within points. Use pointBottomLabel for labels below points.
+   */
   pointLabelPosition?: MapPointLabelPosition;
+  /** Point bottom label accessor function. Default: `undefined` */
+  pointBottomLabel?: StringAccessor<PointDatum>;
   /** Point color brightness ratio for switching between dark and light text label color. Default: `0.65` */
   pointLabelTextBrightnessRatio?: number;
   /** Point id accessor function. Default: `d => d.id` */
@@ -167,7 +177,9 @@ export const TopoJSONMapDefaultConfig: TopoJSONMapConfigInterface<unknown, unkno
   pointRingWidth: (d: unknown): number => (d as { ringWidth: number }).ringWidth ?? 2,
   pointCursor: null,
   pointLabel: undefined,
-  pointLabelPosition: MapPointLabelPosition.Bottom,
+  pointLabelColor: undefined,
+  pointLabelPosition: MapPointLabelPosition.Center,
+  pointBottomLabel: undefined,
   pointLabelTextBrightnessRatio: 0.65,
   pointId: (d: unknown): string => (d as { id: string }).id,
 

--- a/packages/ts/src/components/topojson-map/style.ts
+++ b/packages/ts/src/components/topojson-map/style.ts
@@ -27,7 +27,11 @@ export const variables = injectGlobal`
     // Undefined by default to allow proper fallback to var(--vis-font-family)
     /* --vis-map-point-label-font-family: */
     --vis-map-point-label-font-weight: 600;
-    --vis-map-point-label-font-size: 12px;'
+    --vis-map-point-label-font-size: 12px;
+
+    --vis-map-area-label-text-color: #5b5f6d;
+    --vis-map-area-label-font-weight: 600;
+    --vis-map-area-label-font-size: 12px;
 
     --vis-map-point-default-fill-color: #B9BEC3;
     --vis-map-point-ring-fill-color: #ffffff;
@@ -39,6 +43,7 @@ export const variables = injectGlobal`
     --vis-dark-map-boundary-color: #2a2a2a;
     --vis-dark-map-point-label-text-color-dark: #fff;
     --vis-dark-map-point-label-text-color-light:#5b5f6d;
+    --vis-dark-map-area-label-text-color: #fff;
     --vis-dark-map-point-default-fill-color: #B9BEC3;
     --vis-dark-map-point-default-stroke-color: #959da3;
     --vis-dark-map-point-ring-fill-color: #5b5f6d;
@@ -49,6 +54,7 @@ export const variables = injectGlobal`
     --vis-map-boundary-color: var(--vis-dark-map-boundary-color);
     --vis-map-point-label-text-color-dark: var(--vis-dark-map-point-label-text-color-dark);
     --vis-map-point-label-text-color-light: var(--vis-dark-map-point-label-text-color-light);
+    --vis-map-area-label-text-color: var(--vis-dark-map-area-label-text-color);
     --vis-map-point-default-fill-color: var(--vis-dark-map-point-default-fill-color);
     --vis-map-point-default-stroke-color: var(--vis-dark-map-point-default-stroke-color);
     --vis-map-point-ring-fill-color: var(--vis-dark-map-point-ring-fill-color);
@@ -73,10 +79,10 @@ export const areaLabel = css`
   cursor: default;
   pointer-events: none;
 
-  font-size: var(--vis-map-point-label-font-size);
-  font-family: var(--vis-map-point-label-font-family, var(--vis-font-family));
-  font-weight: var(--vis-map-point-label-font-weight);
-  fill: var(--vis-map-point-label-text-color-dark);
+  font-size: var(--vis-map-area-label-font-size);
+  font-family: var(--vis-map-area-label-font-family, var(--vis-font-family));
+  font-weight: var(--vis-map-area-label-font-weight);
+  fill: var(--vis-map-area-label-text-color);
 `
 
 export const background = css`
@@ -117,6 +123,19 @@ export const pointLabel = css`
   font-weight: var(--vis-map-point-label-font-weight);
   fill: var(--vis-map-point-default-fill-color);
   stroke-width: var(--vis-map-point-default-stroke-width);
+`
+
+export const pointBottomLabel = css`
+  label: point-bottom-label;
+
+  text-anchor: middle;
+  cursor: default;
+  pointer-events:none;
+
+  font-size: var(--vis-map-point-bottom-label-font-size, 10px);
+  font-family: var(--vis-map-point-label-font-family, var(--vis-font-family));
+  font-weight: 600;
+  fill: var(--vis-map-point-bottom-label-text-color, #5b5f6d);
 `
 
 export const links = css`


### PR DESCRIPTION
This PR does few things:

- Deprecate pointLabelPosition
- Adding PointBottomLabel: now PointLabel is always centered of the point, pointBottomLabel is dedicated for display label on the bottom with trim to 15 characters like leaflet map
- Add PointLabelColor params, like leaflet map

<img width="992" height="500" alt="Screenshot 2026-02-05 at 2 08 49 PM" src="https://github.com/user-attachments/assets/3cdaf61d-62ed-4395-90f9-7b77ce56ea4c" />
