### PR TITLE
Dev | Examples | Area: Gradient areas; custom font; time axis formatting; Doc tweaks

### DIFF
--- a/packages/dev/src/App.module.css
+++ b/packages/dev/src/App.module.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap');
 @import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css');
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&display=swap');
 
 * {
   box-sizing: border-box;

--- a/packages/dev/src/examples/xy-components/area/gradient-area/index.tsx
+++ b/packages/dev/src/examples/xy-components/area/gradient-area/index.tsx
@@ -1,0 +1,146 @@
+import React, { useMemo, useRef } from 'react'
+import { VisXYContainer, VisArea, VisAxis, VisTooltip, VisCrosshair, VisStackedBar, VisGroupedBar, VisScatter } from '@unovis/react'
+
+import { TimeSeriesDataRecord, generateTimeSeriesDataRecords } from '@src/utils/data'
+import { formatDateTimeLabel } from '@src/utils/format'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { Scale } from '@unovis/ts'
+
+export const title = 'Gradient Area Chart'
+export const subTitle = 'Theming, Time Axis Formatting'
+
+const numSeries = 5
+const colors = ['#3b82f6', '#ef4444', '#f59e0b', '#14b8a6', '#8b5cf6', '#fb923c', '#ec4899', '#10b981', '#6366f1', '#facc15', '#22c55e', '#06b6d4', '#a855f7', '#d946ef']
+
+const svgDefs = colors.slice(0, numSeries).map((color, i) => `
+  <linearGradient id="gradient-${i}" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="${color}" stop-opacity="0.4" />
+    <stop offset="100%" stop-color="${color}" stop-opacity="0.02" />
+  </linearGradient>
+  <linearGradient id="gradient-2-${i}" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="${color}" stop-opacity="0.7" />
+    <stop offset="100%" stop-color="${color}" stop-opacity="0.4" />
+  </linearGradient>
+  `).join('')
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const tooltipRef = useRef(null)
+  const accessors = Array.from({ length: numSeries }, (_, i) => (d: TimeSeriesDataRecord) => d.values[i])
+  const gradientColors = colors.slice(0, numSeries).map((_, i) => `url(#gradient-${i})`)
+  const gradientColorsStackedBar = colors.slice(0, numSeries).map((_, i) => `url(#gradient-2-${i})`)
+
+  const lineColors = colors.slice(0, numSeries)
+
+  const data = generateTimeSeriesDataRecords(numSeries, 35)
+  const barData = generateTimeSeriesDataRecords(numSeries, 12)
+
+  const areaScale = useMemo(() => Scale.scaleTime(), [])
+  const stackedBarScale = useMemo(() => Scale.scaleTime(), [])
+  const groupedBarScale = useMemo(() => Scale.scaleTime(), [])
+  const scatterScale = useMemo(() => Scale.scaleTime(), [])
+
+  const containerStyle = {
+    '--vis-tooltip-padding': '3px 6px',
+    '--vis-crosshair-line-stroke-color': '#aac',
+    '--vis-font-family': 'Bricolage Grotesque',
+    fontFamily: 'Bricolage Grotesque',
+    lineHeight: 1,
+  }
+
+  const xAxisProps = {
+    numTicks: 5,
+    tickFormat: (x: number | Date, i: number, ticks: number[] | Date[]) => formatDateTimeLabel(x, i, ticks),
+    duration: props.duration,
+    // gridLine: false,
+  }
+
+  const yAxisProps = {
+    type: 'y' as const,
+    gridLine: false,
+    duration: props.duration,
+    tickSize: 3,
+    numTicks: 3,
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <VisXYContainer<TimeSeriesDataRecord>
+        data={data}
+        margin={{ top: 5, left: 5 }}
+        xScale={areaScale}
+        svgDefs={svgDefs}
+        style={containerStyle}
+      >
+        <VisArea
+          x={d => d.time}
+          y={accessors}
+          duration={props.duration}
+          color={gradientColors}
+          line={true}
+          lineWidth={1}
+          lineColor={lineColors}
+        />
+        <VisAxis type='x' {...xAxisProps} />
+        <VisAxis {...yAxisProps} label='Area' />
+        <VisCrosshair
+          color={lineColors}
+          template={(d: TimeSeriesDataRecord) =>
+            `<span style="color: grey; font-size: 12px;">${new Date(d.time).toLocaleTimeString()}</span>`}
+        />
+        <VisTooltip ref={tooltipRef}/>
+      </VisXYContainer>
+
+      <VisXYContainer<TimeSeriesDataRecord>
+        data={barData}
+        margin={{ top: 5, left: 5 }}
+        xScale={stackedBarScale}
+        svgDefs={svgDefs}
+        style={containerStyle}
+      >
+        <VisStackedBar
+          x={d => d.time}
+          y={accessors}
+          duration={props.duration}
+          color={gradientColorsStackedBar}
+        />
+        <VisAxis type='x' {...xAxisProps} />
+        <VisAxis {...yAxisProps} label='Stacked Bar' />
+      </VisXYContainer>
+
+      <VisXYContainer<TimeSeriesDataRecord>
+        data={barData}
+        margin={{ top: 5, left: 5 }}
+        xScale={groupedBarScale}
+        svgDefs={svgDefs}
+        style={containerStyle}
+      >
+        <VisGroupedBar
+          x={d => d.time}
+          y={accessors}
+          duration={props.duration}
+          color={gradientColorsStackedBar}
+        />
+        <VisAxis type='x' {...xAxisProps} />
+        <VisAxis {...yAxisProps} label='Grouped Bar' />
+      </VisXYContainer>
+
+      <VisXYContainer<TimeSeriesDataRecord>
+        data={data}
+        margin={{ top: 5, left: 5 }}
+        xScale={scatterScale}
+        svgDefs={svgDefs}
+        style={containerStyle}
+      >
+        <VisScatter
+          x={d => d.time}
+          y={accessors}
+          duration={props.duration}
+          color={gradientColorsStackedBar}
+          size={10}
+        />
+        <VisAxis type='x' {...xAxisProps} />
+        <VisAxis {...yAxisProps} label='Scatter' />
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/dev/src/utils/data.ts
+++ b/packages/dev/src/utils/data.ts
@@ -22,6 +22,11 @@ export interface TimeDataRecord {
   type?: string;
 }
 
+export type TimeSeriesDataRecord = {
+  time: number;
+  values: number[];
+}
+
 export type NodeDatum = GenericDataRecord & {
   id: string;
   group?: string;
@@ -50,6 +55,14 @@ export function generateXYDataRecords (n = 10): XYDataRecord[] {
     y: 5 + 5 * randomNumberGenerator(),
     y1: 1 + 3 * randomNumberGenerator(),
     y2: 2 * randomNumberGenerator(),
+  }))
+}
+
+export function generateTimeSeriesDataRecords (numSeries = 5, n = 25, interval = 1000 * 60 * 60): TimeSeriesDataRecord[] {
+  const startTime = Date.now() - (n - 1) * interval
+  return Array(n).fill(0).map((_, i) => ({
+    time: startTime + i * interval,
+    values: Array(numSeries).fill(0).map((_, j) => j + 5 * randomNumberGenerator()),
   }))
 }
 

