### PR TITLE
Component | Axis: Provide function to `tickTextAlign`

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -72,10 +72,10 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   }
 
   /** Axis position: `Position.Top`, `Position.Bottom`, `Position.Right` or `Position.Left`. Default: `undefined` */
-  @Input() position?: Position | string
+  @Input() position?: Position | `${Position}`
 
   /** Axis type: `AxisType.X` or `AxisType.Y` */
-  @Input() type?: AxisType | string
+  @Input() type?: AxisType | `${AxisType}`
 
   /** Extend the axis domain line to be full width or full height. Default: `true` */
   @Input() fullSize?: boolean
@@ -90,10 +90,10 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   @Input() labelMargin?: number
 
   /** Label text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
-  @Input() labelTextFitMode?: FitMode | string
+  @Input() labelTextFitMode?: FitMode | `${FitMode}`
 
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
-  @Input() labelTextTrimType?: TrimMode | string
+  @Input() labelTextTrimType?: TrimMode | `${TrimMode}`
 
   /** Font color of the axis label as CSS string. Default: `null` */
   @Input() labelColor?: string | null
@@ -128,7 +128,7 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   @Input() numTicks?: number
 
   /** Tick text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
-  @Input() tickTextFitMode?: FitMode | string
+  @Input() tickTextFitMode?: FitMode | `${FitMode}`
 
   /** Maximum width in pixels for the tick text to be wrapped or trimmed. Default: `undefined` */
   @Input() tickTextWidth?: number
@@ -140,13 +140,13 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   @Input() tickTextForceWordBreak?: boolean
 
   /** Tick text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
-  @Input() tickTextTrimType?: TrimMode | string
+  @Input() tickTextTrimType?: TrimMode | `${TrimMode}`
 
   /** Font size of the tick text as CSS string. Default: `null` */
   @Input() tickTextFontSize?: string | null
 
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
-  @Input() tickTextAlign?: TextAlign | string
+  @Input() tickTextAlign?: TextAlign | `${TextAlign}` | ((tickValue: number | Date, tickIndex: number, tickValues: number[] | Date[], tickPosition: [number, number], componentWidth: number, componentHeight: number) => TextAlign | `${TextAlign}`)
 
   /** Font color of the tick text as CSS string. Default: `null` */
   @Input() tickTextColor?: string | null

--- a/packages/angular/src/components/timeline/timeline.component.ts
+++ b/packages/angular/src/components/timeline/timeline.component.ts
@@ -135,7 +135,7 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   /** Line start icon arrangement configuration. Controls how the icon is positioned relative to the line.
    * Accepts values from the Arrangement enum: `Arrangement.Start`, `Arrangement.Middle`, `Arrangement.End` or a string equivalent.
    * Default: `Arrangement.Inside` */
-  @Input() lineStartIconArrangement?: GenericAccessor<Arrangement | any, Datum>
+  @Input() lineStartIconArrangement?: GenericAccessor<Arrangement | `${Arrangement}`, Datum>
 
   /** Provide a href to an SVG defined in container's `svgDefs` to display an icon at the end of the line. Default: undefined */
   @Input() lineEndIcon?: StringAccessor<Datum>
@@ -149,7 +149,7 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   /** Line end icon arrangement configuration. Controls how the icon is positioned relative to the line.
    * Accepts values from the Arrangement enum: `Arrangement.Start`, `Arrangement.Middle`, `Arrangement.End` or a string equivalent.
    * Default: `Arrangement.Inside` */
-  @Input() lineEndIconArrangement?: GenericAccessor<Arrangement | any, Datum>
+  @Input() lineEndIconArrangement?: GenericAccessor<Arrangement | `${Arrangement}`, Datum>
 
   /** Configurable Timeline item cursor when hovering over. Default: `undefined` */
   @Input() lineCursor?: StringAccessor<Datum>
@@ -197,7 +197,7 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   @Input() rowMaxLabelWidth?: number
 
   /** Text alignment for labels: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `TextAlign.Right` */
