### PR TITLE
Component | Line: Call `_renderLines` even when `config.line` is `false`

### DIFF
--- a/packages/dev/src/examples/xy-components/area/line-area/index.tsx
+++ b/packages/dev/src/examples/xy-components/area/line-area/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import { VisXYContainer, VisArea, VisAxis, VisTooltip, VisCrosshair } from '@unovis/react'
 
 import { XYDataRecord, generateXYDataRecords } from '@src/utils/data'
@@ -8,6 +8,9 @@ export const title = 'Line Area Chart'
 export const subTitle = 'Generated Data'
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
   const tooltipRef = useRef(null)
+  const fullData = useRef(generateXYDataRecords(15)).current
+  const [hasData, setHasData] = useState(true)
+
   const accessors = [
     (d: XYDataRecord) => d.y,
     (d: XYDataRecord) => d.y1,
@@ -15,20 +18,25 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
   ]
 
   return (
-    <VisXYContainer<XYDataRecord> data={generateXYDataRecords(15)} margin={{ top: 5, left: 5 }}>
-      <VisArea
-        x={d => d.x}
-        y={accessors}
-        duration={props.duration}
-        line={true}
-        lineWidth={2}
-        lineColor={['#1F5BC7', '#CB3B54', '#C48900']}
-        lineDashArray={[4, 4]}
-      />
-      <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
-      <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
-      <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
-      <VisTooltip ref={tooltipRef} container={document.body}/>
-    </VisXYContainer>
+    <div>
+      <button onClick={() => setHasData(prev => !prev)} style={{ marginBottom: 8 }}>
+        {hasData ? 'Clear data' : 'Restore data'}
+      </button>
+      <VisXYContainer<XYDataRecord> data={hasData ? fullData : []} margin={{ top: 5, left: 5 }}>
+        <VisArea
+          x={d => d.x}
+          y={accessors}
+          duration={props.duration}
+          line={hasData}
+          lineWidth={2}
+          lineColor={['#1F5BC7', '#CB3B54', '#C48900']}
+          lineDashArray={[4, 4]}
+        />
+        <VisAxis type='x' numTicks={3} tickFormat={(x: number) => `${x}ms`} duration={props.duration}/>
+        <VisAxis type='y' tickFormat={(y: number) => `${y}bps`} duration={props.duration}/>
+        <VisCrosshair template={(d: XYDataRecord) => `${d.x}`} />
+        <VisTooltip ref={tooltipRef} container={document.body}/>
+      </VisXYContainer>
+    </div>
   )
 }

--- a/packages/ts/src/components/area/index.ts
+++ b/packages/ts/src/components/area/index.ts
@@ -162,9 +162,7 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
       .style('opacity', 0)
       .remove()
 
-    if (config.line) {
-      this._renderLines(duration, stackedData)
-    }
+    this._renderLines(duration, config.line ? stackedData : [])
   }
 
   _renderLines (duration: number, stackedData: AreaDatum[][]): void {


### PR DESCRIPTION
Currently if you switch `config.line` from `true` to `false`, the phantom lines remain visible even when you update the data.
This PR fixes that

### Before
https://github.com/user-attachments/assets/1c9a4469-5c4f-4597-8a66-7dfcde7060e1

### After
https://github.com/user-attachments/assets/c1b7f8fc-7a91-497d-9354-ea838c1b8ae0