--- a/packages/dev/src/utils/format.ts
+++ b/packages/dev/src/utils/format.ts
@@ -1,0 +1,65 @@
+type DateInput = number | Date;
+
+function fmt (date: DateInput, timeZone: string | undefined, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('en-US', { timeZone, ...options }).format(new Date(date))
+}
+
+// Format option constants (replaces date-fns format strings)
+const FMT_HH_MM_SS: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true }
+const FMT_HH_MM: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', hour12: true }
+const FMT_MONTH_DAY_HH_MM: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
+const FMT_MONTH_DAY: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit' }
+const FMT_MONTH_DAY_YEAR: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', year: 'numeric' }
+const FMT_YEAR_MONTH_DAY_HH_MM: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
+const FMT_MONTH_YEAR_DAY_HH_MM: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: true }
+const FMT_YEAR_MONTH_DAY_HH_MM_SS: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true }
+const FMT_YEAR: Intl.DateTimeFormatOptions = { year: 'numeric' }
+const FMT_MONTH: Intl.DateTimeFormatOptions = { month: 'short' }
+
+// ─── Range / axis formatting ──────────────────────────────────────────────────
+function getTimeFormatForRange (startDate: Date, endDate: Date): Intl.DateTimeFormatOptions {
+  const diff = endDate.getTime() - startDate.getTime()
+
+  if (diff < 1000 * 60 * 60) return FMT_HH_MM_SS // < 1 hour
+  if (diff < 1000 * 60 * 60 * 24) return FMT_HH_MM // < 1 day
+  if (diff < 1000 * 60 * 60 * 24 * 7) return FMT_MONTH_DAY_HH_MM // < 1 week
+  if (diff < 1000 * 60 * 60 * 24 * 365) return FMT_MONTH_DAY // < 1 year
+  return FMT_MONTH
+}
+
+function getFirstTickTimeFormat (startDate: Date, endDate: Date): Intl.DateTimeFormatOptions {
+  const diff = endDate.getTime() - startDate.getTime()
+  if (diff < 1000 * 60 * 60 * 24) return FMT_YEAR_MONTH_DAY_HH_MM
+  return FMT_MONTH_DAY_YEAR
+}
+
+export function formatDateTimeLabel (
+  tick: DateInput,
+  index: number,
+  allTicks: DateInput[],
+  timeZone?: string
+): string {
+  if (allTicks.length < 2) {
+    return fmt(tick, timeZone, FMT_YEAR_MONTH_DAY_HH_MM)
+  }
+
+  const startDate = new Date(allTicks[0])
+  const endDate = new Date(allTicks[allTicks.length - 1])
+  const timeFormat = (!startDate || !endDate || startDate.getTime() === endDate.getTime())
+    ? FMT_YEAR_MONTH_DAY_HH_MM
+    : getTimeFormatForRange(startDate, endDate)
+
+  if (index === 0) {
+    return fmt(tick, timeZone, getFirstTickTimeFormat(startDate, endDate))
+  }
+
+  const dateTick = new Date(tick)
+  const datePrevTick = new Date(allTicks[index - 1])
+
+  if (datePrevTick.getFullYear() !== dateTick.getFullYear()) return fmt(dateTick, timeZone, FMT_YEAR)
+  if (datePrevTick.getMonth() !== dateTick.getMonth()) return fmt(dateTick, timeZone, FMT_MONTH)
+  if (datePrevTick.getDate() !== dateTick.getDate()) return fmt(tick, timeZone, FMT_MONTH_DAY)
+  if (datePrevTick.getHours() !== dateTick.getHours()) return fmt(tick, timeZone, FMT_HH_MM)
+
+  return fmt(tick, timeZone, timeFormat)
+}

