### PR TITLE
Vue | Lint: Fix `__dirname` ESM error in eslint.config.js

### DIFF
--- a/packages/vue/eslint.config.js
+++ b/packages/vue/eslint.config.js
@@ -1,4 +1,8 @@
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import antfu from '@antfu/eslint-config'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default antfu({
   ignorePatterns: ['dist/*'],


### PR DESCRIPTION
`packages/vue/eslint.config.js` referenced `__dirname`, which isn't defined when the file is loaded as ESM (the package has `"type": "module"`). This crashed `eslint .` immediately with `ReferenceError: __dirname is not defined in ES module scope`.

Restored a `__dirname` constant via `fileURLToPath(import.meta.url)` + `path.dirname` (Node 18+ compatible). Same behavior as before; lint now actually runs.