### PR TITLE
Dev | Examples: Tidy up imports in raster/treemap/scatter examples

### DIFF
--- a/packages/dev/src/examples/maps/leaflet/leaflet-map-raster/index.tsx
+++ b/packages/dev/src/examples/maps/leaflet/leaflet-map-raster/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { VisLeafletMap } from '@unovis/react'
-import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
 
 export const title = 'Raster Leaflet Map'
 export const subTitle = 'Raster renderer with PNG'

--- a/packages/dev/src/examples/misc/treemap/search/index.tsx
+++ b/packages/dev/src/examples/misc/treemap/search/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { format } from 'd3-format'
 import { VisSingleContainer, VisTooltip, VisTreemap } from '@unovis/react'
-import { Position, Treemap, TreemapNode } from '@unovis/ts'
-import { colors } from '@unovis/ts/styles/colors'
+import { colors, Position, Treemap, TreemapNode } from '@unovis/ts'
 import s from './styles.module.css'
 
 export const title = 'Treemap: Search'

--- a/packages/dev/src/examples/xy-components/scatter/scatter-with-line/index.tsx
+++ b/packages/dev/src/examples/xy-components/scatter/scatter-with-line/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { VisXYContainer, VisScatter, VisAxis, VisLine } from '@unovis/react'
+import type { WithOptional } from '@unovis/ts'
 
 import { XYDataRecord } from '@src/utils/data'
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
-import type { WithOptional } from '@unovis/ts/lib/types/misc'
 
 export const title = 'Scatter with Line'
 export const subTitle = 'And undefined segments'

--- a/packages/ts/src/types.ts
+++ b/packages/ts/src/types.ts
@@ -13,6 +13,7 @@ export * from 'types/spacing'
 export * from 'types/graph'
 export * from 'types/data'
 export * from 'types/direction'
+export * from 'types/misc'
 
 // Component Types
 export * from 'core/component/types'


### PR DESCRIPTION
- **`@unovis/ts`**: add `export * from 'types/misc'` to the public types barrel — exposes `WithOptional` (already used internally by Crosshair/Timeline configs).
- **`leaflet-map-raster`**: drop unused `ExampleViewerDurationProps` import.
- **`treemap/search`**: import `colors` from `@unovis/ts` main entry instead of the deep `@unovis/ts/styles/colors` path.
- **`scatter-with-line`**: replace broken `@unovis/ts/lib/types/misc` import with `@unovis/ts` (now public via the barrel change above).