### PR TITLE
Component | Scatter: Skip points with missing values

### DIFF
--- a/packages/dev/src/examples/xy-components/scatter/scatter-performance/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-performance/index.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react'
+import { VisXYContainer, VisScatter, VisAxis } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+const NUM_POINTS = 10000
+const SPARSITY = 0.75 // 85% of y values will be null
+
+type SparseScatterRecord = {
+  x: number;
+  y: number | null;
+  size: number;
+}
+
+function generateSparseScatterData (seed = 42): SparseScatterRecord[] {
+  let s = seed
+  const random = (): number => {
+    s = (s * 1664525 + 1013904223) % 4294967296
+    return s / 4294967296
+  }
+
+  return Array.from({ length: NUM_POINTS }, () => ({
+    x: random() * 100,
+    y: random() < SPARSITY ? null : random() * 100,
+    size: 2 + random() * 8,
+  }))
+}
+
+export const title = 'Scatter Performance'
+export const subTitle = `${NUM_POINTS.toLocaleString()} points (${SPARSITY * 100}% sparse)`
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const data = useMemo(() => generateSparseScatterData(), [])
+
+  return (
+    <>
+      <div style={{ marginBottom: 10 }}>
+        <strong>Performance Test:</strong> {NUM_POINTS.toLocaleString()} points ({SPARSITY * 100}% sparse)
+      </div>
+      <VisXYContainer<SparseScatterRecord> data={data} margin={{ top: 5, left: 5 }}>
+        <VisScatter<SparseScatterRecord>
+          x={d => d.x}
+          y={d => d.y}
+          size={d => d.size}
+          duration={props.duration}
+        />
+        <VisAxis type='x' duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+    </>
+  )
+}

--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -199,6 +199,8 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
       return data?.reduce<ScatterPoint<Datum>[]>((acc, d, i) => {
         const xValue = getNumber(d, config.x, i)
         const yValue = getNumber(d, y, j)
+        if (xValue == null || yValue == null) return acc
+
         const pointSize = getNumber(d, config.size, i)
         const pointSizeScaled = config.sizeRange ? this._sizeScale(pointSize) : pointSize
         const pointSizeXDomain = (this.xScale.invert(pointSizeScaled) as number) - (this.xScale.invert(0) as number)


### PR DESCRIPTION
Currently if Scatter data has `null` values the component still tries to plot those points (they end up at the top left corner) and throws lots of console errors. This small change fixes that by filtering them out before plotting.