### PR TITLE
Component | Timeline: Config option to fill empty space

### DIFF
--- a/packages/angular/src/components/timeline/timeline.component.ts
+++ b/packages/angular/src/components/timeline/timeline.component.ts
@@ -201,10 +201,13 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   @Input() rowLabelTextAlign?: TextAlign | `${TextAlign}`
 
   /** Row label trim mode when width is limited: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
-  @Input() rowLabelTrimMode?: TrimMode | any
+  @Input() rowLabelTrimMode?: TrimMode | `${TrimMode}`
 
-  /** Row label margin in pixels. Default: `5` */
-  @Input() rowLabelMargin?: number
+  /** Row label margin in pixels. Can be a single number or a `[left, right]` tuple. Default: `[0, 5]` */
+  @Input() rowLabelMargin?: number | [number, number]
+
+  /** When component height is larger than the height of all rows, render rows to fill empty space */
+  @Input() rowFillEmptySpace?: boolean
 
 
   @Input() arrows?: TimelineArrow[]
@@ -238,8 +241,8 @@ export class VisTimelineComponent<Datum> implements TimelineConfigInterface<Datu
   }
 
   private getConfig (): TimelineConfigInterface<Datum> {
-    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
-    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
+    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, rowFillEmptySpace, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll } = this
+    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, type, length, cursor, lineRow, lineDuration, lineWidth, lineCap, lineStartIcon, lineStartIconColor, lineStartIconSize, lineStartIconArrangement, lineEndIcon, lineEndIconColor, lineEndIconSize, lineEndIconArrangement, lineCursor, showEmptySegments, showEmptySegmentsCorrectPosition, rowHeight, alternatingRowColors, showLabels, labelWidth, maxLabelWidth, showRowLabels, rowLabelStyle, rowLabelFormatter, rowIcon, rowLabelWidth, rowMaxLabelWidth, rowLabelTextAlign, rowLabelTrimMode, rowLabelMargin, rowFillEmptySpace, arrows, animationLineEnterPosition, animationLineExitPosition, onScroll }
     const keys = Object.keys(config) as (keyof TimelineConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -88,6 +88,8 @@ export interface TimelineConfigInterface<Datum> extends WithOptional<XYComponent
   rowLabelTrimMode?: TrimMode | `${TrimMode}`;
   /** Row label margin in pixels. Can be a single number or a `[left, right]` tuple. Default: `[0, 5]` */
   rowLabelMargin?: number | [number, number];
+  /** When component height is larger than the height of all rows, render rows to fill empty space */
+  rowFillEmptySpace?: boolean;
 
   // Arrows
   arrows?: TimelineArrow[];
@@ -151,6 +153,7 @@ export const TimelineDefaultConfig: TimelineConfigInterface<unknown> = {
   rowLabelTextAlign: TextAlign.Right,
   rowLabelTrimMode: TrimMode.Middle,
   rowLabelMargin: [0, 5],
+  rowFillEmptySpace: true,
 
   // Arrows
   arrows: undefined,

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -321,7 +321,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
 
     // Row background rects
     const timelineWidth = xRange[1] - xRange[0] + this._lineIconBleed[0] + this._lineIconBleed[1] + this._lineBleed[0] + this._lineBleed[1]
-    const numRows = Math.max(Math.floor(yHeight / rowHeight), numRowLabels)
+    const numRows = config.rowFillEmptySpace ? Math.max(Math.floor(yHeight / rowHeight), numRowLabels) : numRowLabels
     const recordTypes = Array(numRows).fill(null).map((_, i) => rowLabels[i])
     const rects = this._rowsGroup.selectAll<SVGRectElement, number>(`.${s.row}`)
       .data(recordTypes)

--- a/packages/website/docs/xy-charts/Timeline.mdx
+++ b/packages/website/docs/xy-charts/Timeline.mdx
@@ -151,6 +151,9 @@ background color across all rows, disable the `alternatingRowColors` property:
 Use the `rowHeight` property to adjust the size of each row.
 <XYWrapper {...timelineProps(20, 5)} rowHeight={50} hideTabLabels/>
 
+### Filling empty vertical space
+When the timeline container is taller than the combined height of all rows, `rowFillEmptySpace` (default: `true`) stretches row layout so the rows use the extra space. Set it to `false` if you prefer rows to stay compact at the top and leave the remainder of the container empty.
+
 ## Line Configuration
 ### Line Cap
 By default, lines have squared ends. You can give your lines a rounded appearance by setting `lineCap` property to `true`.


### PR DESCRIPTION
New config property `rowFillEmptySpace` to control how we fill empty space when the components has bigger height.

### `rowFillEmptySpace: true` (default)
<img width="772" height="613" alt="SCR-20260425-itli" src="https://github.com/user-attachments/assets/cc6ab070-1add-4063-bb5f-c0d218cf71da" />

### `rowFillEmptySpace: false`
<img width="765" height="616" alt="SCR-20260425-itoc" src="https://github.com/user-attachments/assets/a118bcfc-fae2-449a-ba5f-a7a7f9b1699c" />