### PR TITLE
Vue | Wrappers: Drop unused `parseProps`

### DIFF
--- a/packages/vue/src/utils/props.ts
+++ b/packages/vue/src/utils/props.ts
@@ -1,5 +1,5 @@
 import { isEqual } from '@unovis/ts'
-import { ComponentInternalInstance, camelize, computed, getCurrentInstance } from 'vue'
+import { camelize, computed, getCurrentInstance } from 'vue'
 
 export function arePropsEqual<PropTypes> (prevProps: PropTypes, nextProps: PropTypes): boolean {
   return isEqual(prevProps, nextProps)
@@ -20,16 +20,5 @@ export function useForwardProps<T extends Record<string, any>> (props: T) {
     })
     return { ...preservedProps, ...attrs }
   })
-}
-
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
-export function parseProps <T extends object> (props: T, instance: ComponentInternalInstance | null) {
-  const preservedProps = {} as T
-  const assignedProps = instance?.vnode.props ?? {}
-
-  Object.keys(assignedProps).forEach(key => {
-    preservedProps[camelize(key)] = assignedProps[key]
-  })
-  return preservedProps
 }
 


### PR DESCRIPTION
Spotted while working on #773 — `parseProps` in `packages/vue/src/utils/props.ts` is exported but not used anywhere across the repo (`grep -rn 'parseProps\b' packages/vue` confirms it's dead). TypeScript was complaining (`TS6133: 'props' is declared but its value is never read`).

Removed the function and the now-orphan `ComponentInternalInstance` import.