-  @Input() rowLabelTextAlign?: TextAlign | any
+  @Input() rowLabelTextAlign?: TextAlign | `${TextAlign}`
 
 
   @Input() arrows?: TimelineArrow[]

--- a/packages/dev/src/examples/xy-components/axis/axis-tick-text-alignment/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-tick-text-alignment/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { VisXYContainer, VisArea, VisAxis } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { TextAlign } from '@unovis/ts'
+import { generateXYDataRecords, XYDataRecord } from '@src/utils/data'
+
+export const title = 'Tick Text Alignment'
+export const subTitle = 'Fine control'
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const data = generateXYDataRecords(10)
+  const yAccessors = [
+    (d: XYDataRecord) => d.y,
+  ]
+
+  const tickTextAlign = (tick: number | Date, i: number, ticks: number[] | Date[], pos: [number, number], width: number): TextAlign => {
+    if (i === 0) return TextAlign.Left
+    if (i === ticks.length - 1 && pos[0] > (width - 10)) return TextAlign.Right
+    return TextAlign.Center
+  }
+
+  const tickFormat = (tick: number | Date): string => `${tick}ms`
+
+  return (<>
+    <p style={{ fontSize: 18 }}>This example shows to how to control the text alignment of the tick labels granularly by providing a function to <code>tickTextAlign</code>.</p>
+    <p>The first last X axis tick label is left aligned, the last one is too close to the edge of the chart and should be right aligned:</p>
+    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }} height={150}>
+      <VisArea x={d => d.x} y={yAccessors} duration={props.duration}/>
+      <VisAxis type='x' minMaxTicksOnly={true} tickTextAlign={tickTextAlign} tickFormat={tickFormat} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number | Date) => `${y}bps`} duration={props.duration}/>
+    </VisXYContainer>
+    <p>When the last label fits, it should be center aligned:</p>
+    <VisXYContainer<XYDataRecord> data={data} margin={{ top: 5, left: 5 }} height={150}>
+      <VisArea x={d => d.x} y={yAccessors} duration={props.duration}/>
+      <VisAxis type='x' numTicks={5} tickTextHideOverlapping={true} tickTextAlign={tickTextAlign} tickFormat={tickFormat} duration={props.duration}/>
+      <VisAxis type='y' tickFormat={(y: number | Date) => `${y}bps`} duration={props.duration}/>
+    </VisXYContainer>
+  </>
+  )
+}

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -8,9 +8,9 @@ import { FitMode, TrimMode, TextAlign } from 'types/text'
 // We extend partial XY config interface because x and y properties are optional for Axis
 export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInterface<Datum>> {
   /** Axis position: `Position.Top`, `Position.Bottom`, `Position.Right` or `Position.Left`. Default: `undefined` */
-  position?: Position | string;
+  position?: Position | `${Position}`;
   /** Axis type: `AxisType.X` or `AxisType.Y` */
-  type?: AxisType | string;
+  type?: AxisType | `${AxisType}`;
   /** Extend the axis domain line to be full width or full height. Default: `true` */
   fullSize?: boolean;
   /** Axis label. Default: `undefined` */
@@ -20,9 +20,9 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   /** Distance between the axis and the label in pixels. Default: `8` */
   labelMargin?: number;
   /** Label text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
-  labelTextFitMode?: FitMode | string;
+  labelTextFitMode?: FitMode | `${FitMode}`;
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
-  labelTextTrimType?: TrimMode | string;
+  labelTextTrimType?: TrimMode | `${TrimMode}`;
   /** Font color of the axis label as CSS string. Default: `null` */
   labelColor?: string | null;
   /** Sets whether to draw the grid lines or not. Default: `true` */
@@ -46,7 +46,7 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   /** Set the approximate number of axis ticks (will be passed to D3's axis constructor). Default: `undefined` */
   numTicks?: number;
   /** Tick text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
-  tickTextFitMode?: FitMode | string;
+  tickTextFitMode?: FitMode | `${FitMode}`;
   /** Maximum width in pixels for the tick text to be wrapped or trimmed. Default: `undefined` */
   tickTextWidth?: number;
   /** Tick text wrapping separator. String or array of strings. Default: `undefined` */
@@ -54,11 +54,12 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   /** Force word break for ticks when they don't fit. Default: `false` */
   tickTextForceWordBreak?: boolean;
   /** Tick text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
-  tickTextTrimType?: TrimMode | string;
+  tickTextTrimType?: TrimMode | `${TrimMode}`;
   /** Font size of the tick text as CSS string. Default: `null` */
   tickTextFontSize?: string | null;
   /** Text alignment for ticks: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `undefined` */
-  tickTextAlign?: TextAlign | string;
+  tickTextAlign?: TextAlign | `${TextAlign}` |
+  ((tickValue: number | Date, tickIndex: number, tickValues: number[] | Date[], tickPosition: [number, number], componentWidth: number, componentHeight: number) => TextAlign | `${TextAlign}`);
   /** Font color of the tick text as CSS string. Default: `null` */
   tickTextColor?: string | null;
   /** Text rotation angle for ticks. Default: `undefined` */

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -69,7 +69,7 @@ Change the label color with the `labelColor` property.
 The spacing between the label and the axis itself can be set with the `labelMargin` property:
 <XYWrapperWithInput {...axisProps()} label="Label" inputType="range" inputProps={{ min: 0, max: 50, step: 1}} defaultValue={5} property="labelMargin"/>
 
-### Grid Line
+## Grid Line
 You can enable or disable the visibility of the _Axis_ grid line with the `gridLine` property.
 <XYWrapperWithInput
   {...axisProps()}
@@ -82,18 +82,6 @@ You can enable or disable the visibility of the _Axis_ grid line with the `gridL
 ### Axis Domain Line
 You can enable or disable the visibility of the axis domain line with the `domainLine` property.
 <XYWrapperWithInput {...axisProps()} label="Label" inputType="checkbox" defaultValue={true} property="domainLine"/>
-
-### Providing Data to _Axis_
-If you use the _Axis_ component alone, without other xy-components, you'll need to provide an `x` accessor or `y` accessors to populate the axis values.
-Consider the following example with a single axis and a data array with x values in the range `0 < x < 10`:
-
-<XYWrapper {...axisProps()} x={d => d.x} showContext="full"/>
-Another example:
-
-```ts
-const x = (d: DataRecord) => d.x * 100
-```
-<XYWrapper {...axisProps()} x={d => d.x * 100} excludeTabs/>
 
 ## Tick Configuration
 The _Axis_ component supports a wide variety of tick customization options
@@ -115,8 +103,9 @@ You can customize how ticks are formatted using the `tickFormat` property and a 
 The following example uses Javascript's built-in Date formatter function `toDateString()`.
 <XYWrapper {...axisProps()} data={generateTimeSeries(10)} x={d => d.timestamp} tickFormat={d=> new Date(d).toDateString()}/>
 
-### Label Alignment
-Change the tick's label alignment with respect to the tick marker using `tickTextAlign` property with a TextAlign value: `TextAlign.Left`, `TextAlign.Right` or `TextAlign.Center`.
+### Tick Label Alignment
+Change the tick's label alignment with respect to the tick marker using `tickTextAlign`. It accepts a constant `TextAlign` value (`TextAlign.Left`, `TextAlign.Right` or `TextAlign.Center`)
+or a function for per-tick control. The function receives `(tickValue, tickIndex, ticksValues, tickPosition, componentWidth, componentHeight)` and should return a `TextAlign` value.
 <XYWrapperWithInput
   {...axisProps()}
   inputType="select"
@@ -125,7 +114,7 @@ Change the tick's label alignment with respect to the tick marker using `tickTex
   options={['right', 'center', 'left']}
   property="tickTextAlign"/>
 
-### Label Rotation
+### Tick Label Rotation
 Change the tick's label angle using `tickTextAngle` property with a number value. Use this variable along with `tickTextAlign` to make sure the tick label displays as desired.
 <XYWrapperWithInput
   {...axisProps()}
@@ -137,7 +126,7 @@ Change the tick's label angle using `tickTextAngle` property with a number value
   options={[15, 30, 45]}
   property="tickTextAngle"/>
 
-### Label Width
+### Tick Label Width
 To limit the width of the tick labels (in pixels), you can use the `tickTextWidth` property.
 <XYWrapperWithInput
   {...axisProps()}
@@ -148,7 +137,7 @@ To limit the width of the tick labels (in pixels), you can use the `tickTextWidt
   hiddenProps={{gridLine: false, x: d => d.timestamp, tickFormat: d=> new Date(d).toDateString()}}
 />
 
-### Label Fit Mode
+### Tick Label Fit Mode
 _Axis_ accepts the following values for the `tickTextFitMode` property: `FitMode.Wrap` or `FitMode.Trim`. This determines how the axis will
 handle tick text overflow. The following example showcases the previous example using `"trim"` instead of `"wrap"`.
 <XYWrapperWithInput inputType="select"
@@ -159,7 +148,7 @@ handle tick text overflow. The following example showcases the previous example 
   options={['trim', 'wrap']}
   property="tickTextFitMode"/>
 
-### Label Trim Type
+### Tick Label Trim Type
 When a tick label becomes too long, and you want to trim it, you can customize the trimming method with the `tickTextTrimType` property.
 _Axis_ accepts a `TrimMode` or a string. For example, when we configure `tickTextTrimType` to `TrimMode.Start`, we can see the start of the label gets cut off instead of the middle.
 <XYWrapperWithInput inputType="select"
@@ -182,7 +171,7 @@ In addition, you can enable a forced word break for overflowing tick labels with
   defaultValue={true}
   property="tickTextForceWordBreak"/>
 
-### Text Separator
+### Tick Label Separator
 _Axis_ accepts a `string` or `string[]` value for `tickTextSeparator` property. This will allow tick labels to be separated by custom values in the case of overflow.
 Note: this only takes effect when `FitMode.Wrap` is enabled and `tickTextWidth` is defined.
 <XYWrapperWithInput
@@ -273,6 +262,16 @@ You can include a chart within your _XY Container_ alongside your axes like this
     ...multiProps().components,
     { name: "Line", key: 'components', props: {x: d=>d.x, y: d=>d.y }}
   ]}/>
+
+## Using Axis Alone
+If you use the _Axis_ component alone, without other xy-components, you can provide an `x` accessor or `y` accessors to populate the axis values.
+Consider the following example with a single axis and a data array with x values in the range `0 < x < 10`:
+<XYWrapper {...axisProps()} x={d => d.x} height={50}/>
+<br />
+
+Alternatively, you can set the `xDomain` or `yDomain` property on `XYContainer` to set the domain of the axis:
+
+<XYWrapper {...axisProps()}  showContext="full" containerProps={{ xDomain: [0, 15] }}/>
 
 ## Additional Styling: CSS Variables
 The _Axis_ component supports additional styling via CSS variables that you can define for your visualization container. For example:


### PR DESCRIPTION
This PR implements granular control on tick text label alignment by allowing to provide a function.

- Also fixes the issue with incorrect required margin measurements during pre-render (the label alignment step was applied to a wrong SVG group).
- Better typings in `AxisConfigInterface`
- [x] A new dev example
  <img width="1027" height="506" alt="SCR-20260213-nspy" src="https://github.com/user-attachments/assets/61603dfe-fd21-4646-bda7-e911c40f7246" />
- [x] Docs updated (also reworked the "alone" usage section)
- [x] Angular wrapper update

---

This capability will enables users to fix an annoying problem with aligning two charts vertically (due to automatic margin calculation):
<img width="490" height="226" alt="image" src="https://github.com/user-attachments/assets/8175294c-72ef-4997-9700-11af2b639893" />

### Before

https://github.com/user-attachments/assets/abbfbd78-0b5b-4e58-bb13-d514e996df27


### After

https://github.com/user-attachments/assets/b0b1b101-e351-4983-b4c6-d669da686e69


