### PR TITLE
Timeline: Get rid of deprecated properties in the docs and gallery

### DIFF
--- a/packages/shared/examples/basic-timeline/basic-timeline-solid.tsx
+++ b/packages/shared/examples/basic-timeline/basic-timeline-solid.tsx
@@ -18,8 +18,8 @@ const BasicTimeline = (): JSX.Element => {
   }
 
   const x = (d: DataRecord) => d.startDate
-  const length = (d: DataRecord) => d.endDate - d.startDate
-  const type = (d: DataRecord) => d.name
+  const lineDuration = (d: DataRecord) => d.endDate - d.startDate
+  const lineRow = (d: DataRecord) => d.name
   const color = (d: DataRecord) => colorMap[d.type]
 
   const legendItems = Object.keys(ProductType).map((name, i) => ({
@@ -34,11 +34,11 @@ const BasicTimeline = (): JSX.Element => {
       <VisBulletLegend items={legendItems} />
       <VisTimeline
         x={x}
-        length={length}
-        type={type}
+        lineDuration={lineDuration}
+        lineRow={lineRow}
         color={color}
-        labelWidth={labelWidth}
-        showLabels
+        rowLabelWidth={labelWidth}
+        showRowLabels
       />
       <VisTooltip triggers={triggers} />
       <VisAxis type='x' numTicks={10} tickFormat={dateFormatter} />

--- a/packages/shared/examples/basic-timeline/basic-timeline.component.html
+++ b/packages/shared/examples/basic-timeline/basic-timeline.component.html
@@ -3,11 +3,11 @@
     <vis-bullet-legend [items]="legendItems"></vis-bullet-legend>
     <vis-timeline
         [x]="x"
-        [length]="length"
-        [type]="type"
+        [lineDuration]="lineDuration"
+        [lineRow]="lineRow"
         [color]="color"
-        [labelWidth]="labelWidth"
-        [showLabels]="true">
+        [rowLabelWidth]="labelWidth"
+        [showRowLabels]="true">
     </vis-timeline>
     <vis-tooltip [triggers]="triggers"></vis-tooltip>
     <vis-axis type="x" [tickFormat]="dateFormatter" [numTicks]="10"></vis-axis>

--- a/packages/shared/examples/basic-timeline/basic-timeline.component.ts
+++ b/packages/shared/examples/basic-timeline/basic-timeline.component.ts
@@ -12,8 +12,8 @@ export class BasicTimelineComponent {
 
   data: DataRecord[] = data
   x = (d: DataRecord): number => d.startDate
-  length = (d: DataRecord): number => d.endDate - d.startDate
-  type = (d: DataRecord): string => d.name
+  lineDuration = (d: DataRecord): number => d.endDate - d.startDate
+  lineRow = (d: DataRecord): string => d.name
   color = (d: DataRecord): string => colorMap[d.type]
 
   legendItems = Object.keys(ProductType).map((name, i) => ({ name, color: colorMap[name] }))

--- a/packages/shared/examples/basic-timeline/basic-timeline.svelte
+++ b/packages/shared/examples/basic-timeline/basic-timeline.svelte
@@ -16,8 +16,8 @@
   }
 
   const x = (d: DataRecord) => d.startDate
-  const length = (d: DataRecord) => d.endDate - d.startDate
-  const type = (d: DataRecord) => d.name
+  const lineDuration = (d: DataRecord) => d.endDate - d.startDate
+  const lineRow = (d: DataRecord) => d.name
   const color = (d: DataRecord) => colorMap[d.type]
 
   const legendItems = Object.keys(ProductType).map((name, i) => ({ name, color: colorMap[name] }))
@@ -27,7 +27,7 @@
 <VisXYContainer {data} height={500}>
   <h3>A Timeline of Abandoned Google Products, 1997 - 2022</h3>
   <VisBulletLegend items={legendItems}/>
-  <VisTimeline {x} {length} {type} {color} {labelWidth} showLabels={true}/>
+  <VisTimeline {x} {lineDuration} {lineRow} {color} rowLabelWidth={labelWidth} showRowLabels={true}/>
   <VisTooltip {triggers}/>
   <VisAxis type="x" tickFormat={dateFormatter} numTicks={10}/>
 </VisXYContainer>

--- a/packages/shared/examples/basic-timeline/basic-timeline.ts
+++ b/packages/shared/examples/basic-timeline/basic-timeline.ts
@@ -13,11 +13,11 @@ const legend = new BulletLegend(container, {
 
 const timeline = new Timeline<DataRecord>({
   x: (d: DataRecord) => d.startDate,
-  length: (d: DataRecord) => d.endDate - d.startDate,
-  type: (d: DataRecord) => d.name,
+  lineDuration: (d: DataRecord) => d.endDate - d.startDate,
+  lineRow: (d: DataRecord) => d.name,
   color: (d: DataRecord) => colorMap[d.type],
-  labelWidth,
-  showLabels: true,
+  rowLabelWidth: labelWidth,
+  showRowLabels: true,
 })
 
 const chart = new XYContainer(container, {

--- a/packages/shared/examples/basic-timeline/basic-timeline.tsx
+++ b/packages/shared/examples/basic-timeline/basic-timeline.tsx
@@ -25,11 +25,11 @@ export default function BasicTimeline (): JSX.Element {
       <VisBulletLegend items={legendItems}/>
       <VisTimeline
         x={useCallback((d: DataRecord) => d.startDate, [])}
-        length={useCallback((d: DataRecord) => d.endDate - d.startDate, [])}
-        type={useCallback((d: DataRecord) => d.name, [])}
+        lineDuration={useCallback((d: DataRecord) => d.endDate - d.startDate, [])}
+        lineRow={useCallback((d: DataRecord) => d.name, [])}
         color={useCallback((d: DataRecord) => colorMap[d.type], [])}
-        maxLabelWidth={labelWidth}
-        showLabels={true}
+        rowMaxLabelWidth={labelWidth}
+        showRowLabels={true}
       />
       <VisTooltip triggers={{
         [Timeline.selectors.label]: getTooltipText,

--- a/packages/shared/examples/basic-timeline/basic-timeline.vue
+++ b/packages/shared/examples/basic-timeline/basic-timeline.vue
@@ -16,8 +16,8 @@ function getTooltipText(_: string, i: number): string {
 }
 
 const x = (d: DataRecord) => d.startDate
-const length = (d: DataRecord) => d.endDate - d.startDate
-const type = (d: DataRecord) => d.name
+const lineDuration = (d: DataRecord) => d.endDate - d.startDate
+const lineRow = (d: DataRecord) => d.name
 const color = (d: DataRecord) => colorMap[d.type]
 
 const legendItems = Object.keys(ProductType).map((name, i) => ({ name, color: colorMap[name] }))
@@ -28,7 +28,7 @@ const triggers = { [Timeline.selectors.label]: getTooltipText }
   <VisXYContainer :data :height="500">
     <h3>A Timeline of Abandoned Google Products, 1997 - 2022</h3>
     <VisBulletLegend :items="legendItems" />
-    <VisTimeline :x :length :type :color :labelWidth :showLabels="true" />
+    <VisTimeline :x :lineDuration :lineRow :color :rowLabelWidth="labelWidth" :showRowLabels="true" />
     <VisTooltip :triggers />
     <VisAxis type="x" :tickFormat="dateFormatter" :numTicks="10" />
   </VisXYContainer>

--- a/packages/ts/src/components/timeline/config.ts
+++ b/packages/ts/src/components/timeline/config.ts
@@ -11,7 +11,7 @@ import type { TimelineArrow, TimelineLineRenderState, TimelineRowIcon, TimelineR
 
 export interface TimelineConfigInterface<Datum> extends WithOptional<XYComponentConfigInterface<Datum>, 'y'> {
   // Items (Lines)
-  /** @deprecated This property has been renamed to `key` */
+  /** @deprecated This property has been renamed to `lineRow` */
   type?: StringAccessor<Datum>;
   /** @deprecated This property has been renamed to `lineDuration` */
   length?: NumericAccessor<Datum>;

--- a/packages/website/docs/xy-charts/Timeline.mdx
+++ b/packages/website/docs/xy-charts/Timeline.mdx
@@ -26,7 +26,9 @@ export const timelineProps = (n = 5, rows=n) => ({
 
 export const emptyProps = {
   ...timelineProps(),
-  data: Array(4).fill(0).map((_, i) => ({ type: 'a', timestamp: i * 10, length: i % 2 === 1 ? 8 : 0 })),
+  data: Array(4).fill(0).map((_, i) => ({ name: 'a', timestamp: i * 10, duration: i % 2 === 1 ? 8 : 0 })),
+  lineRow: d => d.name,
+  lineDuration: d => d.duration,
   height: 50,
 }
 
@@ -36,23 +38,22 @@ The minimal _Timeline_ configuration looks like:
 
 <XYWrapper {...timelineProps(6)} showContext="full"/>
 
-where `TimeDataRecord` has at least the following properties:
+where each record should provide at least the following information:
 
 ```ts
 type TimeDataRecord = {
   timestamp: Date; // Position on the X axis. Can be `number` or `Date`
-  length: number; // Length of the line in X axis values, i.e. milliseconds if you use `Date`
-  type: string; // The row it will be displayed in
+  duration: number; // Length of the line in X axis values, i.e. milliseconds if you use `Date`
+  name: string; // The row it will be displayed in
 }
 ```
 
+Wire these up via the `lineDuration` and `lineRow` accessors (along with `x` for the timestamp).
+
 :::note
 
-By default, if the records in your data array contain `length` and `type` properties (as shown above),
-_Timeline_ will only need the `x` accessor provided to display the data.
-Otherwise, you can explicitly define accessor functions for `lineDuration` and `lineRow`.
-
-The `type` and `length` properties are deprecated in favor of `lineRow` and `lineDuration`, respectively.
+The legacy `type` and `length` properties on the _Timeline_ component are deprecated.
+Use `lineRow` and `lineDuration` instead.
 
 :::
 
@@ -219,13 +220,13 @@ The `lineSourceId` and `lineTargetId` correspond to the values returned by the `
 export const arrowData = Array(7).fill(0).map((_, i) => ({
   id: `item-${i}`,
   timestamp: Date.now() + i * 1000 * 60 * 60 * 24 + Math.random() * 1000 * 60 * 60 * 12,
-  length: 1000 * 60 * 60 * 24,
-  type: `Task ${i + 1}`,
+  duration: 1000 * 60 * 60 * 24,
+  name: `Task ${i + 1}`,
 }))
 
 export const arrowItems = arrowData.slice(0, -1).map((d, i) => ({
   id: `arrow-${i}`,
-  xSource: d.timestamp + d.length,
+  xSource: d.timestamp + d.duration,
   lineSourceId: d.id,
   lineTargetId: arrowData[i + 1].id,
   lineSourceMarginPx: 2,
@@ -239,6 +240,8 @@ export const arrowItems = arrowData.slice(0, -1).map((d, i) => ({
   height={255}
   x={d => d.timestamp}
   id={d => d.id}
+  lineRow={d => d.name}
+  lineDuration={d => d.duration}
   lineCap
   rowHeight={35}
   showRowLabels


### PR DESCRIPTION
Addresses https://github.com/f5/unovis/issues/809

Issue #809 reported that the [[VisTimeline docs](https://unovis.dev/docs/xy-charts/Timeline/#component-props)](https://unovis.dev/docs/xy-charts/Timeline/#component-props) say the `type` prop was "renamed to `key` which is a mistake.

Also updating the docs and gallery examples to avoid using deprecated props.