### PR TITLE
React: Use specific imports instead of barrel 

### DIFF
--- a/packages/react/autogen/index.ts
+++ b/packages/react/autogen/index.ts
@@ -17,8 +17,8 @@ const skipProperties = ['width', 'height']
 const components = getComponentList() as ReactComponentInput[]
 
 for (const component of components) {
-  const { generics, statements } = getConfigSummary(component, skipProperties)
-  const importStatements = getImportStatements(component.name, statements, [], generics)
+  const { generics, statements, importSourceMap } = getConfigSummary(component, skipProperties)
+  const importStatements = getImportStatements(component.name, statements, [], generics, [], importSourceMap)
 
   const componentCode = getComponentCode(
     component.name,

--- a/packages/react/src/components/annotations/index.tsx
+++ b/packages/react/src/components/annotations/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Annotations, AnnotationsConfigInterface } from '@unovis/ts'
+import { Annotations } from '@unovis/ts/components/annotations'
+import { AnnotationsConfigInterface } from '@unovis/ts/components/annotations/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/area/index.tsx
+++ b/packages/react/src/components/area/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Area, AreaConfigInterface } from '@unovis/ts'
+import { Area } from '@unovis/ts/components/area'
+import { AreaConfigInterface } from '@unovis/ts/components/area/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/axis/index.tsx
+++ b/packages/react/src/components/axis/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Axis, AxisConfigInterface } from '@unovis/ts'
+import { Axis } from '@unovis/ts/components/axis'
+import { AxisConfigInterface } from '@unovis/ts/components/axis/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/brush/index.tsx
+++ b/packages/react/src/components/brush/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Brush, BrushConfigInterface } from '@unovis/ts'
+import { Brush } from '@unovis/ts/components/brush'
+import { BrushConfigInterface } from '@unovis/ts/components/brush/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/chord-diagram/index.tsx
+++ b/packages/react/src/components/chord-diagram/index.tsx
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { ChordDiagram, ChordDiagramConfigInterface, ChordInputNode, ChordInputLink } from '@unovis/ts'
+import { ChordDiagram } from '@unovis/ts/components/chord-diagram'
+import { ChordDiagramConfigInterface } from '@unovis/ts/components/chord-diagram/config'
+import { ChordInputNode, ChordInputLink } from '@unovis/ts/components/chord-diagram/types'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/crosshair/index.tsx
+++ b/packages/react/src/components/crosshair/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Crosshair, CrosshairConfigInterface } from '@unovis/ts'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { CrosshairConfigInterface } from '@unovis/ts/components/crosshair/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/donut/index.tsx
+++ b/packages/react/src/components/donut/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Donut, DonutConfigInterface } from '@unovis/ts'
+import { Donut } from '@unovis/ts/components/donut'
+import { DonutConfigInterface } from '@unovis/ts/components/donut/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/free-brush/index.tsx
+++ b/packages/react/src/components/free-brush/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { FreeBrush, FreeBrushConfigInterface } from '@unovis/ts'
+import { FreeBrush } from '@unovis/ts/components/free-brush'
+import { FreeBrushConfigInterface } from '@unovis/ts/components/free-brush/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/graph/index.tsx
+++ b/packages/react/src/components/graph/index.tsx
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Graph, GraphConfigInterface, GraphInputNode, GraphInputLink } from '@unovis/ts'
+import { Graph } from '@unovis/ts/components/graph'
+import { GraphConfigInterface } from '@unovis/ts/components/graph/config'
+import { GraphInputNode, GraphInputLink } from '@unovis/ts/types/graph'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/grouped-bar/index.tsx
+++ b/packages/react/src/components/grouped-bar/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { GroupedBar, GroupedBarConfigInterface } from '@unovis/ts'
+import { GroupedBar } from '@unovis/ts/components/grouped-bar'
+import { GroupedBarConfigInterface } from '@unovis/ts/components/grouped-bar/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/line/index.tsx
+++ b/packages/react/src/components/line/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Line, LineConfigInterface } from '@unovis/ts'
+import { Line } from '@unovis/ts/components/line'
+import { LineConfigInterface } from '@unovis/ts/components/line/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/nested-donut/index.tsx
+++ b/packages/react/src/components/nested-donut/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { NestedDonut, NestedDonutConfigInterface } from '@unovis/ts'
+import { NestedDonut } from '@unovis/ts/components/nested-donut'
+import { NestedDonutConfigInterface } from '@unovis/ts/components/nested-donut/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/plotband/index.tsx
+++ b/packages/react/src/components/plotband/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Plotband, PlotbandConfigInterface } from '@unovis/ts'
+import { Plotband } from '@unovis/ts/components/plotband'
+import { PlotbandConfigInterface } from '@unovis/ts/components/plotband/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/plotline/index.tsx
+++ b/packages/react/src/components/plotline/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Plotline, PlotlineConfigInterface } from '@unovis/ts'
+import { Plotline } from '@unovis/ts/components/plotline'
+import { PlotlineConfigInterface } from '@unovis/ts/components/plotline/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/sankey/index.tsx
+++ b/packages/react/src/components/sankey/index.tsx
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Sankey, SankeyConfigInterface, SankeyInputNode, SankeyInputLink } from '@unovis/ts'
+import { Sankey } from '@unovis/ts/components/sankey'
+import { SankeyConfigInterface } from '@unovis/ts/components/sankey/config'
+import { SankeyInputNode, SankeyInputLink } from '@unovis/ts/components/sankey/types'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/scatter/index.tsx
+++ b/packages/react/src/components/scatter/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Scatter, ScatterConfigInterface } from '@unovis/ts'
+import { Scatter } from '@unovis/ts/components/scatter'
+import { ScatterConfigInterface } from '@unovis/ts/components/scatter/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/stacked-bar/index.tsx
+++ b/packages/react/src/components/stacked-bar/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { StackedBar, StackedBarConfigInterface } from '@unovis/ts'
+import { StackedBar } from '@unovis/ts/components/stacked-bar'
+import { StackedBarConfigInterface } from '@unovis/ts/components/stacked-bar/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/timeline/index.tsx
+++ b/packages/react/src/components/timeline/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Timeline, TimelineConfigInterface } from '@unovis/ts'
+import { Timeline } from '@unovis/ts/components/timeline'
+import { TimelineConfigInterface } from '@unovis/ts/components/timeline/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Tooltip, TooltipConfigInterface } from '@unovis/ts'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { TooltipConfigInterface } from '@unovis/ts/components/tooltip/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/topojson-map/index.tsx
+++ b/packages/react/src/components/topojson-map/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { TopoJSONMap, TopoJSONMapConfigInterface } from '@unovis/ts'
+import { TopoJSONMap } from '@unovis/ts/components/topojson-map'
+import { TopoJSONMapConfigInterface } from '@unovis/ts/components/topojson-map/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/treemap/index.tsx
+++ b/packages/react/src/components/treemap/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { Treemap, TreemapConfigInterface } from '@unovis/ts'
+import { Treemap } from '@unovis/ts/components/treemap'
+import { TreemapConfigInterface } from '@unovis/ts/components/treemap/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/components/xy-labels/index.tsx
+++ b/packages/react/src/components/xy-labels/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { XYLabels, XYLabelsConfigInterface } from '@unovis/ts'
+import { XYLabels } from '@unovis/ts/components/xy-labels'
+import { XYLabelsConfigInterface } from '@unovis/ts/components/xy-labels/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/composites/time-series/index.tsx
+++ b/packages/react/src/composites/time-series/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useMemo } from 'react'
-import { Spacing, TextAlign, Scale } from '@unovis/ts'
+import { Spacing } from '@unovis/ts/types/spacing'
+import { TextAlign } from '@unovis/ts/types/text'
+import { Scale } from '@unovis/ts/types/scale'
 import { VisXYContainer } from '@unovis/react/containers/xy-container'
 import { VisArea } from '@unovis/react/components/area'
 import { VisAxis } from '@unovis/react/components/axis'

