### PR TITLE
Component | StackedBar & Scatter: Preserve element index for events

### DIFF
--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -237,6 +237,19 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
     })
   }
 
+  // The D3 datum bound to each point is a `ScatterPoint<Datum>` wrapper, and the
+  // DOM-derived index no longer matches the original row index: off-screen
+  // points and points with missing values are filtered out, and points from
+  // all y-accessor groups share the same selection. We restore the original
+  // row index from `_point.pointIndex` while leaving the datum wrapper intact.
+  // Todo: This can be revisited in Unovis 2.0, but the migration guide should contain a note about it.
+  protected _mapEventDatum (d: ScatterPoint<Datum>): { datum: ScatterPoint<Datum>; index: number } {
+    return {
+      datum: d,
+      index: d._point.pointIndex,
+    }
+  }
+
   private _onPointMouseOver (d: ScatterPoint<Datum>, event: MouseEvent): void {
     const point = select(event.target as SVGGElement)
     const pointNode = point.node() as ScatterPointGroupNode | null

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -271,16 +271,17 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
   }
 
   // After performance optimizations in https://github.com/f5/unovis/pull/708
-  // there's a breaking change in the event data structure.
-  // This method is used to map the event data to the original data structure.
+  // there's a breaking change in the event data structure: the d3 datum bound
+  // to each bar is now a `StackedBarDataRecord` wrapper, and the DOM-derived
+  // index no longer matches the original row index (zero-height segments are
+  // filtered out, and bars from all groups share the same selection).
+  // This method maps both back to the pre-#708 contract.
   // Todo: This can be removed in Unovis 2.0, but the migration guide should contain a note about it.
-  protected _mapEventDatum (d: StackedBarDataRecord<Datum>): Datum {
-    const eventDatum = {
-      ...d,
-      ...d.datum,
+  protected _mapEventDatum (d: StackedBarDataRecord<Datum>): { datum: Datum; index: number } {
+    return {
+      datum: { ...d, ...d.datum },
+      index: d.index,
     }
-
-    return eventDatum
   }
 
   getValueScaleExtent (scaleByVisibleData: boolean): number[] {

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -142,7 +142,7 @@ export class ComponentCore<
 
   // Sometimes we don't want to pass the original data and/or index to the event handler.
   // This method can be overridden by components to implement a custom mapping.
-  // See Stacked Bar for an example.
+  // See Stacked Bar and Scatter for examples.
   protected _mapEventDatum (datum: unknown, index: number): { datum: unknown; index: number } {
     return { datum, index }
   }

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -140,11 +140,11 @@ export class ComponentCore<
     this._bindEvents(this.config.events, '.user')
   }
 
-  // Sometimes we don't want to pass the original data to the event handler.
+  // Sometimes we don't want to pass the original data and/or index to the event handler.
   // This method can be overridden by components to implement a custom mapping.
   // See Stacked Bar for an example.
-  protected _mapEventDatum (datum: unknown): unknown {
-    return datum
+  protected _mapEventDatum (datum: unknown, index: number): { datum: unknown; index: number } {
+    return { datum, index }
   }
 
   private _bindEvents (events = this.events, suffix = ''): void {
@@ -156,8 +156,8 @@ export class ComponentCore<
           const els = selection.nodes()
           const i = els.indexOf(event.currentTarget as SVGGElement | HTMLElement)
           const eventFunction = events[className][eventType as VisEventType]
-          const datum = this._mapEventDatum(d)
-          return eventFunction?.(datum, event, i, els)
+          const { datum, index } = this._mapEventDatum(d, i)
+          return eventFunction?.(datum, event, index, els)
         })
       })
     })


### PR DESCRIPTION
[#708](https://github.com/f5/unovis/issues/708) introduced a breaking change — the d3 datum bound to each bar became a StackedBarDataRecord wrapper, and the index passed to event handlers stopped matching the original row index because zero-height segments are filtered out and bars from all groups share one selection, so els.indexOf(currentTarget) no longer corresponds to the data row.

We added `_mapEventDatum` to restore the original Datum, but had no way to also fix up the index.

This PR extends `_mapEventDatum` to return `{ datum, index }` and updates StackedBar's and Scatter's override to return the original row index, restoring the pre-[#708](https://github.com/f5/unovis/issues/708) behavior.