### PR TITLE
Component | Axis: Configurable tick size

### DIFF
--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -70,6 +70,9 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickTextHideOverlapping?: boolean;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
   tickPadding?: number;
+  /** The size of the tick marks in pixels. Accepts a single number (applies to both inner and outer ticks)
+   * or a tuple `[innerTickSize, outerTickSize]`. Default: `6` */
+  tickSize?: number | [number, number];
 }
 
 export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
@@ -102,5 +105,6 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   tickValues: undefined,
   fullSize: true,
   tickPadding: 8,
+  tickSize: 6,
   tickTextHideOverlapping: undefined,
 }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -157,44 +157,41 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     this._resolveTickLabelOverlap(selection)
   }
 
-  private _buildAxis (): D3Axis<any> {
-    const { config: { type, position, tickPadding } } = this
+  private _getAxisGen (): D3Axis<NumberValue | Date> {
+    const { config } = this
 
-    const ticks = this._getNumTicks()
-    switch (type) {
+    switch (config.type) {
       case AxisType.X:
-        switch (position) {
-          case Position.Top: return axisTop(this.xScale).ticks(ticks).tickPadding(tickPadding)
-          case Position.Bottom: default: return axisBottom(this.xScale).ticks(ticks).tickPadding(tickPadding)
+        switch (config.position) {
+          case Position.Top: return axisTop(this.xScale)
+          case Position.Bottom: default: return axisBottom(this.xScale)
         }
       case AxisType.Y:
-        switch (position) {
-          case Position.Right: return axisRight(this.yScale).ticks(ticks).tickPadding(tickPadding)
-          case Position.Left: default: return axisLeft(this.yScale).ticks(ticks).tickPadding(tickPadding)
+        switch (config.position) {
+          case Position.Right: return axisRight(this.yScale)
+          case Position.Left: default: return axisLeft(this.yScale)
         }
     }
+  }
+
+  private _buildAxis (): D3Axis<NumberValue | Date> {
+    const { config: { tickPadding, tickSize } } = this
+
+    const tickSizeInner = Array.isArray(tickSize) ? tickSize[0] : tickSize
+    const tickSizeOuter = Array.isArray(tickSize) ? tickSize[1] : tickSize
+    const ticks = this._getNumTicks()
+    const axisGen = this._getAxisGen()
+    axisGen.ticks(ticks).tickPadding(tickPadding).tickSizeInner(tickSizeInner).tickSizeOuter(tickSizeOuter)
+
+    return axisGen
   }
 
   private _buildGrid (): D3Axis<NumberValue | Date> {
     const { config } = this
 
-    let gridGen: D3Axis<NumberValue | Date>
-    switch (config.type) {
-      case AxisType.X:
-        switch (config.position) {
-          case Position.Top: { gridGen = axisTop(this.xScale); break }
-          case Position.Bottom: default: { gridGen = axisBottom(this.xScale); break }
-        }
-        gridGen.tickSize(-this._height)
-        break
-      case AxisType.Y:
-        switch (config.position) {
-          case Position.Right: { gridGen = axisRight(this.yScale); break }
-          case Position.Left: default: { gridGen = axisLeft(this.yScale); break }
-        }
-        gridGen.tickSize(-this._width)
-    }
+    const gridGen = this._getAxisGen()
     gridGen
+      .tickSize(config.type === AxisType.X ? -this._height : -this._width)
       .tickSizeOuter(0)
       .tickFormat(() => '')
 

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -100,7 +100,11 @@ The _Axis_ component supports a wide variety of tick customization options
 
 ### Tick Line
 You can remove tick labels from your axis by setting the `tickLine` property to false:
-<XYWrapperWithInput {...axisProps()} inputType="checkbox" defaultValue={false} property="tickLine"/>
+<XYWrapperWithInput {...axisProps()} height={50} inputType="checkbox" defaultValue={false} property="tickLine"/>
+
+### Tick Size
+Control the length of the tick marks (in pixels) with the `tickSize` property. It accepts a single number, which applies to both inner and outer ticks, or a `[innerTickSize, outerTickSize]` tuple to set them independently. The default value is `6`.
+<XYWrapperWithInput {...axisProps()} height={50} hiddenProps={{duration: 0, gridLine: false}} inputType="range" inputProps={{ min: 0, max: 20 }} defaultValue={6} property="tickSize"/>
 
 ### Tick Label Font Size
 To change the font size for the tick labels, you provide the `tickTextFontSize` property with a CSS string.


### PR DESCRIPTION
Configurable `tickSize` for Axis

```ts
  /** The size of the tick marks in pixels. Accepts a single number (applies to both inner and outer ticks)
   * or a tuple `[innerTickSize, outerTickSize]`. Default: `6` */
  tickSize?: number | [number, number];
```

<img width="1505" height="444" alt="image" src="https://github.com/user-attachments/assets/e4262f65-92f3-425a-80c9-36a74397a24a" />

