### PR TITLE
Component | Timeline: Label rendering fixes and Docs

### DIFF
--- a/packages/angular/src/components/timeline/timeline.component.ts
+++ b/packages/angular/src/components/timeline/timeline.component.ts
@@ -15,6 +15,7 @@ import {
   TimelineRowLabel,
   TimelineRowIcon,
   TextAlign,
+  TrimMode,
   TimelineArrow,
   TimelineLineRenderState,
 } from '@unovis/ts'
@@ -199,6 +200,12 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   /** Text alignment for labels: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `TextAlign.Right` */
   @Input() rowLabelTextAlign?: TextAlign | any
 
+  /** Row label trim mode when width is limited: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
+  @Input() rowLabelTrimMode?: TrimMode | any
+
+  /** Row label margin in pixels. Default: `5` */
+  @Input() rowLabelMargin?: number
+
 
   @Input() arrows?: TimelineArrow[]
 
@@ -231,8 +238,8 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   }
 
   private getConfig (): TimelineConfigInterface<Datum> {
-    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
-    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
+    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
+    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
     const keys = Object.keys(config) as (keyof TimelineConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/timeline/timeline-bleed/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-bleed/index.tsx
@@ -34,6 +34,8 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
         showEmptySegments={true}
         // lineEndIcon={'#circle_check_filled'}
         lineStartIcon={'#circle_check_filled'}
+        rowLabelMargin={[5, 15]}
+        rowIcon={() => ({ href: '#circle_check_filled', size: 20, color: '#eee' })}
         // lineEndIconArrangement={Arrangement.Outside}
         lineStartIconArrangement={Arrangement.Outside}
         showRowLabels

--- a/packages/dev/src/examples/xy-components/timeline/timeline-label-alignment/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-label-alignment/index.tsx
@@ -34,7 +34,7 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
         showRowLabels
         rowLabelTextAlign={TextAlign.Left}
         duration={props.duration}
-        rowLabelStyle={rowLabel => rowLabel.label === 'Row 24'
+        rowLabelStyle={rowLabel => rowLabel.label === 'Row 1'
           ? ({ fill: 'rgb(237, 116, 128)', cursor: 'pointer', 'text-decoration': 'underline', transform: 'translateX(5px)' })
           : undefined
         }

--- a/packages/dev/src/examples/xy-components/timeline/timeline-label-events/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-label-events/index.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import { VisXYContainer, VisTimeline, VisAxis } from '@unovis/react'
+import { Timeline, TimelineRowLabel } from '@unovis/ts'
+
+import { TimeDataRecord, generateTimeSeries } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Row Label Events'
+export const subTitle = 'Hover events on label area'
+
+const rows = ['Long Row', 'Empty Row 1', 'Empty Row 2']
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [hoveredLabel, setHoveredLabel] = useState<string | null>(null)
+
+  const data = generateTimeSeries(15, 3, 10).map((d, i) => ({
+    ...d,
+    type: rows[i % rows.length],
+  }))
+
+  const events = {
+    [Timeline.selectors.labelBackground]: {
+      mouseover: (d: { label: string }) => setHoveredLabel(d.label),
+      mouseleave: () => setHoveredLabel(null),
+    },
+  }
+
+  return (<>
+    <div style={{ marginBottom: 8, minHeight: 20, fontFamily: 'monospace', fontSize: 12 }}>
+      {hoveredLabel ? `Hovered: ${hoveredLabel}` : 'Hover a row label'}
+    </div>
+    <VisXYContainer<TimeDataRecord>
+      data={data} height={200}
+      style={{
+        '--vis-timeline-label-pointer-events': 'none',
+      }}>
+      <VisTimeline
+        lineRow={(d: TimeDataRecord) => d.type as string}
+        x={(d: TimeDataRecord) => d.timestamp}
+        rowHeight={50}
+        showRowLabels
+        duration={props.duration}
+        events={events}
+      />
+      <VisAxis type='x' numTicks={3} tickFormat={(x: number | Date) => new Date(x).toDateString()} duration={props.duration} />
+    </VisXYContainer>
+  </>)
+}

--- a/packages/dev/src/examples/xy-components/timeline/timeline-label-width/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-label-width/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { VisXYContainer, VisTimeline, VisAxis } from '@unovis/react'
+
+import { TimeDataRecord, generateTimeSeries } from '@src/utils/data'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { TextAlign, TimelineConfigInterface, TrimMode } from '@unovis/ts'
+
+export const title = 'Row Label Width'
+export const subTitle = 'Tweak the labels'
+
+const longLabels = [
+  'Short',
+  'Medium length row label',
+  'Very long label that should be truncated when width is limited',
+  'A',
+  'Another long one for testing ellipsis behavior',
+]
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const data = generateTimeSeries(15, 5, 10).map((d, i) => ({
+    ...d,
+    type: longLabels[i % longLabels.length],
+  }))
+
+  const common: TimelineConfigInterface<TimeDataRecord> = {
+    lineRow: (d: TimeDataRecord) => d.type as string,
+    x: (d: TimeDataRecord) => d.timestamp,
+    rowHeight: 24,
+    showRowLabels: true,
+    duration: props.duration,
+    rowLabelTrimMode: TrimMode.End,
+    rowLabelTextAlign: TextAlign.Right,
+  }
+  const axisProps = { type: 'x' as const, numTicks: 3, tickFormat: (x: number | Date) => new Date(x).toDateString(), duration: props.duration }
+
+  const rowLabelWidth = 120
+  const rowMaxLabelWidth = 180
+  return (
+    <>
+      <p>Using precise <code>rowLabelWidth</code> value: {rowLabelWidth}px</p>
+      <VisXYContainer<TimeDataRecord> data={data} height={200} margin={{ left: 0, right: 0, bottom: 40 }}>
+        <VisTimeline {...common} rowLabelWidth={rowLabelWidth} />
+        <VisAxis {...axisProps} />
+      </VisXYContainer>
+      <VisXYContainer<TimeDataRecord> data={data} height={200} margin={{ left: 10, right: 10, bottom: 40 }} style={{ marginTop: 24 }}>
+        <p>Using <code>rowMaxLabelWidth</code> value: {rowMaxLabelWidth}px</p>
+        <VisTimeline {...common} rowMaxLabelWidth={rowMaxLabelWidth} />
+        <VisAxis {...axisProps} />
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/dev/src/examples/xy-components/timeline/timeline-row-icons/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-row-icons/index.tsx
@@ -11,10 +11,11 @@ import icon from './icon.svg?raw'
 export const title = 'Row Icons'
 export const subTitle = 'Before text labels'
 
-export const component = (props: ExampleViewerDurationProps): JSX.Element => {
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const labels = ['English', 'Mandarin', 'Spanish', 'Hindi', 'Arabic', 'French', 'Portuguese']
   const data = generateTimeSeries(7, 20, 10).map((d, i) => ({
     ...d,
-    type: `Row ${i}`,
+    type: labels[i],
     lineWidth: 5 + Math.random() * 15,
   }))
   type Datum = typeof data[number]
@@ -33,6 +34,8 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
         lineWidth={(d) => d.lineWidth}
         lineCap
         rowLabelTextAlign={TextAlign.Left}
+        rowMaxLabelWidth={45}
+        rowLabelMargin={10}
         duration={props.duration}
         rowIcon={() => ({ href: '#chevron_down', size: 20, color: 'rgb(38, 86, 201)' })}
         showRowLabels
@@ -40,7 +43,7 @@ export const component = (props: ExampleViewerDurationProps): JSX.Element => {
       <VisAxis
         type='x'
         numTicks={3}
-        tickFormat={(x: number) => new Date(x).toDateString()}
+        tickFormat={(tick: number | Date) => new Date(tick).toDateString()}
         duration={props.duration}
       />
     </VisXYContainer>

--- a/packages/react/src/containers/single-container/index.tsx
+++ b/packages/react/src/containers/single-container/index.tsx
@@ -11,7 +11,7 @@ import { VisComponentElement } from 'src/types/dom'
 export type VisSingleContainerProps<Data> = SingleContainerConfigInterface<Data> & {
   data?: Data;
   className?: string;
-  style?: React.CSSProperties;
+  style?: React.CSSProperties & Record<`--${string}`, string | number>;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/react/src/containers/xy-container/index.tsx
+++ b/packages/react/src/containers/xy-container/index.tsx
@@ -11,7 +11,7 @@ import { VisComponentElement } from 'src/types/dom'
 export type VisXYContainerProps<Datum> = XYContainerConfigInterface<Datum> & {
   data?: Datum[];
   className?: string;
-  style?: React.CSSProperties;
+  style?: React.CSSProperties & Record<`--${string}`, string | number>;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -86,8 +86,8 @@ export interface TimelineConfigInterface<Datum> extends WithOptional<XYComponent
   rowLabelTextAlign?: TextAlign | `${TextAlign}`;
   /** Row label trim mode when width is limited: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
   rowLabelTrimMode?: TrimMode | `${TrimMode}`;
-  /** Row label margin in pixels. Default: `5` */
-  rowLabelMargin?: number;
+  /** Row label margin in pixels. Can be a single number or a `[left, right]` tuple. Default: `[0, 5]` */
+  rowLabelMargin?: number | [number, number];
 
   // Arrows
   arrows?: TimelineArrow[];
@@ -150,7 +150,7 @@ export const TimelineDefaultConfig: TimelineConfigInterface<unknown> = {
   rowMaxLabelWidth: undefined,
   rowLabelTextAlign: TextAlign.Right,
   rowLabelTrimMode: TrimMode.Middle,
-  rowLabelMargin: 5,
+  rowLabelMargin: [0, 5],
 
   // Arrows
   arrows: undefined,

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -3,7 +3,7 @@ import { XYComponentConfigInterface, XYComponentDefaultConfig } from 'core/xy-co
 // Types
 import { WithOptional } from 'types/misc'
 import { ColorAccessor, NumericAccessor, StringAccessor, GenericAccessor } from 'types/accessor'
-import { TextAlign } from 'types/text'
+import { TextAlign, TrimMode } from 'types/text'
 import { Arrangement } from 'types/position'
 
 // Local Types
@@ -84,6 +84,10 @@ export interface TimelineConfigInterface<Datum> extends WithOptional<XYComponent
   rowMaxLabelWidth?: number;
   /** Text alignment for labels: `TextAlign.Left`, `TextAlign.Center` or `TextAlign.Right`. Default: `TextAlign.Right` */
   rowLabelTextAlign?: TextAlign | `${TextAlign}`;
+  /** Row label trim mode when width is limited: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
+  rowLabelTrimMode?: TrimMode | `${TrimMode}`;
+  /** Row label margin in pixels. Default: `5` */
+  rowLabelMargin?: number;
 
   // Arrows
   arrows?: TimelineArrow[];
@@ -145,6 +149,8 @@ export const TimelineDefaultConfig: TimelineConfigInterface<unknown> = {
   rowLabelWidth: undefined,
   rowMaxLabelWidth: undefined,
   rowLabelTextAlign: TextAlign.Right,
+  rowLabelTrimMode: TrimMode.Middle,
+  rowLabelMargin: 5,
 
   // Arrows
   arrows: undefined,

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -45,6 +45,9 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
     [Timeline.selectors.label]: {
       wheel: this._onMouseWheel.bind(this),
     },
+    [Timeline.selectors.labelBackground]: {
+      wheel: this._onMouseWheel.bind(this),
+    },
     [Timeline.selectors.rows]: {
       wheel: this._onMouseWheel.bind(this),
     },
@@ -263,6 +266,27 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
 
     const xStart = xRange[0] - this._lineBleed[0] - this._lineIconBleed[0]
     const labelXStart = xStart - labelOffset
+
+    // Invisible background rects covering the full label column width for pointer events
+    const labelBackgrounds = this._labelsGroup
+      .selectAll<SVGRectElement, TimelineRowLabel<Datum>>(`.${s.labelBackground}`)
+      .data((config.showRowLabels ?? config.showLabels) ? rowLabels : [], l => l?.label)
+
+    const labelBackgroundsEnter = labelBackgrounds.enter().append('rect')
+      .attr('class', s.labelBackground)
+      .attr('x', xStart - this._labelWidth)
+      .attr('y', l => yStart + yOrdinalScale(l.label) * rowHeight)
+      .attr('width', this._labelWidth)
+      .attr('height', rowHeight)
+
+    labelBackgroundsEnter.merge(labelBackgrounds)
+      .attr('x', xStart - this._labelWidth)
+      .attr('y', l => yStart + yOrdinalScale(l.label) * rowHeight)
+      .attr('width', this._labelWidth)
+      .attr('height', rowHeight)
+
+    labelBackgrounds.exit().remove()
+
     const labelsEnter = labels.enter().append('text')
       .attr('class', s.label)
       .attr('x', labelXStart)

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -14,6 +14,7 @@ export const globalStyles = injectGlobal`
 
     --vis-timeline-label-font-size: 12px;
     --vis-timeline-label-color: #6C778C;
+    --vis-timeline-user-select: none;
 
     --vis-timeline-arrow-color: #6C778C;
     --vis-timeline-arrow-stroke-width: 1.5;
@@ -136,7 +137,7 @@ export const label = css`
   font-size: var(--vis-timeline-label-font-size);
   fill: var(--vis-timeline-label-color);
   text-anchor: end;
-  user-select: none;
+  user-select: var(--vis-timeline-user-select);
 `
 
 export const rowIcons = css`

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -14,7 +14,8 @@ export const globalStyles = injectGlobal`
 
     --vis-timeline-label-font-size: 12px;
     --vis-timeline-label-color: #6C778C;
-    --vis-timeline-user-select: none;
+    --vis-timeline-label-user-select: none;
+    --vis-timeline-label-pointer-events: all;
 
     --vis-timeline-arrow-color: #6C778C;
     --vis-timeline-arrow-stroke-width: 1.5;
@@ -137,7 +138,14 @@ export const label = css`
   font-size: var(--vis-timeline-label-font-size);
   fill: var(--vis-timeline-label-color);
   text-anchor: end;
-  user-select: var(--vis-timeline-user-select);
+  user-select: var(--vis-timeline-label-user-select);
+  pointer-events: var(--vis-timeline-label-pointer-events);
+`
+
+export const labelBackground = css`
+  label: label-background;
+  fill: transparent;
+  pointer-events: all;
 `
 
 export const rowIcons = css`

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -1,56 +1,46 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css } from '@emotion/css'
+import type { UnovisCssVariablesDefinition } from 'types/style'
+import { getCssVarNames, injectGlobalCssVariables } from 'utils/style'
 
 export const root = css`
   label: timeline-component;
 `
 
-export const globalStyles = injectGlobal`
-  :root {
-    --vis-timeline-row-even-fill-color: #FFFFFF;
-    --vis-timeline-row-odd-fill-color: #F7FAFC;
-    --vis-timeline-row-background-opacity: 1;
-    --vis-timeline-scrollbar-background-color: #E6E9F3;
-    --vis-timeline-scrollbar-color: #9EA7B8;
+export const cssVarDefaults: UnovisCssVariablesDefinition = {
+  '--vis-timeline-row-even-fill-color': '#FFFFFF',
+  '--vis-timeline-row-odd-fill-color': '#F7FAFC',
+  '--vis-timeline-row-background-opacity': '1',
+  '--vis-timeline-scrollbar-background-color': '#E6E9F3',
+  '--vis-timeline-scrollbar-color': '#9EA7B8',
 
-    --vis-timeline-label-font-size: 12px;
-    --vis-timeline-label-color: #6C778C;
-    --vis-timeline-label-user-select: none;
-    --vis-timeline-label-pointer-events: all;
+  '--vis-timeline-label-font-size': '12px',
+  '--vis-timeline-label-color': '#6C778C',
+  '--vis-timeline-label-user-select': 'none',
+  '--vis-timeline-label-pointer-events': 'all',
 
-    --vis-timeline-arrow-color: #6C778C;
-    --vis-timeline-arrow-stroke-width: 1.5;
+  '--vis-timeline-arrow-color': '#6C778C',
+  '--vis-timeline-arrow-stroke-width': '1.5',
 
-    --vis-timeline-cursor: default;
-    --vis-timeline-line-color: var(--vis-color-main);
-    --vis-timeline-line-stroke-width: 0;
-    --vis-timeline-line-hover-stroke-width: 0;
-    --vis-timeline-line-hover-stroke-color: #6C778C;
+  '--vis-timeline-cursor': 'default',
+  '--vis-timeline-line-color': 'var(--vis-color-main)',
+  '--vis-timeline-line-stroke-color': undefined,
+  '--vis-timeline-line-stroke-width': '0',
+  '--vis-timeline-line-hover-stroke-width': '0',
+  '--vis-timeline-line-hover-stroke-color': '#6C778C',
 
-    --vis-timeline-row-icon-cursor: default;
+  '--vis-timeline-row-icon-cursor': 'default',
 
-    // The line stroke color variable is not defined by default
-    // to allow it to fallback to the corresponding row background color
-    /* --vis-timeline-line-stroke-color: none; */
+  '--vis-dark-timeline-row-even-fill-color': '#292B34',
+  '--vis-dark-timeline-row-odd-fill-color': '#333742',
+  '--vis-dark-timeline-scrollbar-background-color': '#292B34',
+  '--vis-dark-timeline-scrollbar-color': '#6C778C',
+  '--vis-dark-timeline-label-color': '#EFF5F8',
+  '--vis-dark-timeline-arrow-color': '#EFF5F8',
+  '--vis-dark-timeline-line-hover-stroke-color': '#EFF5F8',
+}
 
-    --vis-dark-timeline-row-even-fill-color: #292B34;
-    --vis-dark-timeline-row-odd-fill-color: #333742;
-    --vis-dark-timeline-scrollbar-background-color: #292B34;
-    --vis-dark-timeline-scrollbar-color: #6C778C;
-    --vis-dark-timeline-label-color: #EFF5F8;
-    --vis-dark-timeline-arrow-color: #EFF5F8;
-    --vis-dark-timeline-line-hover-stroke-color: #EFF5F8;
-  }
-
-  body.theme-dark ${`.${root}`} {
-    --vis-timeline-row-even-fill-color: var(--vis-dark-timeline-row-even-fill-color);
-    --vis-timeline-row-odd-fill-color: var(--vis-dark-timeline-row-odd-fill-color);
-    --vis-timeline-scrollbar-background-color: var(--vis-dark-timeline-scrollbar-background-color);
-    --vis-timeline-scrollbar-color: var(--vis-dark-timeline-scrollbar-color);
-    --vis-timeline-label-color: var(--vis-dark-timeline-label-color);
-    --vis-timeline-arrow-color: var(--vis-dark-timeline-arrow-color);
-    --vis-timeline-line-hover-stroke-color: var(--vis-dark-timeline-line-hover-stroke-color);
-  }
-`
+export const variables = getCssVarNames(cssVarDefaults)
+injectGlobalCssVariables(cssVarDefaults, root)
 
 export const background = css`
   label: background;

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -26,6 +26,8 @@ export const globalStyles = injectGlobal`
     --vis-timeline-line-hover-stroke-width: 0;
     --vis-timeline-line-hover-stroke-color: #6C778C;
 
+    --vis-timeline-row-icon-cursor: default;
+
     // The line stroke color variable is not defined by default
     // to allow it to fallback to the corresponding row background color
     /* --vis-timeline-line-stroke-color: none; */
@@ -154,4 +156,5 @@ export const rowIcons = css`
 
 export const rowIcon = css`
   label: row-icon;
+  cursor: var(--vis-timeline-row-icon-cursor);
 `

--- a/packages/ts/src/types/style.ts
+++ b/packages/ts/src/types/style.ts
@@ -1,0 +1,1 @@
+export type UnovisCssVariablesDefinition = Record<string, string | undefined>

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -8,6 +8,7 @@ import { TextAlign, TrimMode, UnovisText, UnovisTextFrameOptions, UnovisTextOpti
 // Utils
 import { flatten, isArray, merge } from 'utils/data'
 import { getTextAnchorFromTextAlign } from 'types/svg'
+import { toPx } from 'utils/to-px'
 
 // Styles
 import { getFontWidthToHeightRatio, UNOVIS_TEXT_DEFAULT, UNOVIS_TEXT_SEPARATOR_DEFAULT, UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT } from 'styles/index'
@@ -171,6 +172,9 @@ export function wrapSVGText (
   })
 }
 
+// TODO: When we calculate `maxCharacters` we don't take into account that the ellipsis character is wider than the regular characters,
+// which sometimes leads to labels getting cut off.  We should rethink the tolerance value and maybe subtract a few characters from `maxCharacters`,
+// but this can be a breaking change and should be done carefully testing all components that use `trimSVGText`
 /**
  * Trims an SVG text element based on the specified max width, trim type, and other options.
  * @param {Selection<SVGTextElement, any, SVGElement, any>} svgTextSelection - The D3 selection of the SVG text element to be trimmed.
@@ -186,7 +190,7 @@ export function trimSVGText (
   maxWidth = 50,
   trimType = TrimMode.Middle,
   fastMode = true,
-  fontSize = +window.getComputedStyle(svgTextSelection.node())?.fontSize || 0,
+  fontSize = toPx(window.getComputedStyle(svgTextSelection.node())?.fontSize || UNOVIS_TEXT_DEFAULT.fontSize),
   fontWidthToHeightRatio = getFontWidthToHeightRatio()
 ): boolean {
   const text = svgTextSelection.text() || ''

--- a/packages/website/docs/utils/data.ts
+++ b/packages/website/docs/utils/data.ts
@@ -29,13 +29,21 @@ export function generateDataRecords (n = 10): DataRecord[] {
 
 export const data = generateDataRecords(10)
 
+const timelineLabels = [
+  'Design Review', 'Backend API', 'User Research', 'Data Migration',
+  'Sprint Planning', 'QA Testing', 'Code Review', 'Deployment',
+  'Feature Launch', 'Bug Triage', 'Performance Audit', 'Documentation',
+  'Client Onboarding', 'Security Patch', 'Infrastructure', 'Analytics',
+  'Release Candidate', 'Stakeholder Demo', 'Accessibility', 'Monitoring',
+]
+
 export function generateTimeSeries (n = 10, types = n): TimeDataRecord[] {
-  const groups = Array(types).fill(0).map((_, i) => String.fromCharCode(i + 65))
+  const groups = Array(types).fill(0).map((_, i) => timelineLabels[i % timelineLabels.length])
   return Array(n).fill(0).map((_, i: number) => ({
     timestamp: Date.now() + i * 1000 * 60 * 60 * 24,
     value: i / 10 + Math.sin(i / 5) + Math.cos(i / 3),
     length: Math.round(1000 * 60 * 60 * 24) * Math.random(),
-    type: i > groups.length ? sample(groups) : groups[i],
+    type: i >= groups.length ? sample(groups) : groups[i],
   }))
 }
 

--- a/packages/website/docs/xy-charts/Timeline.mdx
+++ b/packages/website/docs/xy-charts/Timeline.mdx
@@ -18,6 +18,8 @@ export const timelineProps = (n = 5, rows=n) => ({
   height: 150,
   dataType: 'TimeDataRecord',
   data: generateTimeSeries(n, rows),
+  lineDuration: d => d.length,
+  lineRow: d => d.type,
   x: d => d.timestamp,
 })
 
@@ -47,13 +49,20 @@ type TimeDataRecord = {
 
 By default, if the records in your data array contain `length` and `type` properties (as shown above),
 _Timeline_ will only need the `x` accessor provided to display the data.
-Otherwise, you can explicitly define accessor functions for `length` and `type`.
+Otherwise, you can explicitly define accessor functions for `lineDuration` and `lineRow`.
+
+The `type` and `length` properties are deprecated in favor of `lineRow` and `lineDuration`, respectively.
 
 :::
 
-## Labels
-Enable the `showLabels` property to display row types along the **vertical** axis. You can alter the
-appearance of these labels with the `labelWidth` and `maxLabelWidth` properties.
+## Row Labels
+Enable the `showRowLabels` property to display row types along the **vertical** axis. You can control
+the label width with `rowLabelWidth` (fixed) and `rowMaxLabelWidth` (maximum) properties.
+
+:::note
+The `showLabels`, `labelWidth`, and `maxLabelWidth` properties are deprecated. Use `showRowLabels`,
+`rowLabelWidth`, and `rowMaxLabelWidth` instead.
+:::
 
 Like other XY components, labeling data along the **horizontal** axis can be accomplished
 by adding an _Axis_ component to your container. See following example which displays labeled
@@ -62,7 +71,7 @@ _Timeline_ alongside a labeled _X Axis_:
 <XYWrapper {...timelineProps()}
   components={[xAxis]}
   declarations={{ tickFormat: 'Intl.DateTimeFormat().format'}}
-  showLabels
+  showRowLabels
   showContext="container"/>
 
 <br/>
@@ -73,6 +82,63 @@ Since *Timeline* groups vertical data in an ordinal fashion, adding a Y axis her
 
 :::
 
+### Label Text Align
+Use the `rowLabelTextAlign` property to control the horizontal alignment of row labels:
+`TextAlign.Left`, `TextAlign.Center`, or `TextAlign.Right` (default).
+
+<XYWrapper {...timelineProps(20, 5)} showRowLabels rowLabelTextAlign="left" hideTabLabels/>
+
+### Label Width
+Set a fixed label width with `rowLabelWidth` or a maximum width with `rowMaxLabelWidth`.
+Labels longer than the specified value will be trimmed.
+
+<XYWrapperWithInput {...timelineProps(20, 5)} showRowLabels property="rowLabelWidth" inputType="range" defaultValue={60}/>
+
+### Label Trim Mode
+When labels exceed the available width, they'll be trimmed. Use the `rowLabelTrimMode` property to control
+where the trimming occurs: `TrimMode.Start`, `TrimMode.Middle` (default), or `TrimMode.End`.
+
+<XYWrapper {...timelineProps(20, 5)} showRowLabels rowLabelWidth={70} rowLabelTrimMode="end" hideTabLabels/>
+
+### Label Margin
+Use the `rowLabelMargin` property to set the spacing (in pixels) between the row labels and the timeline content.
+
+You can also provide a `[left, right]` tuple to control spacing on both sides of the label independently:
+- The first value sets the left margin (space from the container edge or row icon to the label)
+- The second value sets the right margin (space between the label and the timeline content)
+
+```ts
+rowLabelMargin: [10, 5] // 10px left, 5px right
+```
+
+<XYWrapperWithInput {...timelineProps(20, 5)} showRowLabels property="rowLabelMargin" inputType="range" defaultValue={5}/>
+
+### Label Style
+Use `rowLabelStyle` to apply custom CSS styles to row labels. It accepts an object with CSS property-value pairs
+or an accessor function for per-label styling.
+
+```ts
+rowLabelStyle: { 'font-weight': 'bold', 'fill': '#333' }
+```
+
+### Label Formatter
+Use `rowLabelFormatter` to customize the displayed label text. It receives the row key, the row's data items, and the row index.
+
+```ts
+rowLabelFormatter: (key: string, items: Datum[], i: number) => `${key} (${items.length})`
+```
+
+### Icon
+Use the `rowIcon` property to display an icon before each row label. The function receives the row key, items, and index,
+and should return a `TimelineRowIcon` object or `undefined`.
+
+```ts
+type TimelineRowIcon = {
+  href: string;  // SVG icon href (defined in container's svgDefs)
+  size: number;
+  color: string;
+}
+```
 
 ## Row Configuration
 ### Alternating row colors
@@ -105,8 +171,77 @@ actual position. When set to `false`, small segments will be aligned to the left
 You can also change the line thickness with the `lineWidth` property, which determines how much
 vertical space each _Timeline_ item occupies.
 
-### Example: Custom timeline lines
-<XYWrapperWithInput {...timelineProps(3)} height={320} rowHeight={100} property="lineWidth" inputType="range" defaultValue={10}/>
+<XYWrapperWithInput {...timelineProps(3)} height={320} rowHeight={50} property="lineWidth" inputType="range" defaultValue={10}/>
+
+### Line Cursor
+Use the `lineCursor` property to set a custom CSS cursor when hovering over a timeline line.
+
+:::note
+The `cursor` property is deprecated. Use `lineCursor` instead.
+:::
+
+### Line Icons
+You can display icons at the start and/or end of each timeline line using SVG symbols defined in the
+container's `svgDefs`.
+
+| Property | Description |
+|---|---|
+| `lineStartIcon` / `lineEndIcon` | SVG icon href accessor |
+| `lineStartIconColor` / `lineEndIconColor` | Icon color accessor |
+| `lineStartIconSize` / `lineEndIconSize` | Icon size accessor |
+| `lineStartIconArrangement` / `lineEndIconArrangement` | Icon positioning relative to the line: `Arrangement.Inside` (default), `Arrangement.Outside`, `Arrangement.Start`, `Arrangement.Middle`, or `Arrangement.End` |
+
+## Arrows
+Use the `arrows` property to draw connecting arrows between timeline lines. Each arrow is defined as a `TimelineArrow` object:
+
+```ts
+type TimelineArrow = {
+  id?: string;
+  xSource?: number;            // X position of arrow start (defaults to source line's end)
+  xTarget?: number;            // X position of arrow end (defaults to target line's start)
+  xSourceOffsetPx?: number;    // Horizontal offset of the source in pixels
+  xTargetOffsetPx?: number;    // Horizontal offset of the target in pixels
+  lineSourceId: string;        // Id of the source line element
+  lineTargetId: string;        // Id of the target line element
+  lineSourceMarginPx?: number; // Margin between source line and arrow in pixels
+  lineTargetMarginPx?: number; // Margin between target line and arrow in pixels
+  arrowHeadLength?: number;    // Arrowhead length in pixels (default: 8)
+  arrowHeadWidth?: number;     // Arrowhead width in pixels (default: 6)
+}
+```
+
+The `lineSourceId` and `lineTargetId` correspond to the values returned by the `id` accessor on your data items.
+
+export const arrowData = Array(7).fill(0).map((_, i) => ({
+  id: `item-${i}`,
+  timestamp: Date.now() + i * 1000 * 60 * 60 * 24 + Math.random() * 1000 * 60 * 60 * 12,
+  length: 1000 * 60 * 60 * 24,
+  type: `Task ${i + 1}`,
+}))
+
+export const arrowItems = arrowData.slice(0, -1).map((d, i) => ({
+  id: `arrow-${i}`,
+  xSource: d.timestamp + d.length,
+  lineSourceId: d.id,
+  lineTargetId: arrowData[i + 1].id,
+  lineSourceMarginPx: 2,
+  lineTargetMarginPx: 2,
+}))
+
+<XYWrapper
+  name="Timeline"
+  data={arrowData}
+  dataType="TimeDataRecord"
+  height={255}
+  x={d => d.timestamp}
+  id={d => d.id}
+  lineCap
+  rowHeight={35}
+  showRowLabels
+  arrows={arrowItems}
+  declarations={{ arrows: `[{ lineSourceId: 'item-0', lineTargetId: 'item-1', xSource: ... }, ...]` }}
+  showContext="minimal"
+/>
 
 ## Events
 ### Scrolling
@@ -137,7 +272,7 @@ export function ScrollExample() {
 <ScrollExample/>
 
 ### Custom cursor for hover events
-You can set custom cursor when hovering over a line. However, it'll only be active if you've defined events for `[Timeline.selectors.line]`:
+You can set a custom cursor when hovering over a line using the `lineCursor` property. It'll only be active if you've defined events for `[Timeline.selectors.line]`:
 <BrowserOnly>
 {() => {
   const { Timeline } = require('@unovis/ts')
@@ -157,7 +292,7 @@ You can set custom cursor when hovering over a line. However, it'll only be acti
             click: (d) => { console.log(d) }
         },
       }}
-      cursor="cell"
+      lineCursor="cell"
     />
   }
 }

--- a/packages/website/docs/xy-charts/Timeline.mdx
+++ b/packages/website/docs/xy-charts/Timeline.mdx
@@ -7,6 +7,7 @@ import BrowserOnly from "@docusaurus/core/lib/client/exports/BrowserOnly"
 import { XYWrapper, XYWrapperWithInput, axis } from '../wrappers/xy-wrapper'
 import { PropsTable } from '@site/src/components/PropsTable'
 import { generateTimeSeries } from '../utils/data'
+import { Timeline } from '@unovis/ts'
 
 export const xAxis = ({
   ...axis('x'),
@@ -318,34 +319,13 @@ const events = {
 ## CSS Variables
 The _Timeline_ component supports additional styling via CSS variables:
 
-
 <details open>
-  <summary>All supported CSS variables</summary>
-  <CodeBlock language="css">{
-`--vis-timeline-row-even-fill-color: #FFFFFF;
---vis-timeline-row-odd-fill-color: #F7FAFC;
---vis-timeline-row-background-opacity: 1;
---vis-timeline-scrollbar-background-color: #E6E9F3;
---vis-timeline-scrollbar-color: #9EA7B8;
- 
---vis-timeline-label-font-size: 12px;
---vis-timeline-label-color: #6C778C;
- 
---vis-timeline-cursor: default;
---vis-timeline-line-color: var(--vis-color-main);
---vis-timeline-line-stroke-width: 0;
- 
-/* The line stroke color variable is not defined by default */
-/* to allow it to fallback to the corresponding row background color */
-/* --vis-timeline-line-stroke-color: none; */
- 
-/* Dark Theme */
---vis-dark-timeline-row-even-fill-color: #292B34;
---vis-dark-timeline-row-odd-fill-color: #333742;
---vis-dark-timeline-scrollbar-background-color: #292B34;
---vis-dark-timeline-scrollbar-color: #6C778C;
---vis-dark-timeline-label-color: #EFF5F8;`}
-  </CodeBlock>
+  <summary>All supported CSS variables and their default values</summary>
+  <CodeBlock language="css">
+{`${
+  Object.entries(Timeline.selectors.cssVarDefaults)
+  .map(([key, value]) => `${key}: ${value};`).join('\n')}
+`}</CodeBlock>
 </details>
 
 ## Component Props


### PR DESCRIPTION
Currently the `rowLabelWidth ` and `rowMaxLabelWidth` properties don't work because of the bug in `trimSVGText`. This PR fixes that along with a few other tweaks:
- Two new config properties: `rowLabelTrimMode` and `rowLabelMargin`
- New dev example to test `rowLabelTrimMode` and `rowLabelMargin`
- Extended clip path to take into account arrowheads when they are in use
- Major update to the docs incorporating all the recent changes

<img width="714" height="419" alt="image" src="https://github.com/user-attachments/assets/eaa16f1b-8b9e-4165-b7e3-195348009bb2" />

<img width="1508" height="858" alt="image" src="https://github.com/user-attachments/assets/2f01d8f5-72c5-4eb3-b56c-b24830f90673" />