--- a/packages/react/src/containers/single-container/index.tsx
+++ b/packages/react/src/containers/single-container/index.tsx
@@ -1,6 +1,10 @@
 // eslint-disable-next-line no-use-before-define
 import React, { ReactNode, useEffect, useRef, useState, PropsWithChildren } from 'react'
-import { SingleContainer, SingleContainerConfigInterface, ComponentCore, Tooltip, Annotations } from '@unovis/ts'
+import { SingleContainer } from '@unovis/ts/containers/single-container'
+import { SingleContainerConfigInterface } from '@unovis/ts/containers/single-container/config'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Annotations } from '@unovis/ts/components/annotations'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/containers/xy-container/index.tsx
+++ b/packages/react/src/containers/xy-container/index.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import React, { ReactNode, useEffect, useRef, useState, PropsWithChildren } from 'react'
-import { XYContainer, XYContainerConfigInterface, XYComponentCore, Tooltip, Crosshair, Axis, AxisType, Annotations } from '@unovis/ts'
+import { XYContainer } from '@unovis/ts/containers/xy-container'
+import { XYContainerConfigInterface } from '@unovis/ts/containers/xy-container/config'
+import { XYComponentCore } from '@unovis/ts/core/xy-component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { Axis } from '@unovis/ts/components/axis'
+import { AxisType } from '@unovis/ts/components/axis/types'
+import { Annotations } from '@unovis/ts/components/annotations'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/html-components/bullet-legend/index.tsx
+++ b/packages/react/src/html-components/bullet-legend/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { BulletLegend, BulletLegendConfigInterface } from '@unovis/ts'
+import { BulletLegend } from '@unovis/ts/components/bullet-legend'
+import { BulletLegendConfigInterface } from '@unovis/ts/components/bullet-legend/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/html-components/flow-legend/index.tsx
+++ b/packages/react/src/html-components/flow-legend/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { FlowLegend, FlowLegendConfigInterface } from '@unovis/ts'
+import { FlowLegend } from '@unovis/ts/components/flow-legend'
+import { FlowLegendConfigInterface } from '@unovis/ts/components/flow-legend/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-flow-map/index.tsx
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { LeafletFlowMap, LeafletFlowMapConfigInterface, GenericDataRecord } from '@unovis/ts'
+import { LeafletFlowMap } from '@unovis/ts/components/leaflet-flow-map'
+import { LeafletFlowMapConfigInterface } from '@unovis/ts/components/leaflet-flow-map/config'
+import { GenericDataRecord } from '@unovis/ts/types/data'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/html-components/leaflet-map/index.tsx
+++ b/packages/react/src/html-components/leaflet-map/index.tsx
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { LeafletMap, LeafletMapConfigInterface, GenericDataRecord } from '@unovis/ts'
+import { LeafletMap } from '@unovis/ts/components/leaflet-map'
+import { LeafletMapConfigInterface } from '@unovis/ts/components/leaflet-map/config'
+import { GenericDataRecord } from '@unovis/ts/types/data'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/html-components/rolling-pin-legend/index.tsx
+++ b/packages/react/src/html-components/rolling-pin-legend/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { RollingPinLegend, RollingPinLegendConfigInterface } from '@unovis/ts'
+import { RollingPinLegend } from '@unovis/ts/components/rolling-pin-legend'
+import { RollingPinLegendConfigInterface } from '@unovis/ts/components/rolling-pin-legend/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/react/src/utils/react.ts
+++ b/packages/react/src/utils/react.ts
@@ -1,5 +1,5 @@
 import { Children, ReactElement, ReactNode } from 'react'