--- a/packages/website/docs/guides/styles.css
+++ b/packages/website/docs/guides/styles.css
@@ -2,11 +2,11 @@
   --stroke: #fff;
   --stroke-dark: #292b34;
   --vis-area-stroke-width: 1px;
-  --vis-area-stroke: var(--stroke);
+  --vis-area-stroke-color: var(--stroke);
   --vis-dark-area-stroke: var(--stroke-dark);
   --vis-donut-segment-stroke-width: 1px;
   --vis-stacked-bar-stroke-width: 1px;
-  --vis-stacked-bar-stroke: var(--stroke);
+  --vis-stacked-bar-stroke-color: var(--stroke);
   --vis-dark-stacked-bar-stroke: var(--stroke-dark);
   --vis-timeline-line-stroke-width: 1px;
 }

--- a/packages/website/docs/guides/theming.mdx
+++ b/packages/website/docs/guides/theming.mdx
@@ -6,11 +6,12 @@ import BrowserOnly from '@docusaurus/BrowserOnly'
 import CodeBlock from '@theme/CodeBlock'
 
 import { CSSVariables } from '../components/css-variables'
-import { data, generateScatterDataRecords, generateTimeSeries } from '../utils/data.ts'
+import { data, generateScatterDataRecords, generateTimeSeries, generateDataRecords } from '../utils/data.ts'
 import { DocWrapper } from '../wrappers'
 import { XYWrapper, axis } from '../wrappers/xy-wrapper'
 import { sankeyProps as sankeyProps } from '../networks-and-flows/Sankey.mdx'
 import { donutProps as donutProps } from '../misc/Donut.mdx'
