### PR TITLE
Feat/sankey zoom modifiers disable

### DIFF
--- a/packages/ts/src/components/sankey/config.ts
+++ b/packages/ts/src/components/sankey/config.ts
@@ -40,6 +40,8 @@ export interface SankeyConfigInterface<N extends SankeyInputNode, L extends Sank
   zoomExtent?: [number, number];
   /** Zoom interaction mode. Default: `SankeyZoomMode.XY` */
   zoomMode?: SankeyZoomMode | string;
+  /** Disable modifier keys. Has effect only for `SankeyZoomMode.XY` zoom mode. When `true`, zoom mode is not altered by modifier keys. Default: `false` */
+  disableZoomModifierKeys?: boolean;
   /** Type of animation on removing nodes. Default: `ExitTransitionType.Default` */
   exitTransitionType?: SankeyExitTransitionType;
   /** Type of animation on creating nodes. Default: `EnterTransitionType.Default` */
@@ -176,6 +178,7 @@ export const SankeyDefaultConfig: SankeyConfigInterface<SankeyInputNode, SankeyI
   enableZoom: false,
   zoomExtent: [1, 5] as [number, number],
   zoomMode: SankeyZoomMode.Y,
+  disableZoomModifierKeys: false,
   exitTransitionType: SankeyExitTransitionType.Default,
   enterTransitionType: SankeyEnterTransitionType.Default,
   id: (d: SankeyInputNode, i: number) => (d as { _id: string })._id ?? `${i}`,

--- a/packages/ts/src/components/sankey/index.ts
+++ b/packages/ts/src/components/sankey/index.ts
@@ -400,8 +400,8 @@ export class Sankey<
       // If Cmd (metaKey) is pressed, only change horizontal scale.
       // If Alt/Option (altKey) is pressed, only change vertical scale.
       const deltaK = transform.k / this._prevZoomTransform.k
-      const isHorizontalOnlyKey = Boolean(sourceEvent?.metaKey)
-      const isVerticalOnlyKey = !isHorizontalOnlyKey && Boolean(sourceEvent?.altKey)
+      const isHorizontalOnlyKey = !config.disableZoomModifierKeys && Boolean(sourceEvent?.metaKey)
+      const isVerticalOnlyKey = !isHorizontalOnlyKey && !config.disableZoomModifierKeys && Boolean(sourceEvent?.altKey)
       const isHorizontalOnly = isHorizontalOnlyKey || zoomMode === SankeyZoomMode.X
       const isVerticalOnly = isVerticalOnlyKey || zoomMode === SankeyZoomMode.Y
 

--- a/packages/website/docs/networks-and-flows/Sankey.mdx
+++ b/packages/website/docs/networks-and-flows/Sankey.mdx
@@ -93,12 +93,15 @@ proportionally to fit horizontally into its container; vertical scrolling will r
 ## Interactive Zoom and Pan
 Zooming scales the Sankey layout (not individual SVG elements), preserving stroke widths and label sizes. Mouse wheel zoom and drag panning are supported.
 
+When `XY` zoom mode is used, holding ⌘/Ctrl key will temporarily make zoom horizontal-only and holding Alt will temporarily make it vertical-only. Setting `disableZoomModifierKeys` to `true` disabled this behavior.
+
 - **enableZoom**: toggle interaction (default: `false`).
 - **zoomMode**: `SankeyZoomMode.XY | SankeyZoomMode.X | SankeyZoomMode.Y` (default: `SankeyZoomMode.Y`).
 - **zoomExtent**: allowed zoom range `[min, max]` (default: `[1, 5]`).
 - **zoomScale**: `[horizontal, vertical]` layout scale factors (programmatic control).
 - **zoomPan**: `[x, y]` pixel offsets (programmatic control).
 - **onZoom**: callback `(hScale, vScale, panX, panY, extent, event) => void`.
+- **disableZoomModifierKeys**: prevents ⌘/Ctrl and Alt modifiers from affecting effective zoom mode (default: `false`).
 
 Smart pan constraints prevent panning beyond diagram bounds.
 


### PR DESCRIPTION
Adding `disableZoomModifierKeys` and documenting modifiers behavior in Sankey diagram.