-import { isEqual } from '@unovis/ts'
+import { isEqual } from '@unovis/ts/utils/data'
 
 export function arePropsEqual<PropTypes extends { children?: ReactNode }> (prevProps: PropTypes, nextProps: PropTypes): boolean {
   if (typeof prevProps.children !== typeof nextProps.children) return false

--- a/packages/shared/integrations/utils.ts
+++ b/packages/shared/integrations/utils.ts
@@ -195,28 +195,36 @@ export function getImportStatements (
   statements: ts.Statement[],
   configInterfaceMembers: ts.TypeElement[],
   generics: GenericParameter[] = [],
-  additionalComponentTypes: string[] = []
+  additionalComponentTypes: string[] = [],
+  importSourceMap?: Record<string, string>
 ): { source: string; elements: string[] }[] {
-  const importSources = {}
+  const importSources: Record<string, string> = {}
 
   // We assume that all extend types in generics come from unovis/ts
   const genericExtends = generics.map(g => g.extends).filter(g => g)
   const genericDefaults = generics.map(g => g.default).filter(g => g)
   const componentTypes = [componentName, `${componentName}ConfigInterface`, ...additionalComponentTypes]
   for (const typeName of [...componentTypes, ...genericExtends, ...genericDefaults]) {
-    importSources[typeName] = '@unovis/ts'
+    importSources[typeName] = importSourceMap?.[typeName] ?? '@unovis/ts'
   }
 
-  const importDeclarations: any[] = statements.filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+  const importDeclarations = statements.filter((node): node is ts.ImportDeclaration => node.kind === ts.SyntaxKind.ImportDeclaration)
   for (const importDec of importDeclarations) {
-    for (const importEl of importDec.importClause.namedBindings.elements) {
-      let importSource: string = importDec.moduleSpecifier.text
-      if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
-        importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
-        importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
-      ) importSource = '@unovis/ts'
+    const namedBindings = importDec.importClause?.namedBindings
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue
+    for (const importEl of namedBindings.elements) {
+      const typeName = importEl.name.escapedText as string
+      if (importSourceMap?.[typeName]) {
+        importSources[typeName] = importSourceMap[typeName]
+      } else {
+        let importSource: string = (importDec.moduleSpecifier as ts.StringLiteral).text
+        if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
+          importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
+          importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
+        ) importSource = '@unovis/ts'
 
-      importSources[importEl.name.escapedText] = importSource
+        importSources[typeName] = importSource
+      }
     }
   }
 
@@ -262,12 +270,13 @@ export function getConfigSummary (
   keepOnlyRequiredProperties = true,
   unovisBasePath = '../ts/src',
   configFileName = '/config.ts'
-): { configProperties: ConfigProperty[]; configInterfaceMembers: ts.TypeElement[]; generics: GenericParameter[]; statements: ts.Statement[] } {
+): { configProperties: ConfigProperty[]; configInterfaceMembers: ts.TypeElement[]; generics: GenericParameter[]; statements: ts.Statement[]; importSourceMap: Record<string, string> } {
   const requiredProps = new Map<string, string[]>() // maps interface to required props
   const configPropertiesMap = new Map<string, ConfigProperty>() // The map of all config properties
   let statements: ts.Statement[] = [] // Statements and ...
   let configInterfaceMembers: ts.TypeElement[] = [] // config interface members to resolve imports of custom types
   let generics: GenericParameter[] | undefined = [] // Generics
+  const importSourceMap: Record<string, string> = {} // Maps type names to their granular @unovis/ts/... import paths
 
   for (const [i, path] of component.sources.entries()) {
     const fullPath = `${unovisBasePath}${path}${configFileName}`
@@ -318,6 +327,32 @@ export function getConfigSummary (
       })
     }
 
+    // Build import source map with resolved paths
+    const importDeclarations: any[] = sourceStatements.filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+    for (const importDec of importDeclarations) {
+      if (!importDec.importClause?.namedBindings?.elements) continue
+      let importSource: string = importDec.moduleSpecifier.text
+      if (importSource.startsWith('./') || importSource.startsWith('../')) {
+        importSource = `@unovis/ts${path}/${importSource.replace(/^\.\//, '')}`
+      } else if (
+        importSource.startsWith('core/') || importSource.startsWith('types/') ||
+        importSource.startsWith('utils/') || importSource.startsWith('components/') ||
+        importSource.startsWith('styles/') || importSource.startsWith('data-models/') ||
+        importSource.startsWith('data/')
+      ) {
+        importSource = `@unovis/ts/${importSource}`
+      }
+      for (const importEl of importDec.importClause.namedBindings.elements) {
+        importSourceMap[importEl.name.escapedText] = importSource
+      }
+    }
+
+    // Map the component class and config interface to their source path
+    if (i === component.sources.length - 1) {
+      importSourceMap[component.name] = `@unovis/ts${path}`
+      importSourceMap[`${component.name}ConfigInterface`] = `@unovis/ts${path}/config`
+    }
+
     statements = [...statements, ...sourceStatements]
     if (i === component.sources.length - 1) {
       generics = configInterface.typeParameters?.map((t: ts.TypeParameterDeclaration) => {
@@ -338,5 +373,6 @@ export function getConfigSummary (
     configInterfaceMembers,
     generics,
     statements,
+    importSourceMap,
   }
 }

--- a/packages/shared/integrations/utils.ts
+++ b/packages/shared/integrations/utils.ts
@@ -175,28 +175,36 @@ export function getImportStatements (
   statements: ts.Statement[],
   configInterfaceMembers: ts.TypeElement[],
   generics: GenericParameter[] = [],
-  additionalComponentTypes: string[] = []
+  additionalComponentTypes: string[] = [],
+  importSourceMap?: Record<string, string>
 ): { source: string; elements: string[] }[] {
-  const importSources = {}
+  const importSources: Record<string, string> = {}
 
   // We assume that all extend types in generics come from unovis/ts
   const genericExtends = generics.map(g => g.extends).filter(g => g)
   const genericDefaults = generics.map(g => g.default).filter(g => g)
   const componentTypes = [componentName, `${componentName}ConfigInterface`, ...additionalComponentTypes]
   for (const typeName of [...componentTypes, ...genericExtends, ...genericDefaults]) {
-    importSources[typeName] = '@unovis/ts'
+    importSources[typeName] = importSourceMap?.[typeName] ?? '@unovis/ts'
   }
 
-  const importDeclarations: any[] = statements.filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+  const importDeclarations = statements.filter((node): node is ts.ImportDeclaration => node.kind === ts.SyntaxKind.ImportDeclaration)
   for (const importDec of importDeclarations) {
-    for (const importEl of importDec.importClause.namedBindings.elements) {
-      let importSource: string = importDec.moduleSpecifier.text
-      if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
-        importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
-        importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
-      ) importSource = '@unovis/ts'
+    const namedBindings = importDec.importClause?.namedBindings
+    if (!namedBindings || !ts.isNamedImports(namedBindings)) continue
+    for (const importEl of namedBindings.elements) {
+      const typeName = importEl.name.escapedText as string
+      if (importSourceMap?.[typeName]) {
+        importSources[typeName] = importSourceMap[typeName]
+      } else {
+        let importSource: string = (importDec.moduleSpecifier as ts.StringLiteral).text
+        if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
+          importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
+          importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
+        ) importSource = '@unovis/ts'
 
-      importSources[importEl.name.escapedText] = importSource
+        importSources[typeName] = importSource
+      }
     }
   }
 
@@ -242,12 +250,13 @@ export function getConfigSummary (
   keepOnlyRequiredProperties = true,
   unovisBasePath = '../ts/src',
   configFileName = '/config.ts'
-): { configProperties: ConfigProperty[]; configInterfaceMembers: ts.TypeElement[]; generics: GenericParameter[]; statements: ts.Statement[] } {
+): { configProperties: ConfigProperty[]; configInterfaceMembers: ts.TypeElement[]; generics: GenericParameter[]; statements: ts.Statement[]; importSourceMap: Record<string, string> } {
   const requiredProps = new Map<string, string[]>() // maps interface to required props
   const configPropertiesMap = new Map<string, ConfigProperty>() // The map of all config properties
   let statements: ts.Statement[] = [] // Statements and ...
   let configInterfaceMembers: ts.TypeElement[] = [] // config interface members to resolve imports of custom types
   let generics: GenericParameter[] | undefined = [] // Generics
+  const importSourceMap: Record<string, string> = {} // Maps type names to their granular @unovis/ts/... import paths
 
   for (const [i, path] of component.sources.entries()) {
     const fullPath = `${unovisBasePath}${path}${configFileName}`
@@ -298,6 +307,32 @@ export function getConfigSummary (
       })
     }
 
+    // Build import source map with resolved paths
+    const importDeclarations: any[] = sourceStatements.filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+    for (const importDec of importDeclarations) {
+      if (!importDec.importClause?.namedBindings?.elements) continue
+      let importSource: string = importDec.moduleSpecifier.text
+      if (importSource.startsWith('./') || importSource.startsWith('../')) {
+        importSource = `@unovis/ts${path}/${importSource.replace(/^\.\//, '')}`
+      } else if (
+        importSource.startsWith('core/') || importSource.startsWith('types/') ||
+        importSource.startsWith('utils/') || importSource.startsWith('components/') ||
+        importSource.startsWith('styles/') || importSource.startsWith('data-models/') ||
+        importSource.startsWith('data/')
+      ) {
+        importSource = `@unovis/ts/${importSource}`
+      }
+      for (const importEl of importDec.importClause.namedBindings.elements) {
+        importSourceMap[importEl.name.escapedText] = importSource
+      }
+    }
+
+    // Map the component class and config interface to their source path
+    if (i === component.sources.length - 1) {
+      importSourceMap[component.name] = `@unovis/ts${path}`
+      importSourceMap[`${component.name}ConfigInterface`] = `@unovis/ts${path}/config`
+    }
+
     statements = [...statements, ...sourceStatements]
     if (i === component.sources.length - 1) {
       generics = configInterface.typeParameters?.map((t: ts.TypeParameterDeclaration) => {
@@ -318,5 +353,6 @@ export function getConfigSummary (
     configInterfaceMembers,
     generics,
     statements,
+    importSourceMap,
   }
 }

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -30,13 +30,26 @@
   "module": "./index.js",
   "typings": "./index.d.ts",
   "type": "module",
+  "typesVersions": {
+    "*": {
+      "components/*": ["dist/components/*"],
+      "containers/*": ["dist/containers/*"],
+      "core/*": ["dist/core/*"],
+      "types/*": ["dist/types/*"],
+      "utils/*": ["dist/utils/*"],
+      "styles/*": ["dist/styles/*"],
+      "data-models/*": ["dist/data-models/*"],
+      "data/*": ["dist/data/*"]
+    }
+  },
   "sideEffects": [
     "styles/index.js",
     "dist/styles/index.js"
   ],
   "scripts": {
-    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild; echo $sha > .srcsha; fi",
-    "forcebuild": "rimraf dist; rollup -c; rm -rf dist/.cache; cp LICENSE README.md package.json ./dist",
+    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild; echo $sha > .srcsha; fi; npm run build:package-json",
+    "forcebuild": "rimraf dist; rollup -c; rm -rf dist/.cache; cp LICENSE README.md ./dist; npm run build:package-json",
+    "build:package-json": "node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); delete p.typesVersions; require('fs').writeFileSync('./dist/package.json', JSON.stringify(p, null, 2))\"",
     "publish:dist": "cd ./dist; npm publish"
   },
   "devDependencies": {

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -30,14 +30,27 @@
   "module": "./index.js",
   "typings": "./index.d.ts",
   "type": "module",
+  "typesVersions": {
+    "*": {
+      "components/*": ["dist/components/*"],
+      "containers/*": ["dist/containers/*"],
+      "core/*": ["dist/core/*"],
+      "types/*": ["dist/types/*"],
+      "utils/*": ["dist/utils/*"],
+      "styles/*": ["dist/styles/*"],
+      "data-models/*": ["dist/data-models/*"],
+      "data/*": ["dist/data/*"]
+    }
+  },
   "sideEffects": [
     "styles/index.js",
     "dist/styles/index.js"
   ],
   "scripts": {
-    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild; echo $sha > .srcsha; fi",
-    "forcebuild": "rimraf dist; rollup -c; rm -rf dist/.cache; cp LICENSE README.md package.json ./dist",
+    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild; echo $sha > .srcsha; fi; npm run build:package-json",
+    "forcebuild": "rimraf dist; rollup -c; rm -rf dist/.cache; cp LICENSE README.md ./dist; npm run build:package-json",
     "publish:dist": "cd ./dist; npm publish",
+    "build:package-json": "node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); delete p.typesVersions; require('fs').writeFileSync('./dist/package.json', JSON.stringify(p, null, 2))\"",
     "license:check": "pnpm license-report --config=../../lic-report-config.json > licences.md"
   },
   "devDependencies": {

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -203,6 +203,12 @@ const config = {
       configureWebpack () {
         return {
           // cache: false, // Disable cache to prevent issues with building after updating Unovis packages
+          resolve: {
+            alias: {
+              // eslint-disable-next-line @typescript-eslint/no-var-requires
+              '@unovis/ts': require('path').resolve(__dirname, '../../packages/ts/dist'),
+            },
+          },
           module: {
             rules: [
               {


### PR DESCRIPTION
Currently, our React components (and other integrations too) import everything from the main entry point `@unovis/ts`. This causes bundlers to load the entire Unovis codebase into memory when compiling a project, which consumes a lot of memory and makes tree-shaking more difficult.

This PR changes the approach to importing only what's needed. This should make the build of projects that use Unovis faster and consume less memory, which is important in CI environments.

I have tried this with one project, and there are no issues. After testing it further with React, we should try extending this approach to other integrations.