+import { FrameworkTabs } from '../components/framework-tabs.tsx'
 
 import './styles.css'
 
@@ -293,7 +294,7 @@ You can customize these patterns by assigning any combination of the following v
 [`marker`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker) elements
 - Variables with the prefix `--vis-pattern-dasharray` to a valid value for the
 [stroke-dasharray](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray) property. The default palette looks like:
-  
+
 <body class='theme-patterns' style={{ marginBottom: '20px'}}>
   <XYWrapper
     name='Line'
@@ -307,7 +308,7 @@ You can customize these patterns by assigning any combination of the following v
   />
 </body>
 
-  
+
 <details>
 <summary>Default CSS Variables:</summary>
 
@@ -357,7 +358,7 @@ as its fill. You can tweak the variables accordingly to create the desired effec
 
   /* Area */
   --vis-area-stroke-width: 1px;
-  --vis-area-stroke: var(--stroke);
+  --vis-area-stroke-color: var(--stroke);
   --vis-dark-area-stroke: var(--stroke-dark);
 
   /* Donut */
@@ -365,7 +366,7 @@ as its fill. You can tweak the variables accordingly to create the desired effec
 
   /* StackedBar */
   --vis-stacked-bar-stroke-width: 1px;
-  --vis-stacked-bar-stroke: var(--stroke);
+  --vis-stacked-bar-stroke-color: var(--stroke);
   --vis-dark-stacked-bar-stroke: var(--stroke-dark);
 
   /* Timeline */
@@ -383,3 +384,47 @@ as its fill. You can tweak the variables accordingly to create the desired effec
   <h4>Timeline</h4>
   <XYWrapper name='Timeline' data={generateTimeSeries(50, 6)} height={200} x={d => d.timestamp} length={d => d.length * 10} type={d => d.type} lineCap excludeTabs/>
 </div>
+
+## Gradient Fills with SVG defs
+Use the `svgDefs` property on the container to inject custom SVG definitions — gradients, patterns, clip paths — that any component can reference by `id`.
+
+Start by building your defs string, then pass the string to `svgDefs` on the container and reference each gradient by id in the `color` array.
+The example below defines one vertical `<linearGradient>` per series.
+
+export const seriesColors = ['#3b82f6', '#ef4444', '#f59e0b']
+export const gradientDefs = seriesColors.map((color, i) => `
+  <linearGradient id="area-grad-${i}" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0%" stop-color="${color}" stop-opacity="0.4" />
+    <stop offset="100%" stop-color="${color}" stop-opacity="0.02" />
+  </linearGradient>`).join('')
+
+
+<XYWrapper
+  name="Area"
+  data={generateDataRecords(20)}
+  x={d => d.x}
+  y={[d => d.y, d => d.y1, d => d.y2]}
+  color={seriesColors.map((_, i) => `url(#area-grad-${i})`)}
+  declarations={{ svgDefs: `\`${gradientDefs}\n  \`` }}
+  showContext="full"
+  line={true}
+  lineWidth={1}
+  lineColor={seriesColors}
+  showAxes
+  height={200}
+  containerProps={{ svgDefs: gradientDefs }}
+/>
+
+export const inlineSvg = `<svg style="position:absolute;width:0;height:0">\n  <defs>${gradientDefs}\n  </defs>\n</svg>`
+
+:::note
+
+Alternatively, you can place the defs in a hidden `<svg>` element anywhere on the same page, and the `url(#id)` references will still resolve.
+
+<FrameworkTabs
+  angular={{html: `<vis-area ... [color]="gradientColors"></vis-area>\n${inlineSvg}`}}
+  react={`<VisArea ... color={gradientColors}/>\n${inlineSvg}`}
+  typescript={`const chart = new Area({ color: gradientColors, ... })\ndocument.body.insertAdjacentHTML('beforeend', \`${inlineSvg}\`)`}/>
+
+:::
+

