### PR TITLE
Misc: Drop `.npmrc` legacy-peer-deps flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-legacy-peer-deps=true


### PR DESCRIPTION
Splitting another small piece off #495.

The `.npmrc` had `legacy-peer-deps=true`, which is an npm-only flag — and we're on pnpm, so it was a no-op anyway. @rokotyan also said in the comments that he didn't remember why it was there and to try removing it.

Verified `pnpm install` still works clean. Since the file only contained that one line, dropped the file altogether.