### PR TITLE
Vue | XYContainer: Defer chart creation until child slots register

### DIFF
--- a/packages/vue/src/containers/xy-container/index.vue
+++ b/packages/vue/src/containers/xy-container/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts" generic="T">
 import { XYContainer, XYComponentCore, XYContainerConfigInterface, Tooltip, Crosshair, Axis, Annotations } from '@unovis/ts'
-import { onMounted, onUnmounted, ref, provide, watch, toRefs, reactive, watchEffect, toRaw } from 'vue'
+import { onUnmounted, ref, provide, watch, toRefs, reactive, watchEffect, toRaw } from 'vue'
 import { componentAccessorKey, tooltipAccessorKey, axisAccessorKey, crosshairAccessorKey, annotationsAccessorKey } from "../../utils/context"
 import { useForwardProps } from "../../utils/props"
 
@@ -8,7 +8,7 @@ const props = defineProps<XYContainerConfigInterface<T> & { data?: T[] }>()
 const { data } = toRefs(props)
 const parsedProps = useForwardProps(props)
 
-const chart = ref<XYContainer<T> | undefined>()
+const chart = ref<XYContainer<T>>()
 const config = reactive({
   components: [],
   annotations: undefined,
@@ -19,20 +19,24 @@ const config = reactive({
 }) as XYContainerConfigInterface<T>
 const elRef = ref<HTMLDivElement>()
 
-watch(data, () => {
-  if (chart.value) {
-    chart.value.setData(data.value, true)
-  }
-})
+const initChart = () => {
+  if (chart.value || !elRef.value) return
+  // config holds only child-registration slots — if all are empty, no slot has registered yet
+  const hasContent = Object.values(config).some(v => Array.isArray(v) ? v.length : v)
+  if (!hasContent) return
+  chart.value = new XYContainer(elRef.value, { ...toRaw(config) }, data.value)
+}
 
 watchEffect(() => {
-  // watch deep changes in components config
+  initChart()
+  // touch deep changes in components config to track them
   const t = config.components.map(i => i.config)
   chart.value?.updateContainer({ ...toRaw(parsedProps.value), ...toRaw(config) })
 })
 
-onMounted(() => {
-  if (elRef.value) chart.value = new XYContainer(elRef.value, { ...toRaw(config) }, data.value)
+watch(data, () => {
+  if (chart.value) chart.value.setData(data.value, true)
+  else initChart()
 })
 
 onUnmounted(() => chart.value?.destroy())


### PR DESCRIPTION
Follow-up to #773. With `useForwardProps` now properly reactive, the timing of the watchEffect in `XYContainer.vue` becomes visible: `chart` is constructed eagerly in `onMounted`, but children's `nextTick` callbacks haven't run yet, so the watchEffect's first non-no-op fire calls `updateContainer({})` with an empty config. The second `requestAnimationFrame` normally cancels the first, but the empty trip through the core is wasteful and timing-fragile — see [#633 (crystalfp)](https://github.com/f5/unovis/issues/633#issuecomment-2867013353), where a window resize is needed to recover.

This PR mirrors `SingleContainer`'s lazy-init pattern: hold `chart` until at least one accessor slot is populated, then construct it inside the watchEffect.

## Behaviour change

- Old: `onMounted` builds an `XYContainer` with `{}`; watchEffect fires with empty config and schedules an empty render; second fire (after children's nextTicks) does the real one.
- New: watchEffect short-circuits while `config` has no registered slots. As soon as a child (line/area/bar/axis/crosshair/tooltip/annotations) registers, `initChart` constructs the chart with the populated config, then the same watchEffect call forwards `parsedProps` via `updateContainer`.

Console trace before/after (instrumented locally), with crystalfp's repro:

**Before**
```
[watchEffect] chart=false  components=0  xAxis=false  yAxis=false   ← setup
[watchEffect] chart=true   components=0  xAxis=false  yAxis=false   ← onMounted, empty config → updateContainer({})
[watchEffect] chart=true   components=1  xAxis=true   yAxis=true    ← children registered → real updateContainer
```

**After**
```
[watchEffect] chart=true   components=1  xAxis=true   yAxis=true    ← only fire that touches the core
```