--- a/packages/website/docs/guides/tips-and-tricks.mdx
+++ b/packages/website/docs/guides/tips-and-tricks.mdx
@@ -11,45 +11,11 @@ import './styles.css'
 
 # Tips and Tricks
 
-## Custom Fills with SVG `defs`
-If you want to custom SVG definitions available for your components, you can use the `svgDefs` property on the container, like this:
-
-export const defs = `
-    <linearGradient id="gradient" gradientTransform="rotate(90)">
-      <stop offset="20%" stop-color="#051937" />
-      <stop offset="40%" stop-color="#004d7a" />
-      <stop offset="60%" stop-color="#008793" />
-      <stop offset="80%" stop-color="#00bf72" />
-    </linearGradient>`
-
-<XYWrapper name="Area"
-  data={generateDataRecords(10)}
-  x={d=>d.x} y={d=>d.y}
-  showContext="full"
-  color="url(#gradient)"
-  declarations={{ svgDefs: `\`${defs}\n  \`` }}
-  containerProps={{
-    svgDefs: defs
-  }}/>
-
-export const svg = `\n<svg>\n  <defs>   ${defs}\n  </defs>\n</svg>`
-
-:::note
-
-Alternatively, you can define any defs you want to use in an SVG element on the same page.
-
-<FrameworkTabs
-  angular={{html: `<vis-area ... color="url(#gradient)"></vis-area>\n${svg}`}}
-  react={`<VisArea ... color="url(#gradient)"/>\n${svg}`}
-  typescript={`const chart = new Area({... color: "url(#gradient)"})\n\ndocument.getElementById('container').insertAdjacentHTML(\`${svg}\`\n)`}/>
-
-:::
-
 ## Displaying Ordinal Values
 We don't natively support the ordinal scale for XY components, but it can still be achieved with some
 small tweaks.
 
-- In your _XY Component_, provide the `x` property _NumericAccessor_ that returns the data index.
+- In your component, provide the `x` property _NumericAccessor_ that returns the data index.
 
 <div className='indent'>
 
@@ -59,25 +25,22 @@ const x = (d: DataRecord, i: number) => i
 
 </div>
 
-- In your _Axis_ component, provide the `tickFormat` property with a _StringAccessor_ that returns
-your value. Two common configurations are:
+- In your _Axis_ component, provide the `tickValues` property set to the array of data indices, and
+the `tickFormat` property with a _StringAccessor_ that returns your value. This ensures all labels
+are visible regardless of chart width. Two common configurations are:
 
 <div className='indent'>
 
-  **Case 1**: When your data is an array of objects containing your ordinal property:
+When your data is an array of objects containing your ordinal property:
 
 ```ts
+const tickValues = data.map((_, i) => i)
 const tickFormat = (tick: number) => data[tick].category
 ```
-  **Case 2**: Your ordinal values are explicitly defined as an array of strings:
 
-```ts
-const categories = ['A', 'B', 'C', 'D', 'E']
-const tickFormat = (tick: number) => categories[tick]
-```
 </div>
 
-When we apply these adjustments to a basic _Stacked Bar_ chart with an _X Axis_ component, the result
+Then we apply these adjustments to a basic _Stacked Bar_ chart with an _X Axis_ component, the result
 looks like:
 
 <XYWrapper
@@ -87,7 +50,7 @@ looks like:
   y={d => d.y}
   showContext='container'
   components={[
-    axis('x', { tickFormat: d => ['A', 'B', 'C', 'D', 'E'][d] })
+    axis('x', { tickValues: [0, 1, 2, 3, 4], tickFormat: d => ['A', 'B', 'C', 'D', 'E'][d] })
   ]}
 />
 


### PR DESCRIPTION
- Adding an example with gradient areas
- Updates docs with a nicer example
- Fixed wrong CSS variables in the Theming → Bordered Segments doc


<img width="1501" height="854" alt="SCR-20260330-msqd" src="https://github.com/user-attachments/assets/7c66b1bb-d8e1-4882-a936-8f50984f0b4b" />

<img width="1505" height="849" alt="SCR-20260330-msuh" src="https://github.com/user-attachments/assets/80f479f5-8e37-4800-829e-6d9f7288b3c7" />
