### PR TITLE
Dev | Examples: Tidy up gallery prop bindings (Vue + Svelte)

### DIFF
--- a/packages/shared/examples/baseline-area-chart/baseline-area-chart.svelte
+++ b/packages/shared/examples/baseline-area-chart/baseline-area-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { CurveType } from '@unovis/ts'
   import { VisXYContainer, VisArea, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import type { Category, DataRecord } from './data'
@@ -26,7 +26,7 @@
 <VisBulletLegend items={categories}/>
 <VisXYContainer {data} height={500}>
   <VisArea {x} {y} {baseline} curveType={CurveType.Basis}/>
-  <VisAxis type='x' label='Year'/>
-  <VisAxis type='y' label='Number of Works Acquired' {...yAxisConfig}/>
+  <VisAxis type="x" label="Year"/>
+  <VisAxis type="y" label="Number of Works Acquired" {...yAxisConfig}/>
 </VisXYContainer>
 

--- a/packages/shared/examples/baseline-area-chart/baseline-area-chart.vue
+++ b/packages/shared/examples/baseline-area-chart/baseline-area-chart.vue
@@ -25,9 +25,9 @@ const yAxisConfig = {
 
 <template>
   <VisBulletLegend :items="categories" />
-  <VisXYContainer :data="data" :height="500">
-    <VisArea :x="x" :y="y" :baseline="baseline" :curveType="CurveType.Basis" />
-    <VisAxis type='x' label='Year' />
-    <VisAxis type='y' label='Number of Works Acquired' v-bind="yAxisConfig" />
+  <VisXYContainer :data :height="500">
+    <VisArea :x :y :baseline :curveType="CurveType.Basis" />
+    <VisAxis type="x" label="Year" />
+    <VisAxis type="y" label="Number of Works Acquired" v-bind="yAxisConfig" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/basic-annotations/basic-annotations.vue
+++ b/packages/shared/examples/basic-annotations/basic-annotations.vue
@@ -94,7 +94,7 @@ const priceTickFormat = (y: number) => `$${y}`
 </script>
 
 <template>
-  <VisXYContainer :data="data" :xScale="xScale" :yScale="yScale" :yDomain="[0.05, 100000]" :height="600">
+  <VisXYContainer :data :xScale :yScale :yDomain="[0.05, 100000]" :height="600">
     <VisLine :x="date" :y="price" />
     <VisStackedBar color="#aaa3" :x="date" :y="volume" />
     <VisAxis type="x" :numTicks="5" :tickFormat="yearTickFormat" />

--- a/packages/shared/examples/basic-donut-chart/basic-donut-chart.svelte
+++ b/packages/shared/examples/basic-donut-chart/basic-donut-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisDonut, VisBulletLegend } from '@unovis/svelte'
   import { data, DataRecord } from './data'
 

--- a/packages/shared/examples/basic-donut-chart/basic-donut-chart.vue
+++ b/packages/shared/examples/basic-donut-chart/basic-donut-chart.vue
@@ -13,7 +13,7 @@ const legendItems = Object.entries(data).map(([_, data]) => ({
   <VisSingleContainer :height="400">
   <VisDonut
     :value="d => d.value"
-    :data="data"
+    :data
     :showEmptySegments="true"
     :padAngle="0.01"
     :arcWidth="100"

--- a/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.svelte
+++ b/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisXYContainer, VisGroupedBar, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import { data, colors, capitalize, ElectionDatum } from './data'
 

--- a/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.vue
+++ b/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.vue
@@ -18,9 +18,9 @@ const color = (d: ElectionDatum, i: number) => items[i].color
 
 <template>
   <h2>U.S. Election Popular Vote Results by Political Party</h2>
-  <VisBulletLegend :items="items" />
+  <VisBulletLegend :items />
   <VisXYContainer :height="500">
-    <VisGroupedBar :data="data" :x="x" :y="y" :color="color" />
+    <VisGroupedBar :data :x :y :color />
     <VisAxis type="x" label="Election Year" :numTicks="data.length" />
     <VisAxis type="y" :tickFormat="(value) => (value / 10 ** 6).toFixed(1)" label="Number of Votes (millions)" />
   </VisXYContainer>

--- a/packages/shared/examples/basic-leaflet-map/basic-leaflet-map.vue
+++ b/packages/shared/examples/basic-leaflet-map/basic-leaflet-map.vue
@@ -15,8 +15,8 @@ const pointColor = '#286e47'
 </script>
 
 <template>
-  <VisLeafletMap height="50vh" :style="style" :data="data" :pointLatitude="pointLatitude" :pointLongitude="pointLongitude"
-    :pointBottomLabel="pointBottomLabel" :pointColor="pointColor" :clusterExpandOnClick="false" :attribution="[
+  <VisLeafletMap height="50vh" :style :data :pointLatitude :pointLongitude
+    :pointBottomLabel :pointColor :clusterExpandOnClick="false" :attribution="[
       `<a href='https://www.maptiler.com/copyright/' target='_blank'>MapTiler</a>`,
       `<a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap contributors</a>`
     ]" />

--- a/packages/shared/examples/basic-line-chart/basic-line-chart.svelte
+++ b/packages/shared/examples/basic-line-chart/basic-line-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisXYContainer, VisLine, VisAxis } from '@unovis/svelte'
   import { data } from './data'
 </script>

--- a/packages/shared/examples/basic-line-chart/basic-line-chart.vue
+++ b/packages/shared/examples/basic-line-chart/basic-line-chart.vue
@@ -5,7 +5,7 @@ import { data } from './data'
 
 <template>
   <VisXYContainer :height="600">
-    <VisLine :data="data" :x="d => d.x" :y="d => d.y" />
+    <VisLine :data :x="d => d.x" :y="d => d.y" />
     <VisAxis type="x" />
     <VisAxis type="y" />
   </VisXYContainer>

--- a/packages/shared/examples/basic-sankey/basic-sankey.svelte
+++ b/packages/shared/examples/basic-sankey/basic-sankey.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { FitMode } from '@unovis/ts'
   import { VisSingleContainer, VisSankey } from '@unovis/svelte'
   import { data, NodeDatum } from './data'

--- a/packages/shared/examples/basic-sankey/basic-sankey.vue
+++ b/packages/shared/examples/basic-sankey/basic-sankey.vue
@@ -7,8 +7,8 @@ const subLabel = (d: NodeDatum) => `£${d.value.toFixed(2)}`
 </script>
 
 <template>
-  <VisSingleContainer :data="data" :height="400">
+  <VisSingleContainer :data :height="400">
     <VisSankey :labelFit="FitMode.Wrap" labelForceWordBreak="false" :labelMaxWidth="150" :nodePadding="20"
-      :subLabel="subLabel" />
+      :subLabel />
   </VisSingleContainer>
 </template>

--- a/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.svelte
+++ b/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import type { NumericAccessor, StringAccessor } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import { data, DataRecord } from './data'
@@ -16,8 +16,8 @@
 </script>
 
 <VisBulletLegend items={legendItems}/>
-<VisXYContainer data={data} height={'60vh'}>
-  <VisScatter x={x} y={y} size={8} color={color}/>
-  <VisAxis type='x' label={'Beak Length (mm)'} />
-  <VisAxis type='y' label={'Flipper Length (mm)'}/>
+<VisXYContainer {data} height={'60vh'}>
+  <VisScatter {x} {y} size={8} {color}/>
+  <VisAxis type="x" label={'Beak Length (mm)'} />
+  <VisAxis type="y" label={'Flipper Length (mm)'}/>
 </VisXYContainer>

--- a/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.vue
+++ b/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.vue
@@ -16,9 +16,9 @@ const color: StringAccessor<DataRecord> = d => legendItems.find(i => i.name === 
 
 <template>
   <VisBulletLegend :items="legendItems"/>
-  <VisXYContainer :data="data" :height="600">
-    <VisScatter :x="x" :y="y" :color="color" :size="8"/>
-    <VisAxis type='x' label='Beak Length (mm)' />
-    <VisAxis type='y' label='Flipper Length (mm)'/>
+  <VisXYContainer :data :height="600">
+    <VisScatter :x :y :color :size="8"/>
+    <VisAxis type="x" label="Beak Length (mm)" />
+    <VisAxis type="y" label="Flipper Length (mm)"/>
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/basic-timeline/basic-timeline.svelte
+++ b/packages/shared/examples/basic-timeline/basic-timeline.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Timeline } from '@unovis/ts'
   import { VisXYContainer, VisBulletLegend, VisTooltip, VisTimeline, VisAxis } from '@unovis/svelte'
   import { colorMap, data, DataRecord, ProductType } from './data'
@@ -24,10 +24,10 @@
   const triggers = { [Timeline.selectors.label]: getTooltipText }
 </script>
 
-<VisXYContainer data={data} height={500}>
+<VisXYContainer {data} height={500}>
   <h3>A Timeline of Abandoned Google Products, 1997 - 2022</h3>
   <VisBulletLegend items={legendItems}/>
   <VisTimeline {x} {length} {type} {color} {labelWidth} showLabels={true}/>
-  <VisTooltip triggers={triggers}/>
+  <VisTooltip {triggers}/>
   <VisAxis type="x" tickFormat={dateFormatter} numTicks={10}/>
 </VisXYContainer>

--- a/packages/shared/examples/basic-timeline/basic-timeline.vue
+++ b/packages/shared/examples/basic-timeline/basic-timeline.vue
@@ -25,11 +25,11 @@ const triggers = { [Timeline.selectors.label]: getTooltipText }
 </script>
 
 <template>
-  <VisXYContainer :data="data" :height="500">
+  <VisXYContainer :data :height="500">
     <h3>A Timeline of Abandoned Google Products, 1997 - 2022</h3>
     <VisBulletLegend :items="legendItems" />
-    <VisTimeline :x="x" :length="length" :type="type" :color="color" :labelWidth="labelWidth" :showLabels="true" />
-    <VisTooltip :triggers="triggers" />
+    <VisTimeline :x :length :type :color :labelWidth :showLabels="true" />
+    <VisTooltip :triggers />
     <VisAxis type="x" :tickFormat="dateFormatter" :numTicks="10" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.svelte
+++ b/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { BulletLegendItemInterface } from '@unovis/ts'
   import { VisXYContainer, VisAxis, VisBrush, VisGroupedBar, VisBulletLegend } from '@unovis/svelte'
   import { data, groups, GroupItem, DataRecord } from './data'
@@ -31,12 +31,12 @@
 
 <VisBulletLegend {items} onLegendItemClick={updateItems} />
 <VisXYContainer {duration} {data} height={300} {xDomain} scaleByDomain={true}>
-  <VisGroupedBar x={x} y={y} groupPadding={0.2} roundedCorners barMinHeight={0} />
-  <VisAxis type='x' label='Year' numTicks={Math.min(15, selection[1] - selection[0])} gridLine={false}/>
-  <VisAxis type='y' label='Cereal Production (metric tons, millions)'/>
+  <VisGroupedBar {x} {y} groupPadding={0.2} roundedCorners barMinHeight={0} />
+  <VisAxis type="x" label="Year" numTicks={Math.min(15, selection[1] - selection[0])} gridLine={false}/>
+  <VisAxis type="y" label="Cereal Production (metric tons, millions)"/>
 </VisXYContainer>
 <VisXYContainer {data} height={75} margin={{ left: 60 }}>
   <VisGroupedBar {x} {y}/>
   <VisBrush bind:selection onBrush={updateDomain} draggable={true}/>
-  <VisAxis type='x' numTicks={15}/>
+  <VisAxis type="x" numTicks={15}/>
 </VisXYContainer>

--- a/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.vue
+++ b/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.vue
@@ -30,15 +30,15 @@ function updateItems(item: LegendItem, i: number) {
 </script>
 
 <template>
-  <VisBulletLegend :items="items" :onLegendItemClick="updateItems" />
-  <VisXYContainer :duration="duration" :data="data" :height="300" :xDomain="domain" :scaleByDomain="true">
-    <VisGroupedBar :x="x" :y="y" :groupPadding="0.2" roundedCorners :barMinHeight="0" />
-    <VisAxis type='x' label='Year' :numTicks="Math.min(15, domain[1] - domain[0])" :gridLine="false" />
-    <VisAxis type='y' label='Cereal Production (metric tons, millions)' />
+  <VisBulletLegend :items :onLegendItemClick="updateItems" />
+  <VisXYContainer :duration :data :height="300" :xDomain="domain" :scaleByDomain="true">
+    <VisGroupedBar :x :y :groupPadding="0.2" roundedCorners :barMinHeight="0" />
+    <VisAxis type="x" label="Year" :numTicks="Math.min(15, domain[1] - domain[0])" :gridLine="false" />
+    <VisAxis type="y" label="Cereal Production (metric tons, millions)" />
   </VisXYContainer>
-  <VisXYContainer :data="data" :height="75" :margin="{ left: 60 }">
-    <VisGroupedBar :x="x" :y="y" />
+  <VisXYContainer :data :height="75" :margin="{ left: 60 }">
+    <VisGroupedBar :x :y />
     <VisBrush :selection="domain" :onBrush="updateDomain" :draggable="true" />
-    <VisAxis type='x' :numTicks="15" />
+    <VisAxis type="x" :numTicks="15" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.svelte
+++ b/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   // eslint-disable svelte/no-at-html-tags
   import { Position } from '@unovis/ts'
   import { VisAxis, VisCrosshair, VisStackedBar, VisTooltip, VisXYContainer } from '@unovis/svelte'

--- a/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.vue
+++ b/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.vue
@@ -30,8 +30,8 @@ function tooltipTemplate(d: DataRecord): string {
   <div>
     <span v-for="l in labels" style="margin-right: 20px" v-html="getIcon(l)"></span>
   </div>
-  <VisXYContainer :data="data" :height="height">
-    <VisStackedBar :x="x" :y="y" />
+  <VisXYContainer :data :height>
+    <VisStackedBar :x :y />
     <VisCrosshair :template="tooltipTemplate" />
     <VisTooltip :verticalShift="height" :horizontalPlacement="Position.Center" />
     <VisAxis type="x" />

--- a/packages/shared/examples/custom-nodes-graph/custom-nodes-graph.vue
+++ b/packages/shared/examples/custom-nodes-graph/custom-nodes-graph.vue
@@ -132,12 +132,12 @@
     
     <VisSingleContainer
       :class="customNodesGraph"
-      :data="data"
+      :data
       height="50vh"
       :duration="1000"
     >
       <VisTooltip
-        :triggers="triggers"
+        :triggers
         :followCursor="tooltipFollowCursor"
         :allowHover="tooltipAllowHover"
       />
@@ -157,20 +157,20 @@
         nodeStroke="none"
         :nodeSubLabel="getNodeSubLabel"
         :nodeSubLabelTrimLength="30"
-        :nodeEnterCustomRenderFunction="nodeEnterCustomRenderFunction"
-        :nodeUpdateCustomRenderFunction="nodeUpdateCustomRenderFunction"
+        :nodeEnterCustomRenderFunction
+        :nodeUpdateCustomRenderFunction
         @renderComplete="onRenderComplete"
         :nodeSelectionHighlightMode="GraphNodeSelectionHighlightMode.None"
-        :selectedNodeId="selectedNodeId"
-        :events="events"
+        :selectedNodeId
+        :events
         :linkFlow="handleLinkFlow"
         @layoutCalculated="onLayoutCalculated"
         :linkFlowAnimDuration="handleLinkFlowAnimDuration"
         :linkFlowParticleSpeed="handleLinkFlowParticleSpeed"
         :linkFlowParticleSize="handleLinkFlowParticleSize"
-        :fitViewPadding="fitViewPadding"
+        :fitViewPadding
         @zoom="onZoom"
-        :zoomScaleExtent="zoomScaleExtent"
+        :zoomScaleExtent
       />
     </VisSingleContainer>
   </div>

--- a/packages/shared/examples/dagre-graph/dagre-graph.svelte
+++ b/packages/shared/examples/dagre-graph/dagre-graph.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { GraphLayoutType, GraphNodeShape } from '@unovis/ts'
   import { data, NodeDatum, LinkDatum } from './data'

--- a/packages/shared/examples/dagre-graph/dagre-graph.vue
+++ b/packages/shared/examples/dagre-graph/dagre-graph.vue
@@ -12,7 +12,7 @@ const linkStroke = (l: LinkDatum) => l.color
 </script>
 
 <template>
-  <VisSingleContainer :data="data" :height="600">
+  <VisSingleContainer :data :height="600">
     <VisGraph v-bind="{
       layoutType,
       nodeLabel,

--- a/packages/shared/examples/data-gap-line-chart/data-gap-line-chart.svelte
+++ b/packages/shared/examples/data-gap-line-chart/data-gap-line-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisXYContainer, VisLine, VisBulletLegend, VisAxis, VisXYLabels } from '@unovis/svelte'
   import type { DataRecord, Country } from './data'
   import { countries, data, legendItems } from './data'
@@ -35,11 +35,11 @@
 </div>
 <VisXYContainer duration={0} height={300} xDomain={[1961, 2022]} yDomain={[0, 650]}>
   <VisLine {data} {x} {y} {fallbackValue}/>
-  <VisXYLabels backgroundColor='none' {...labelConfig}/>
-  <VisAxis type='x' numTicks={10}/>
+  <VisXYLabels backgroundColor="none" {...labelConfig}/>
+  <VisAxis type="x" numTicks={10}/>
   <VisAxis
-    type='y'
-    label='National Cereal Production, tons'
+    type="y"
+    label="National Cereal Production, tons"
     tickFormat={d => `${d}${d ? 'M' : ''}`}
     tickValues={[0, 200, 400, fallbackValue, 600]}
   />

--- a/packages/shared/examples/data-gap-line-chart/data-gap-line-chart.vue
+++ b/packages/shared/examples/data-gap-line-chart/data-gap-line-chart.vue
@@ -32,13 +32,13 @@ function onLegendItemClick(_, i: number): void {
 
 <template>
   <div class="fallbackValueSwitch"> Select a fallback value for missing data points:
-    <VisBulletLegend :items="items" :onLegendItemClick="onLegendItemClick" />
+    <VisBulletLegend :items :onLegendItemClick />
   </div>
   <VisXYContainer :duration="0" :height="300" :xDomain="[1961, 2022]" :yDomain="[0, 650]">
-    <VisLine :data="data" :x="x" :y="y" :fallbackValue="fallbackValue" />
+    <VisLine :data :x :y :fallbackValue />
     <VisXYLabels :style="{ backgroundColor: 'none' }" v-bind="labelConfig" />
-    <VisAxis type='x' :numTicks="10" />
-    <VisAxis type='y' label='National Cereal Production, tons' :tickFormat="d => `${d}${d ? 'M' : ''}`"
+    <VisAxis type="x" :numTicks="10" />
+    <VisAxis type="y" label="National Cereal Production, tons" :tickFormat="d => `${d}${d ? 'M' : ''}`"
       :tickValues="[0, 200, 400, fallbackValue, 600]" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
 
   import { VisXYContainer, VisArea, VisAxis, VisLine } from '@unovis/svelte'
   import { XYDataRecord, generateXYDataRecords } from './data'
@@ -17,38 +17,38 @@
   <VisXYContainer
     data={generateXYDataRecords(150)}
     autoMargin={false}
-    margin={margin}
-    width= {'100%'}
-    height= {'40vh'}
+    {margin}
+    width="100%"
+    height="40vh"
   >
     <VisArea x={chartX} y={chartAY} opacity={0.9} />
-    <VisAxis type='x' numTicks={3} tickFormat={xTicks} label='Time'/>
-    <VisAxis type='y'
+    <VisAxis type="x" numTicks={3} tickFormat={xTicks} label="Time"/>
+    <VisAxis type="y"
       tickFormat={chartAYTicks}
       tickTextWidth={60}
-      tickTextColor={'#4D8CFD'}
-      labelColor={'#4D8CFD'}
-      label='Traffic'
+      tickTextColor="#4D8CFD"
+      labelColor="#4D8CFD"
+      label="Traffic"
     />
   </VisXYContainer>
   <VisXYContainer
     data={generateXYDataRecords(150)}
     yDomain={[0, 150]}
-    margin={margin}
+    {margin}
     autoMargin={false}
-    width= {'100%'}
-    height= {'40vh'}
-    class={'chartContainer'}
+    width="100%"
+    height="40vh"
+    class="chartContainer"
   >
-    <VisLine x={chartX} y={chartBY} color={'#FF6B7E'} />
+    <VisLine x={chartX} y={chartBY} color="#FF6B7E" />
     <VisAxis
-      type='y'
-      position={'right'}
+      type="y"
+      position="right"
       tickFormat={chartBYTicks}
       gridLine={false}
-      tickTextColor={'#FF6B7E'}
-      labelColor={'#FF6B7E'}
-      label='Signal Strength'
+      tickTextColor="#FF6B7E"
+      labelColor="#FF6B7E"
+      label="Signal Strength"
     />
   </VisXYContainer>
 </div>

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
@@ -4,7 +4,6 @@
   import { XYDataRecord, generateXYDataRecords } from './data'
 
   const margin = { left: 100, right: 100, top: 40, bottom: 60 }
-  const style: React.CSSProperties = { position: 'absolute', top: 0, left: 0, width: '100%', height: '40vh' }
   const chartX = d => d.x
   const chartAY = (d: XYDataRecord, i: number) => i * (d.y || 0)
   const chartBY = (d: XYDataRecord) => 20 + 10 * (d.y2 || 0)
@@ -43,6 +42,9 @@
   >
     <VisLine x={chartX} y={chartBY} color={'#FF6B7E'} />
     <VisAxis
+      type='y'
+      position={'right'}
+      tickFormat={chartBYTicks}
       gridLine={false}
       tickTextColor={'#FF6B7E'}
       labelColor={'#FF6B7E'}

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.vue
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.vue
@@ -15,38 +15,38 @@ const chartBYTicks = (y: number) => `${y}db`
 
 <template>
   <VisXYContainer
-      :data=generateXYDataRecords(150)
-      :margin= margin
-      :autoMargin= false
-      :width="'100%'"
-      :height= "'40vh'"
+      :data="generateXYDataRecords(150)"
+      :margin
+      :autoMargin="false"
+      width="100%"
+      height="40vh"
     >
-      <VisArea :x=chartX :y=chartAY :opacity=0.9 />
-      <VisAxis type='x' :numTicks=3 :tickFormat="xTicks" :label="'Time'"/>
-      <VisAxis type='y'
+      <VisArea :x="chartX" :y="chartAY" :opacity="0.9" />
+      <VisAxis type="x" :numTicks="3" :tickFormat="xTicks" label="Time"/>
+      <VisAxis type="y"
         :tickFormat="chartAYTicks"
-        :tickTextWidth=60
-        :tickTextColor="'#4D8CFD'"
-        :labelColor="'#4D8CFD'"
-        :label="'Traffic'"
+        :tickTextWidth="60"
+        tickTextColor="#4D8CFD"
+        labelColor="#4D8CFD"
+        label="Traffic"
       />
     </VisXYContainer>
     <VisXYContainer
-      :data=generateXYDataRecords(150)
+      :data="generateXYDataRecords(150)"
       :yDomain="[0, 150]"
-      :margin=margin
-      :autoMargin=false
-      :style=style
+      :margin
+      :autoMargin="false"
+      :style
     >
-      <VisLine :x=chartX :y=chartBY :color="'#FF6B7E'" />
+      <VisLine :x="chartX" :y="chartBY" color="#FF6B7E" />
       <VisAxis
-        type='y'
-        :position="'right'"
+        type="y"
+        position="right"
         :tickFormat="chartBYTicks"
-        :gridLine=false
-        :tickTextColor="'#FF6B7E'"
-        :labelColor="'#FF6B7E'"
-        :label="'Signal Strength'"
+        :gridLine="false"
+        tickTextColor="#FF6B7E"
+        labelColor="#FF6B7E"
+        label="Signal Strength"
       />
     </VisXYContainer>
 </template>

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.vue
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import { VisXYContainer, VisArea, VisAxis, VisLine } from '@unovis/vue'
 import { XYDataRecord, generateXYDataRecords } from './data'
 const margin = { left: 100, right: 100, top: 40, bottom: 60 }
-const style: React.CSSProperties = { position: 'absolute', top: 0, left: 0, width: '100%', height: '40vh' }
+const style: CSSProperties = { position: 'absolute', top: 0, left: 0, width: '100%', height: '40vh' }
 
 const chartX = d => d.x
 const chartAY = (d: XYDataRecord, i: number) => i * (d.y || 0)

--- a/packages/shared/examples/elk-layered-graph/elk-layered-graph.svelte
+++ b/packages/shared/examples/elk-layered-graph/elk-layered-graph.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { GraphLayoutType, GraphNodeShape } from '@unovis/ts'
   import { data, NodeDatum, LinkDatum, panels } from './data'

--- a/packages/shared/examples/elk-layered-graph/elk-layered-graph.vue
+++ b/packages/shared/examples/elk-layered-graph/elk-layered-graph.vue
@@ -22,7 +22,7 @@ const layoutElkNodeGroups = [
 
 <template>
   <div class="chart">
-    <VisSingleContainer :data="data" height="60vh">
+    <VisSingleContainer :data height="60vh">
       <VisGraph v-bind="{
         nodeShape,
         nodeStrokeWidth,

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { FitMode, Sankey, SankeyLink, SankeyNode, SankeySubLabelPlacement, VerticalAlign } from '@unovis/ts'
   import { VisSingleContainer, VisSankey } from '@unovis/svelte'
   import { sankeyData, root, Node, Link } from './data'

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.vue
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.vue
@@ -33,7 +33,7 @@ const callbacks = {
 </script>
 
 <template>
-  <VisSingleContainer :data="data" height="min(60vh,75vw)">
+  <VisSingleContainer :data height="min(60vh,75vw)">
     <VisSankey v-bind="callbacks" :labelFit="FitMode.Wrap" :labelForceWordBreak="false" :labelMaxWidth="150"
       :labelVerticalAlign="VerticalAlign.Middle" :nodePadding="20" :subLabelPlacement="SankeySubLabelPlacement.Inline" />
   </VisSingleContainer>

--- a/packages/shared/examples/force-graph/force-graph.svelte
+++ b/packages/shared/examples/force-graph/force-graph.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { GraphForceLayoutSettings, GraphLayoutType } from '@unovis/ts'
   import { data, LinkDatum, NodeDatum } from './data'

--- a/packages/shared/examples/force-graph/force-graph.vue
+++ b/packages/shared/examples/force-graph/force-graph.vue
@@ -15,8 +15,8 @@ const nodeFill = (n: NodeDatum) => n.color
 </script>
 
 <template>
-  <VisSingleContainer :data="data" height="60vh">
-    <VisGraph :layoutType="GraphLayoutType.Force" :nodeSize="40" :forceLayoutSettings="forceLayoutSettings"
-      :linkLabel="linkLabel" :nodeFill="nodeFill" :nodeLabel="nodeLabel" />
+  <VisSingleContainer :data height="60vh">
+    <VisGraph :layoutType="GraphLayoutType.Force" :nodeSize="40" :forceLayoutSettings
+      :linkLabel :nodeFill :nodeLabel />
   </VisSingleContainer>
 </template>

--- a/packages/shared/examples/free-brush-scatters/free-brush-scatters.svelte
+++ b/packages/shared/examples/free-brush-scatters/free-brush-scatters.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { FreeBrushMode, Scale, Position } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisBulletLegend, VisFreeBrush } from '@unovis/svelte'
   import { palette, data, DataRecord } from './data'
@@ -29,19 +29,19 @@
 <div class="scatter-with-minimap">
   <div>
     <VisXYContainer
-      data={data}
+      {data}
       xDomain={selection?.[0]}
       yDomain={selection?.[1]}
       height={'55vh'}
       scaleByDomain={true}
     >
       <VisScatter {...scatterProps} sizeRange={[20, 80]} labelPosition={Position.Bottom} />
-      <VisAxis type='x' label='Median Salary ($)' tickFormat={formatNumber} gridLine={false}/>
-      <VisAxis type='y' label='Employment Rate' tickPadding={0} gridLine={false}/>
+      <VisAxis type="x" label="Median Salary ($)" tickFormat={formatNumber} gridLine={false}/>
+      <VisAxis type="y" label="Employment Rate" tickPadding={0} gridLine={false}/>
     </VisXYContainer>
   </div>
   <div class="minimap">
-    <VisXYContainer data={data} height={125}>
+    <VisXYContainer {data} height={125}>
       <VisScatter {...scatterProps} sizeRange={[3, 10]} label={undefined}/>
       <VisFreeBrush
         selectionMinLength={[0, 0]}

--- a/packages/shared/examples/free-brush-scatters/free-brush-scatters.vue
+++ b/packages/shared/examples/free-brush-scatters/free-brush-scatters.vue
@@ -30,18 +30,18 @@ const scatterProps = {
   <VisBulletLegend :items="legendItems" />
   <div class="scatter-with-minimap">
     <div>
-      <VisXYContainer :data="data" :xDomain="selection?.[0]" :yDomain="selection?.[1]" height="55vh"
+      <VisXYContainer :data :xDomain="selection?.[0]" :yDomain="selection?.[1]" height="55vh"
         :scaleByDomain="true">
         <VisScatter v-bind="scatterProps" :sizeRange="[20, 80]" :labelPosition="Position.Bottom" />
-        <VisAxis type='x' label='Median Salary ($)' :tickFormat="formatNumber" :gridLine="false" />
-        <VisAxis type='y' label='Employment Rate' :tickPadding="0" :gridLine="false" />
+        <VisAxis type="x" label="Median Salary ($)" :tickFormat="formatNumber" :gridLine="false" />
+        <VisAxis type="y" label="Employment Rate" :tickPadding="0" :gridLine="false" />
       </VisXYContainer>
     </div>
     <div class="minimap">
-      <VisXYContainer :data="data" :height="125">
+      <VisXYContainer :data :height="125">
         <VisScatter v-bind="scatterProps" :sizeRange="[3, 10]" :label="undefined" />
         <VisFreeBrush :selectionMinLength="[0, 0]" :autoHide="false" :x="scatterProps.x" :y="scatterProps.y"
-          :onBrushEnd="onBrushEnd" :mode="FreeBrushMode.XY" />
+          :onBrushEnd :mode="FreeBrushMode.XY" />
       </VisXYContainer>
     </div>
   </div>

--- a/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.svelte
+++ b/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisChordDiagram } from '@unovis/svelte'
   import { ChordHierarchyNode, ChordLabelAlignment } from '@unovis/ts'
   import { colorMap, links, nodes, LinkDatum, NodeDatum } from './data'
@@ -10,7 +10,7 @@
   const nodeLabelColor = (n: NodeDatum) => n.height && 'var(--vis-tooltip-text-color)'
 </script>
 
-<VisSingleContainer data={data} height={'60vh'}>
+<VisSingleContainer {data} height={'60vh'}>
   <VisChordDiagram
     {linkColor}
     {nodeColor}

--- a/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.vue
+++ b/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.vue
@@ -11,7 +11,7 @@ const nodeLabelColor = (n: NodeDatum) => n.height && 'var(--vis-tooltip-text-col
 </script>
 
 <template>
-  <VisSingleContainer :data="data" height="60vh">
+  <VisSingleContainer :data height="60vh">
     <VisChordDiagram v-bind="{
       linkColor,
       nodeColor,

--- a/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.svelte
+++ b/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisXYContainer, VisStackedBar, VisAxis, VisBulletLegend, VisTooltip } from '@unovis/svelte'
   import { FitMode, Direction, Orientation, StackedBar } from '@unovis/ts'
   import { data, labels, EducationDatum } from './data'

--- a/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.vue
+++ b/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.vue
@@ -31,10 +31,10 @@ function tooltipTemplate(d: EducationDatum): string {
   <h3>Highest Degree Earned across Country Populations as of 2020</h3>
   <VisBulletLegend :items="chartLabels.map(d => ({ name: d.legend }))" />
   <VisXYContainer :height="isSmallScreen ? 600 : 800" :yDirection="Direction.South">
-    <VisStackedBar :data="data" :x="x" :y="y" :orientation="Orientation.Horizontal" />
+    <VisStackedBar :data :x :y :orientation="Orientation.Horizontal" />
     <VisTooltip :triggers="{ [StackedBar.selectors.bar]: tooltipTemplate }" />
     <VisAxis type="x" label="% of population aged 25 or above" />
     <VisAxis type="y" :tickTextWidth="isSmallScreen ? 75 : null" :tickTextFitMode="FitMode.Trim"
-      :label="isSmallScreen ? null : 'Country'" :numTicks="data.length" :tickFormat="tickFormat" />
+      :label="isSmallScreen ? null : 'Country'" :numTicks="data.length" :tickFormat />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/leaflet-flow-map/leaflet-flow-map.vue
+++ b/packages/shared/examples/leaflet-flow-map/leaflet-flow-map.vue
@@ -27,11 +27,11 @@ const pointColor = '#435647'
 </script>
 
 <template>
-  <VisLeafletFlowMap height="50vh" :data="data" :style="style" :fitViewPadding="fitViewPadding"
-    :pointLatitude="pointLatitude" :pointLongitude="pointLongitude" :pointBottomLabel="pointBottomLabel"
-    :sourceLatitude="sourceLatitude" :sourceLongitude="sourceLongitude" :targetLatitude="targetLatitude"
-    :targetLongitude="targetLongitude" :flowParticleDensity="flowParticleDensity" :flowParticleRadius="flowParticleRadius"
-    :flowParticleColor="flowParticleColor" :pointRadius="pointRadius" :pointColor="pointColor" :attribution="[
+  <VisLeafletFlowMap height="50vh" :data :style :fitViewPadding
+    :pointLatitude :pointLongitude :pointBottomLabel
+    :sourceLatitude :sourceLongitude :targetLatitude
+    :targetLongitude :flowParticleDensity :flowParticleRadius
+    :flowParticleColor :pointRadius :pointColor :attribution="[
       `<a href=' https://www.maptiler.com/copyright/' target='_blank'>MapTiler</a>`,
       `<a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap contributors</a>`
     ]" />

--- a/packages/shared/examples/multi-line-chart/multi-line-chart.svelte
+++ b/packages/shared/examples/multi-line-chart/multi-line-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Scale } from '@unovis/ts'
   import { VisXYContainer, VisLine, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import { data, labels, CityTemps } from './data'
@@ -14,7 +14,7 @@
 </script>
 
 <VisBulletLegend {items}/>
-<VisXYContainer data={data} height={300} {xScale}>
+<VisXYContainer {data} height={300} {xScale}>
   <VisLine {x} {y}/>
   <VisAxis type="x" label="Date" numTicks={6} tickFormat={(value) => Intl.DateTimeFormat().format(value)}/>
   <VisAxis type="y" label="Temperature (celsius)"/>

--- a/packages/shared/examples/multi-line-chart/multi-line-chart.vue
+++ b/packages/shared/examples/multi-line-chart/multi-line-chart.vue
@@ -14,9 +14,9 @@ const xScale = Scale.scaleTime()
 </script>
 
 <template>
-  <VisBulletLegend :items="items" />
-  <VisXYContainer :data="data" :height="300" :xScale="xScale">
-    <VisLine :x="x" :y="y" />
+  <VisBulletLegend :items />
+  <VisXYContainer :data :height="300" :xScale>
+    <VisLine :x :y />
     <VisAxis type="x" label="Date" :numTicks="6" :tickFormat="(value) => Intl.DateTimeFormat().format(value)" />
     <VisAxis type="y" label="Temperature (celsius)" />
   </VisXYContainer>

--- a/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
+++ b/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import type { NumericAccessor } from '@unovis/ts'
   import { CurveType } from '@unovis/ts'
   import { VisXYContainer, VisAxis, VisArea, VisBulletLegend } from '@unovis/svelte'
@@ -13,11 +13,11 @@
   const yTicks = Intl.NumberFormat(navigator.language, { notation: 'compact' }).format
 </script>
 
-<VisXYContainer data={data} height={400}>
+<VisXYContainer {data} height={400}>
   <VisBulletLegend items={Object.values(countries)}/>
   <VisArea {x} {...accessors(Country.UnitedStates)} opacity={0.7} curveType={CurveType.Basis}/>
   <VisArea {x} {...accessors(Country.India)} opacity={0.7} curveType={CurveType.Basis}/>
-  <VisAxis type='x' tickFormat={xTicks}/>
-  <VisAxis type='y' tickFormat={yTicks}/>
+  <VisAxis type="x" tickFormat={xTicks}/>
+  <VisAxis type="y" tickFormat={yTicks}/>
 </VisXYContainer>
 

--- a/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.vue
+++ b/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.vue
@@ -14,11 +14,11 @@ const yTicks = Intl.NumberFormat(navigator.language, { notation: 'compact' }).fo
 </script>
 
 <template>
-  <VisXYContainer :data="data" :height="400">
+  <VisXYContainer :data :height="400">
     <VisBulletLegend :items="Object.values(countries)" />
-    <VisArea :x="x" v-bind="accessors(Country.UnitedStates)" :opacity="0.7" :curveType="CurveType.Basis" />
-    <VisArea :x="x" v-bind="accessors(Country.India)" :opacity="0.7" :curveType="CurveType.Basis" />
-    <VisAxis type='x' :tickFormat="xTicks" />
-    <VisAxis type='y' :tickFormat="yTicks" />
+    <VisArea :x v-bind="accessors(Country.UnitedStates)" :opacity="0.7" :curveType="CurveType.Basis" />
+    <VisArea :x v-bind="accessors(Country.India)" :opacity="0.7" :curveType="CurveType.Basis" />
+    <VisAxis type="x" :tickFormat="xTicks" />
+    <VisAxis type="y" :tickFormat="yTicks" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/parallel-graph/parallel-graph.svelte
+++ b/packages/shared/examples/parallel-graph/parallel-graph.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { Graph, GraphLayoutType } from '@unovis/ts'
 

--- a/packages/shared/examples/parallel-graph/parallel-graph.vue
+++ b/packages/shared/examples/parallel-graph/parallel-graph.vue
@@ -48,9 +48,9 @@ const graphConfig = computed(() => ({
 
 <template>
   <div class="chart">
-    <VisSingleContainer :data="data">
+    <VisSingleContainer :data>
       <VisGraph v-bind="graphConfig" :layoutType="GraphLayoutType.Parallel" :layoutGroupOrder="['west', mainSite, 'east']"
-        :layoutParallelNodesPerColumn="4" :panels="panels" />
+        :layoutParallelNodesPerColumn="4" :panels />
     </VisSingleContainer>
   </div>
 </template>

--- a/packages/shared/examples/patchy-line-chart/patchy-line-chart.svelte
+++ b/packages/shared/examples/patchy-line-chart/patchy-line-chart.svelte
@@ -31,10 +31,10 @@
       Show Scatter: <input type="checkbox" bind:checked={showScatter} />
     </label>
   </div>
-  <VisXYContainer data={data} xDomain={[1989, 2024]} width="100%" height="50vh">
+  <VisXYContainer {data} xDomain={[1989, 2024]} width="100%" height="50vh">
     <VisLine
       curveType={CurveType.Linear}
-      fallbackValue={fallbackValue}
+      {fallbackValue}
       interpolateMissingData={interpolation}
       x={xCallback}
       y={countriesYMemo}

--- a/packages/shared/examples/patchy-line-chart/patchy-line-chart.vue
+++ b/packages/shared/examples/patchy-line-chart/patchy-line-chart.vue
@@ -15,10 +15,10 @@
       </label>
     </div>
     <div>
-      <VisXYContainer :data="data" :xDomain="[1990, 2024]" width="100%">
+      <VisXYContainer :data :xDomain="[1990, 2024]" width="100%">
         <VisLine
           :curveType="CurveType.Linear"
-          :fallbackValue="fallbackValue"
+          :fallbackValue
           :interpolateMissingData="interpolation"
           :x="xCallback"
           :y="countriesYMemo"

--- a/packages/shared/examples/plotband-plotline/plotband-plotline.svelte
+++ b/packages/shared/examples/plotband-plotline/plotband-plotline.svelte
@@ -8,8 +8,8 @@
     <VisLine {data} x={d => d.x} y={d => d.y} />
     <VisAxis type="x" />
     <VisAxis type="y" />
-    <VisPlotband from={4} to={6} labelText='Plot band on x-axis' axis="x" labelPosition="top-inside" />
-    <VisPlotband from={1} to={3} color="rgba(34, 99, 182, 0.3)" labelText='Plot band on y-axis' labelPosition="left-inside" />
+    <VisPlotband from={4} to={6} labelText="Plot band on x-axis" axis="x" labelPosition="top-inside" />
+    <VisPlotband from={1} to={3} color="rgba(34, 99, 182, 0.3)" labelText="Plot band on y-axis" labelPosition="left-inside" />
     <VisPlotline value={6} color="rgba(7, 114, 21, 1)" labelText="Plot line on y-axis" labelPosition="top-left" />
     <VisPlotline value={10} color="rgba(220, 114, 0, 1)" axis="x" labelOrientation="vertical" labelText="Plot line on x-axis" />
   </VisXYContainer>

--- a/packages/shared/examples/plotband-plotline/plotband-plotline.vue
+++ b/packages/shared/examples/plotband-plotline/plotband-plotline.vue
@@ -5,11 +5,11 @@ import { data } from './data'
 
 <template>
   <VisXYContainer :height="600">
-    <VisLine :data="data" :x="d => d.x" :y="d => d.y" />
+    <VisLine :data :x="d => d.x" :y="d => d.y" />
     <VisAxis type="x" />
     <VisAxis type="y" />
     <VisPlotband :from="4" :to="6" labelText="Plot band on x-axis" axis="x" labelPosition="top-inside" />
-    <VisPlotband :from="1" :to="3" color="rgba(34, 99, 182, 0.3)" labelText='Plot band on y-axis' labelPosition="left-inside" />
+    <VisPlotband :from="1" :to="3" color="rgba(34, 99, 182, 0.3)" labelText="Plot band on y-axis" labelPosition="left-inside" />
     <VisPlotline :value="6" color="rgba(7, 114, 21, 1)" labelText="Plot line on y-axis" labelPosition="top-left" />
     <VisPlotline :value="10" color="rgba(220, 114, 0, 1)" axis="x" labelOrientation="vertical" labelText="Plot line on x-axis" />
   </VisXYContainer>

--- a/packages/shared/examples/range-plot/range-plot.svelte
+++ b/packages/shared/examples/range-plot/range-plot.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
 
   import { VisXYContainer, VisBulletLegend, VisTooltip, VisAxis, VisScatter, VisLine } from '@unovis/svelte'
   import { Scale, Scatter } from '@unovis/ts'
@@ -28,7 +28,7 @@
 <div>
   <VisBulletLegend items={legendItems}/>
   <VisXYContainer
-    height={height}
+    {height}
   >
     <VisLine
       data={lineData}
@@ -37,21 +37,21 @@
       color={'grey'}
     />
     <VisScatter
-      data={data}
+      {data}
       x={xMen}
-      y={y}
+      {y}
       color={'#4D8CFD'}
       size={10}
     />
     <VisScatter
-      data={data}
+      {data}
       x={xWomen}
-      y={y}
+      {y}
       color={'#FF6B7E'}
       size={10}
     />
-    <VisAxis type='x' numTicks={5} label={'Yearly Salary'} />
-    <VisAxis type='y' tickFormat={tickFormat} numTicks={data.length} gridLine={false} />
+    <VisAxis type="x" numTicks={5} label={'Yearly Salary'} />
+    <VisAxis type="y" {tickFormat} numTicks={data.length} gridLine={false} />
     <VisTooltip triggers={tooltipTriggers}/>
   </VisXYContainer>
 

--- a/packages/shared/examples/range-plot/range-plot.vue
+++ b/packages/shared/examples/range-plot/range-plot.vue
@@ -24,35 +24,33 @@ const tickFormat = (_, i: number) => data[i].occupation
 </script>
 
 <template>
-  <VisBulletLegend :items='legendItems'/>
-  <VisXYContainer
-      :height= "height"
-    >
+  <VisBulletLegend :items="legendItems"/>
+  <VisXYContainer :height>
     <VisLine
       :data="lineData"
       :x="xLine"
       :y="yLine"
-      :color="'grey'" 
+      color="grey"
     />
     <VisScatter
-      :data="data"
+      :data
       :x="xMen"
-      :y="y"
-      :color="'#4D8CFD'"
+      :y
+      color="#4D8CFD"
       :size="10"
     />
     <VisScatter
-      :color="'#FF6B7E'"
-      :data="data"
+      color="#FF6B7E"
+      :data
       :x="xWomen"
-      :y="y"
+      :y
       :size="10"
     />
-    <VisAxis type='x' :numTicks=5 :label="'Yearly Salary'"/>
-    <VisAxis type='y'
-      :tickFormat="tickFormat"
-      :numTicks='data.length' 
-      :gridLine='false'
+    <VisAxis type="x" :numTicks="5" label="Yearly Salary"/>
+    <VisAxis type="y"
+      :tickFormat
+      :numTicks="data.length"
+      :gridLine="false"
     />
     <VisTooltip :triggers="tooltipTriggers"/>
   </VisXYContainer>

--- a/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.svelte
+++ b/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Position, Scale, Scatter, colors } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisTooltip, VisBulletLegend } from '@unovis/svelte'
   import { data, DataRecord, shapes, categories, sumCategories } from './data'
@@ -25,8 +25,8 @@
 <h2>The Rise and Rise of A.I. Large Language Models</h2>
 <VisBulletLegend items={legendItems}/>
 <VisXYContainer {data} height={600} scaleByDomain={true}>
-  <VisScatter {x} {y} {color} {label} {shape} size={15} cursor='pointer'/>
-  <VisAxis type='x' label='Date Released' tickFormat={Intl.DateTimeFormat('en', { month: 'long', year: 'numeric' }).format}/>
-  <VisAxis excludeFromDomainCalculation type='y' label='Billion Parameters' tickPadding={0}/>
+  <VisScatter {x} {y} {color} {label} {shape} size={15} cursor="pointer"/>
+  <VisAxis type="x" label="Date Released" tickFormat={Intl.DateTimeFormat('en', { month: 'long', year: 'numeric' }).format}/>
+  <VisAxis excludeFromDomainCalculation type="y" label="Billion Parameters" tickPadding={0}/>
   <VisTooltip {triggers}/>
 </VisXYContainer>

--- a/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.vue
+++ b/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.vue
@@ -25,11 +25,11 @@ const triggers = {
 <template>
   <h2>The Rise and Rise of A.I. Large Language Models</h2>
   <VisBulletLegend :items="legendItems" />
-  <VisXYContainer :data="data" :height="600" :scaleByDomain="true">
-    <VisScatter :x="x" :y="y" :color="color" :shape="shape" :label="label"
+  <VisXYContainer :data :height="600" :scaleByDomain="true">
+    <VisScatter :x :y :color :shape :label
        cursor="pointer" />
     <VisAxis type="x" label="Date Released" :tickFormat="Intl.DateTimeFormat('en', {month: 'long', year: 'numeric',}).format" />
     <VisAxis excludeFromDomainCalculation type="y" label="Billion Parameters" :tickPadding="0" />
-    <VisTooltip :triggers="triggers" />
+    <VisTooltip :triggers />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.svelte
+++ b/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Position, Scale, Scatter } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisTooltip, VisBulletLegend } from '@unovis/svelte'
   import { palette, data, DataRecord } from './data'
@@ -25,8 +25,8 @@
 <h2>American College Graduates, 2010-2012</h2>
 <VisBulletLegend items={legendItems}/>
 <VisXYContainer {data} height={600} scaleByDomain={true}>
-  <VisScatter {x} {y} {color} {size} {label} labelPosition={Position.Bottom} sizeRange={[10, 50]} cursor='pointer'/>
-  <VisAxis type='x' label='Median Salary ($)' tickFormat={formatNumber}/>
-  <VisAxis excludeFromDomainCalculation type='y' label='Employment Rate' tickPadding={0}/>
+  <VisScatter {x} {y} {color} {size} {label} labelPosition={Position.Bottom} sizeRange={[10, 50]} cursor="pointer"/>
+  <VisAxis type="x" label="Median Salary ($)" tickFormat={formatNumber}/>
+  <VisAxis excludeFromDomainCalculation type="y" label="Employment Rate" tickPadding={0}/>
   <VisTooltip {triggers}/>
 </VisXYContainer>

--- a/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.vue
+++ b/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.vue
@@ -25,11 +25,11 @@ const triggers = {
 <template>
   <h2>American College Graduates, 2010-2012</h2>
   <VisBulletLegend :items="legendItems" />
-  <VisXYContainer :data="data" :height="600" :scaleByDomain="true">
-    <VisScatter :x="x" :y="y" :color="color" :size="size" :label="label" :labelPosition="Position.Bottom"
+  <VisXYContainer :data :height="600" :scaleByDomain="true">
+    <VisScatter :x :y :color :size :label :labelPosition="Position.Bottom"
       :sizeRange="[10, 50]" cursor="pointer" />
-    <VisAxis type='x' label='Median Salary ($)' :tickFormat="formatNumber" />
-    <VisAxis excludeFromDomainCalculation type='y' label='Employment Rate' :tickPadding="0" />
-    <VisTooltip :triggers="triggers" />
+    <VisAxis type="x" label="Median Salary ($)" :tickFormat="formatNumber" />
+    <VisAxis excludeFromDomainCalculation type="y" label="Employment Rate" :tickPadding="0" />
+    <VisTooltip :triggers />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.svelte
+++ b/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Area } from '@unovis/ts'
   import { VisXYContainer, VisBulletLegend, VisAxis, VisArea } from '@unovis/svelte'
   import { data, countries, FoodExportData, bulletLegends } from './data'
@@ -20,8 +20,8 @@
 <VisXYContainer {data} height={500}>
   <VisBulletLegend items={Object.values(bulletLegends)}/>
   <VisArea {x} {y} {attributes}/>
-  <VisAxis type='x' label='Year' numTicks={10} gridLine={false} domainLine={false}/>
-  <VisAxis type='y' label='Food Exports(% of merchandise exports)' numTicks={10}/>
+  <VisAxis type="x" label="Year" numTicks={10} gridLine={false} domainLine={false}/>
+  <VisAxis type="y" label="Food Exports(% of merchandise exports)" numTicks={10}/>
 </VisXYContainer>
 
 <style>

--- a/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.vue
+++ b/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.vue
@@ -19,10 +19,10 @@ const attributes = {
 </script>
 
 <template>
-  <VisXYContainer :data="data" :height="500">
+  <VisXYContainer :data :height="500">
     <VisBulletLegend :items="Object.values(bulletLegends)" />
-    <VisArea :x="x" :y="y" :attributes="attributes"/>
-    <VisAxis type='x' label='Year' :numTicks="10" :gridLine="false" :domainLine="false" />
-    <VisAxis type='y' label='Food Exports(% of merchandise exports)' :numTicks="10" />
+    <VisArea :x :y :attributes/>
+    <VisAxis type="x" label="Year" :numTicks="10" :gridLine="false" :domainLine="false" />
+    <VisAxis type="y" label="Food Exports(% of merchandise exports)" :numTicks="10" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/stacked-area-chart/stacked-area-chart.svelte
+++ b/packages/shared/examples/stacked-area-chart/stacked-area-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisXYContainer, VisAxis, VisArea, VisXYLabels } from '@unovis/svelte'
   import { data, formats, DataRecord, getLabels } from './data'
 
@@ -17,7 +17,7 @@
 <VisXYContainer {data} height={500}>
   <VisXYLabels {...labelProps} clusterBackgroundColor="none" clusterLabel={() => ''}/>
   <VisArea {x} {y}/>
-  <VisAxis type='x' label='Year' numTicks={10} gridLine={false} domainLine={false}/>
-  <VisAxis type='y' label='Revenue (USD, billions)' numTicks={10}/>
+  <VisAxis type="x" label="Year" numTicks={10} gridLine={false} domainLine={false}/>
+  <VisAxis type="y" label="Revenue (USD, billions)" numTicks={10}/>
 </VisXYContainer>
 

--- a/packages/shared/examples/stacked-area-chart/stacked-area-chart.vue
+++ b/packages/shared/examples/stacked-area-chart/stacked-area-chart.vue
@@ -15,10 +15,10 @@ const labelProps = {
 </script>
 
 <template>
-  <VisXYContainer :data="data" :height="500">
+  <VisXYContainer :data :height="500">
     <VisXYLabels v-bind="labelProps" clusterBackgroundColor="none" :clusterLabel="() => ''" />
-    <VisArea :x="x" :y="y" />
-    <VisAxis type='x' label='Year' :numTicks="10" :gridLine="false" :domainLine="false" />
-    <VisAxis type='y' label='Revenue (USD, billions)' :numTicks="10" />
+    <VisArea :x :y />
+    <VisAxis type="x" label="Year" :numTicks="10" :gridLine="false" :domainLine="false" />
+    <VisAxis type="y" label="Revenue (USD, billions)" :numTicks="10" />
   </VisXYContainer>
 </template>

--- a/packages/shared/examples/step-area-chart/step-area-chart.svelte
+++ b/packages/shared/examples/step-area-chart/step-area-chart.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { BulletLegendItemInterface } from '@unovis/ts'
   import { VisXYContainer, VisArea, VisAxis, VisBulletLegend } from '@unovis/svelte'
   import { candidates, data, DataRecord } from './data'
@@ -17,16 +17,16 @@
 </script>
 
 <step-area-chart>
-  <div class='panel'>
+  <div class="panel">
     <VisBulletLegend items={Object.keys(data[0][curr]).map(d => ({ name: d }))}/>
-    <div class='legendSwitch'>
-      <VisBulletLegend labelClassName='legendLabel' {items} {onLegendItemClick}/>
+    <div class="legendSwitch">
+      <VisBulletLegend labelClassName="legendLabel" {items} {onLegendItemClick}/>
     </div>
   </div>
-  <VisXYContainer data={data} height={400} yDomain={[0, 42]}>
-    <VisArea {x} {y} curveType='stepAfter'/>
-    <VisAxis type='x' label='Year'/>
-    <VisAxis type='y' label='Number of Mentions'/>
+  <VisXYContainer {data} height={400} yDomain={[0, 42]}>
+    <VisArea {x} {y} curveType="stepAfter"/>
+    <VisAxis type="x" label="Year"/>
+    <VisAxis type="y" label="Number of Mentions"/>
   </VisXYContainer>
 </step-area-chart>
 

--- a/packages/shared/examples/step-area-chart/step-area-chart.vue
+++ b/packages/shared/examples/step-area-chart/step-area-chart.vue
@@ -19,16 +19,16 @@ const items = computed(() => candidates.map(c => ({ ...c, inactive: curr.value !
 
 <template>
   <div class="step-area-chart">
-    <div class='panel'>
+    <div class="panel">
       <VisBulletLegend :items="Object.keys(data[0][curr]).map(d => ({ name: d }))" />
-      <div class='legendSwitch'>
-        <VisBulletLegend labelClassName='legendLabel' :items="items" @legend-item-click="onLegendItemClick" />
+      <div class="legendSwitch">
+        <VisBulletLegend labelClassName="legendLabel" :items @legend-item-click="onLegendItemClick" />
       </div>
     </div>
-    <VisXYContainer :data="data" :height="400" :yDomain="[0, 42]">
-      <VisArea :x="x" :y="y" curveType='stepAfter' />
-      <VisAxis type='x' label='Year' />
-      <VisAxis type='y' label='Number of Mentions' />
+    <VisXYContainer :data :height="400" :yDomain="[0, 42]">
+      <VisArea :x :y curveType="stepAfter" />
+      <VisAxis type="x" label="Year" />
+      <VisAxis type="y" label="Number of Mentions" />
     </VisXYContainer>
   </div>
 </template>

--- a/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
+++ b/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisNestedDonut } from '@unovis/svelte'
   import { NestedDonutSegment } from '@unovis/ts'
   import { colors, data, Datum } from './data'
@@ -13,10 +13,10 @@
   const segmentColor = (d: NestedDonutSegment<Datum>) => colors.get(d.data.key)
 </script>
 
-<div class='sunburst'>
-  <VisSingleContainer data={data} >
+<div class="sunburst">
+  <VisSingleContainer {data} >
     <VisNestedDonut
-      direction='outwards'
+      direction="outwards"
       hideOverflowingSegmentLabels={false}
       layerSettings={{ width: '6vmin' }}
       {layers}

--- a/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.vue
+++ b/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.vue
@@ -14,9 +14,9 @@ const segmentColor = (d: NestedDonutSegment<Datum>) => colors.get(d.data.key)
 </script>
 
 <template>
-  <VisSingleContainer :data="data" class="sunburst">
+  <VisSingleContainer :data class="sunburst">
     <VisNestedDonut direction="outwards" :hideOverflowingSegmentLabels="false" :layerSettings="{ width: '6vmin' }"
-      :layers="layers" :segmentColor="segmentColor" />
+      :layers :segmentColor />
   </VisSingleContainer>
 </template>
 

--- a/packages/shared/examples/synced-crosshairs/synced-crosshairs.vue
+++ b/packages/shared/examples/synced-crosshairs/synced-crosshairs.vue
@@ -37,7 +37,7 @@ const tooltipContainer = typeof document !== 'undefined' ? document.body : undef
       />
     </div>
 
-    <VisXYContainer :data="data" :margin="{ top: 5, left: 5 }">
+    <VisXYContainer :data :margin="{ top: 5, left: 5 }">
       <VisArea :x="(d: XYDataRecord) => d.x" :y="accessors" />
       <VisAxis type="x" />
       <VisAxis type="y" />
@@ -47,7 +47,7 @@ const tooltipContainer = typeof document !== 'undefined' ? document.body : undef
 
     <VisXYContainer
       y-direction="south"
-      :data="data"
+      :data
       :margin="{ top: 5, left: 5 }"
       :x-domain="[0, 100]"
     >

--- a/packages/shared/examples/topojson-map/topojson-map.svelte
+++ b/packages/shared/examples/topojson-map/topojson-map.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { Orientation, Scale, TopoJSONMap } from '@unovis/ts'
   import { WorldMapTopoJSON } from '@unovis/ts/maps'
   import { VisSingleContainer, VisTopoJSONMap, VisTooltip, VisAxis, VisXYContainer, VisStackedBar } from '@unovis/svelte'
@@ -31,7 +31,7 @@
 
 <div class="topojson-map">
   <!-- year slider -->
-  <header class='year-slider'>
+  <header class="year-slider">
     <h2>Life expectancy by Country, <em>{year}</em></h2>
     <input type="range" bind:value={year} min={yearRange[0]} max={yearRange[1]}/>
   </header>
@@ -46,7 +46,7 @@
     <VisAxis
       type="x"
       position="top"
-      label='Life Expectancy (years)'
+      label="Life Expectancy (years)"
       numTicks={gradientSteps.length / 5}
       {tickFormat}
     />

--- a/packages/shared/examples/topojson-map/topojson-map.vue
+++ b/packages/shared/examples/topojson-map/topojson-map.vue
@@ -32,7 +32,7 @@ const gradientSteps = Array(range).fill(1)
 <template>
   <div class="topojson-map">
     <!-- year slider -->
-    <header class='year-slider'>
+    <header class="year-slider">
       <h2>Life expectancy by Country, <em>{{ year }}</em></h2>
       <input type="range" v-model="year" :min="yearRange[0]" :max="yearRange[1]" />
     </header>
@@ -43,8 +43,8 @@ const gradientSteps = Array(range).fill(1)
     </VisSingleContainer>
     <!-- gradient legend-->
     <VisXYContainer :data="[{}]" :height="70" :width="500">
-      <VisStackedBar :x="0" :y="gradientSteps" :color="color" :orientation="Orientation.Horizontal" />
-      <VisAxis type="x" position="top" :numTicks="range / 5" label='Life Expectancy (years)' />
+      <VisStackedBar :x="0" :y="gradientSteps" :color :orientation="Orientation.Horizontal" />
+      <VisAxis type="x" position="top" :numTicks="range / 5" label="Life Expectancy (years)" />
     </VisXYContainer>
   </div>
 </template>

--- a/packages/shared/examples/treemap/treemap.svelte
+++ b/packages/shared/examples/treemap/treemap.svelte
@@ -1,4 +1,4 @@
-<script lang='ts'>
+<script lang="ts">
   import { VisSingleContainer, VisTreemap, VisBulletLegend, VisTooltip } from '@unovis/svelte'
   import { data, DataRecord } from './data'
   import { colors, Position, Treemap } from '@unovis/ts'
@@ -31,7 +31,7 @@
 </script>
 
 <VisBulletLegend items={legendItems} />
-<VisSingleContainer height={400} data={data}>
+<VisSingleContainer height={400} {data}>
   <VisTooltip
     horizontalPlacement={Position.Center}
     triggers={{ [Treemap.selectors.tile]: getTooltipContent }}

--- a/packages/shared/examples/treemap/treemap.vue
+++ b/packages/shared/examples/treemap/treemap.vue
@@ -39,7 +39,7 @@ function getTooltipContent(node: any): string {
       :triggers="{ [Treemap.selectors.tile]: getTooltipContent }"
     />
     <VisTreemap
-      :data="data"
+      :data
       :numberFormat="populationFormat"
       :value="(d: DataRecord) => d.billions"
       :layers="[(d: DataRecord) => d.category, (d: DataRecord) => d.name]"


### PR DESCRIPTION
## Summary

Two-commit cleanup of the shared gallery examples.

### 1. Fix: React.CSSProperties leak in dual-axis chart (Vue + Svelte)
- **Vue:** `import type { CSSProperties } from 'vue'` instead of leaking the React-only `React.CSSProperties` type.
- **Svelte:** drop the dead `React.CSSProperties` const (the second container uses `class={'chartContainer'}` + a CSS block, so the const was unused).
- **Svelte:** restore missing `type="y"` / `position="right"` / `tickFormat` on the second axis.

### 2. Stylistic sweep across Vue/Svelte gallery examples
- Adopt Vue 3.4+ same-name shorthand (`:prop="prop"` → `:prop`).
- Quote string-literal props directly (`:label="'X'"` → `label="X"`).
- Standardize on double quotes for HTML attribute values.
- Same spirit applied to Svelte: same-name shorthand (`prop={prop}` → `{prop}`) and double quotes.