### PR TITLE
Component | Timeline: Disable `tolerance` in bleed because we now have `config.rowLabelMargin`

### DIFF
--- a/packages/dev/src/examples/xy-components/timeline/timeline-label-events/index.tsx
+++ b/packages/dev/src/examples/xy-components/timeline/timeline-label-events/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { VisXYContainer, VisTimeline, VisAxis } from '@unovis/react'
-import { Timeline, TimelineRowLabel } from '@unovis/ts'
+import { Timeline } from '@unovis/ts'
 
 import { TimeDataRecord, generateTimeSeries } from '@src/utils/data'
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
@@ -13,10 +13,10 @@ const rows = ['Long Row', 'Empty Row 1', 'Empty Row 2']
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
   const [hoveredLabel, setHoveredLabel] = useState<string | null>(null)
 
-  const data = generateTimeSeries(15, 3, 10).map((d, i) => ({
+  const data = useMemo(() => generateTimeSeries(15, 3, 10).map((d, i) => ({
     ...d,
     type: rows[i % rows.length],
-  }))
+  })), [])
 
   const events = {
     [Timeline.selectors.labelBackground]: {
@@ -35,8 +35,8 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
         '--vis-timeline-label-pointer-events': 'none',
       }}>
       <VisTimeline
-        lineRow={(d: TimeDataRecord) => d.type as string}
-        x={(d: TimeDataRecord) => d.timestamp}
+        lineRow={useCallback((d: TimeDataRecord) => d.type as string, [])}
+        x={useCallback((d: TimeDataRecord) => d.timestamp, [])}
         rowHeight={50}
         showRowLabels
         duration={props.duration}

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -152,7 +152,7 @@ export const TimelineDefaultConfig: TimelineConfigInterface<unknown> = {
   rowMaxLabelWidth: undefined,
   rowLabelTextAlign: TextAlign.Right,
   rowLabelTrimMode: TrimMode.Middle,
-  rowLabelMargin: [0, 5],
+  rowLabelMargin: [0, 6],
   rowFillEmptySpace: true,
 
   // Arrows

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -135,9 +135,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
     if (config.showRowLabels ?? config.showLabels) {
       const [marginLeft, marginRight] = this._getRowLabelMargin()
       if (config.rowLabelWidth ?? config.labelWidth) {
-        // We add a little of extra space to take into account the fact that `trimSVGText` is not always precise
-        const tolerance = 1.1
-        this._labelWidth = tolerance * (config.rowLabelWidth ?? config.labelWidth) + marginLeft + marginRight
+        this._labelWidth = (config.rowLabelWidth ?? config.labelWidth) + marginLeft + marginRight
       } else {
         const labels = rowLabels.map(l => this._labelsGroup.append('text')
           .attr('class', s.label)


### PR DESCRIPTION
Current tolerance coefficient in `bleed` produces wrong label spacing. This PR removes the tolerance logic completely because we've recently added `config.rowLabelMargin` that allows you to fine-tune the spacing if required.

### Before
<img width="1128" height="244" alt="image" src="https://github.com/user-attachments/assets/4d00f0e8-42fc-47c6-b063-649d7948ce09" />

### Afger
<img width="1080" height="260" alt="image" src="https://github.com/user-attachments/assets/fc7b1375-87fe-419b-99e2-9b9a6ab7aeed" />
