### PR TITLE
Component | TopoJSON: Make sure node renders on top of flow links

### DIFF
--- a/packages/ts/src/components/topojson-map/index.ts
+++ b/packages/ts/src/components/topojson-map/index.ts
@@ -119,13 +119,14 @@ export class TopoJSONMap<
   private _areaLabelsGroup = this.g.append('g').attr('class', s.areaLabel)
   private _linksGroup = this.g.append('g').attr('class', s.links)
   private _clusterBackgroundGroup = this.g.append('g').attr('class', s.clusterBackground)
+  private _flowParticlesGroup = this.g.append('g').attr('class', s.flowParticles)
+  // Points after links + flow groups so map nodes paint above link arcs and flow particles
   private _pointsGroup = this.g.append('g').attr('class', s.points)
   private _pointSelectionRing = this._pointsGroup.append('g').attr('class', s.pointSelectionRing)
     .call(sel => sel.append('path').attr('class', s.pointSelection))
 
-  private _selectedPoint: TopoJSONMapPoint<PointDatum> | null = null
-  private _flowParticlesGroup = this.g.append('g').attr('class', s.flowParticles)
   private _sourcePointsGroup = this.g.append('g').attr('class', s.sourcePoints)
+  private _selectedPoint: TopoJSONMapPoint<PointDatum> | null = null
   private _flowParticles: FlowParticle[] = []
   private _sourcePoints: { x: number; y: number; radius: number; color: string; flowData: LinkDatum }[] = []
   private _animationId: number | null = null


### PR DESCRIPTION
Change the rendering order for flow topojson:
links -> target node -> source node
Issue:
Links renders on top of target node.

https://github.com/user-attachments/assets/b685b861-c336-4ef1-ae33-7c030065929f

Fix:
<img width="1207" height="790" alt="Screenshot 2026-05-07 at 3 19 41 PM" src="https://github.com/user-attachments/assets/01a7b371-d518-4229-869d-4c09daf61a89" />
