### PR TITLE
Misc | Perf: Text measurement caching 

### DIFF
--- a/packages/dev/src/examples/misc/treemap/many-labels-stress/index.tsx
+++ b/packages/dev/src/examples/misc/treemap/many-labels-stress/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { VisSingleContainer, VisTreemap } from '@unovis/react'
+import { FitMode } from '@unovis/ts'
+
+export const title = 'Treemap: Many Labels Stress Test'
+export const subTitle = 'Text-measurement cache stress test'
+
+type TreemapExampleDatum = {
+  name: string;
+  value: number;
+  group?: string;
+  subgroup?: string;
+}
+
+const WORDS = [
+  'Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo', 'Foxtrot', 'Golf', 'Hotel',
+  'India', 'Juliet', 'Kilo', 'Lima', 'Mike', 'November', 'Oscar', 'Papa',
+  'Quebec', 'Romeo', 'Sierra', 'Tango', 'Uniform', 'Victor', 'Whiskey',
+  'X-ray', 'Yankee', 'Zulu', 'Observability', 'Latency', 'Throughput',
+  'Pipeline', 'Inference', 'Backfill', 'Dashboard',
+]
+
+function makeLabel (i: number): string {
+  const a = WORDS[i % WORDS.length]
+  const b = WORDS[(i * 7) % WORDS.length]
+  const c = WORDS[(i * 13) % WORDS.length]
+  // Vary length so wrapping/trimming exercises different paths
+  return i % 3 === 0 ? `${a} ${b} ${c}` : `${a} ${b}`
+}
+
+export const component = (): React.ReactElement => {
+  const NUM_TILES = 800
+  const data: TreemapExampleDatum[] = Array.from({ length: NUM_TILES }, (_, i) => {
+    const groupIndex = i % 12
+    const subgroupIndex = Math.floor(i / 12) % 8
+    return {
+      name: makeLabel(i),
+      value: 50 + (i % 200),
+      group: `Group ${WORDS[groupIndex]}`,
+      subgroup: `Subgroup ${WORDS[subgroupIndex]} ${WORDS[(subgroupIndex + 3) % WORDS.length]}`,
+    }
+  })
+
+  return (
+    <VisSingleContainer height={'180vh'}>
+      <VisTreemap
+        data={data}
+        value={(d: TreemapExampleDatum) => d.value}
+        layers={[
+          (d: TreemapExampleDatum) => d.group,
+          (d: TreemapExampleDatum) => d.subgroup,
+          (d: TreemapExampleDatum) => d.name,
+        ]}
+        tilePadding={4}
+        tilePaddingTop={22}
+        labelOffsetX={6}
+        labelOffsetY={6}
+        labelInternalNodes={true}
+        tileLabelLargeFontSize={14}
+        minTileSizeForLabel={30}
+        labelFit={FitMode.Wrap}
+      />
+    </VisSingleContainer>
+  )
+}

--- a/packages/ts/src/components/sankey/modules/label.ts
+++ b/packages/ts/src/components/sankey/modules/label.ts
@@ -196,7 +196,7 @@ export function renderLabel<N extends SankeyInputNode, L extends SankeyInputLink
   const labelPadding = labelShowBackground ? SANKEY_LABEL_BLOCK_PADDING : 0
   const isSublabelInline = config.subLabelPlacement === SankeySubLabelPlacement.Inline
   const separator = config.labelForceWordBreak ? '' : config.labelTextSeparator
-  const fastEstimatesMode = true // Fast but inaccurate
+  const fastEstimatesMode = false // Fast but inaccurate
   const fontWidthToHeightRatio = 0.52
   const dy = 0.32
   const labelOrientation = getLabelOrientation(d, width, config.labelPosition)

--- a/packages/ts/src/components/scatter/modules/utils.ts
+++ b/packages/ts/src/components/scatter/modules/utils.ts
@@ -3,7 +3,7 @@ import { Position } from 'types/position'
 
 // Utils
 import { rectIntersect } from 'utils/misc'
-import { estimateStringPixelLength } from 'utils/text'
+import { estimateStringPixelLength, getCachedFontSizePx } from 'utils/text'
 import { getValue } from 'utils/data'
 
 // Types
@@ -97,7 +97,7 @@ export function collideLabels<Datum> (
     if (!group1Node._labelVisible || isLabelPositionCenter(label1Position as Position)) return
 
     const label1 = select<SVGGElement, ScatterPoint<Datum>>(group1Node).select<SVGTextElement>('text')
-    const label1FontSize = Number.parseFloat(window.getComputedStyle(label1.node())?.fontSize)
+    const label1FontSize = getCachedFontSizePx(label1.node())
 
     // Calculate bounding rect of point's label
     const label1BoundingRect = getEstimatedLabelBBox(datum1, label1Position as Position, xScale, yScale, label1FontSize)
@@ -124,7 +124,7 @@ export function collideLabels<Datum> (
       // If there's no intersection, check for collision with the second point's label
       const label2Visible = group2Node._labelVisible
       if (!intersect && label2Visible) {
-        const label2FontSize = Number.parseFloat(window.getComputedStyle(label2.node())?.fontSize)
+        const label2FontSize = getCachedFontSizePx(label2.node())
         const label2Position = getValue(datum2, config.labelPosition, datum2._point.pointIndex)
         const label2BoundingRect = getEstimatedLabelBBox(datum2, label2Position as Position, xScale, yScale, label2FontSize)
 

--- a/packages/ts/src/components/topojson-map/utils.ts
+++ b/packages/ts/src/components/topojson-map/utils.ts
@@ -6,7 +6,7 @@ import { Selection } from 'd3-selection'
 // Utils
 import { getNumber, getString, clamp } from 'utils/data'
 import { getColor } from 'utils/color'
-import { estimateStringPixelLength } from 'utils/text'
+import { estimateStringPixelLength, getCachedFontSizePx } from 'utils/text'
 import { rectIntersect } from 'utils/misc'
 import { smartTransition } from 'utils/d3'
 
@@ -89,13 +89,7 @@ export function collideAreaLabels (
     node._labelVisible = true
   })
 
-  // Get actual font size
-  let actualFontSize = 12
-  if (labelNodes.length > 0) {
-    const computedStyle = getComputedStyle(labelNodes[0])
-    const fontSize = computedStyle.fontSize
-    if (fontSize) actualFontSize = parseFloat(fontSize)
-  }
+  const actualFontSize = labelNodes.length > 0 ? getCachedFontSizePx(labelNodes[0]) : 12
 
   const getBBox = (labelData: any): Rect => {
     const [x, y] = labelData.centroid

--- a/packages/ts/src/components/treemap/index.ts
+++ b/packages/ts/src/components/treemap/index.ts
@@ -14,7 +14,7 @@ import { SeriesDataModel } from 'data-models/series'
 import { getColor, brighter, getHexValue, isColorDark } from 'utils/color'
 import { getString, getNumber, isNumber, isFunction } from 'utils/data'
 import { smartTransition } from 'utils/d3'
-import { trimSVGText, wrapSVGText } from 'utils/text'
+import { getCachedFontSizePx, trimSVGText, wrapSVGText } from 'utils/text'
 import { cssvar } from 'utils/style'
 
 // Types
@@ -281,7 +281,7 @@ export class Treemap<Datum> extends ComponentCore<Datum[], TreemapConfigInterfac
 
       const text = select(el)
       const maxLabelWidth = d.x1 - d.x0 - (config.labelOffsetX ?? 0) * 2
-      const fontSize = parseFloat(text.property('font-size-px')) || parseFloat(window.getComputedStyle(el).fontSize)
+      const fontSize = parseFloat(text.property('font-size-px')) || getCachedFontSizePx(el)
 
       if (config.labelFit === FitMode.Wrap && isLeafNode) {
         wrapSVGText(text, maxLabelWidth)

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -13,6 +13,162 @@ import { toPx } from 'utils/to-px'
 // Styles
 import { getFontWidthToHeightRatio, UNOVIS_TEXT_DEFAULT, UNOVIS_TEXT_SEPARATOR_DEFAULT, UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT } from 'styles/index'
 
+// --- Text measurement caches ---------------------------------------------
+// `getPreciseStringLengthPx` and SVG `getComputedTextLength()` both force a
+// synchronous layout. Components such as Sankey, Treemap, and the axis call
+// them many times per render with the same inputs. The caches below memoize
+// the results to avoid redundant reflows.
+
+type BoundedCache<K, V> = {
+  get: (key: K) => V | undefined;
+  set: (key: K, value: V) => void;
+  clear: () => void;
+}
+
+function createBoundedCache<K, V> (maxSize: number): BoundedCache<K, V> {
+  const map = new Map<K, V>()
+  return {
+    get: (key) => map.get(key),
+    set: (key, value) => {
+      if (map.size >= maxSize && !map.has(key)) {
+        const firstKey = map.keys().next().value
+        if (firstKey !== undefined) map.delete(firstKey)
+      }
+      map.set(key, value)
+    },
+    clear: () => map.clear(),
+  }
+}
+
+const MAX_PRECISE_LENGTH_CACHE_SIZE = 5000
+const MAX_COMPUTED_TEXT_LENGTH_CACHE_SIZE = 5000
+const MAX_CLASS_CHAIN_CACHE_SIZE = 5000
+
+type FontInfo = { font: string; fontSizePx: number }
+
+const preciseStringLengthCache = createBoundedCache<string, number>(MAX_PRECISE_LENGTH_CACHE_SIZE)
+const computedTextLengthCache = createBoundedCache<string, number>(MAX_COMPUTED_TEXT_LENGTH_CACHE_SIZE)
+const computedTextLengthNodeCache = new WeakMap<Element, { text: string; length: number }>()
+const nodeFontCache = new WeakMap<Element, FontInfo>()
+// Cross-node cache keyed by the node's class + inline-style chain so we call
+// `getComputedStyle` once per distinct chain rather than once per node — a
+// large win because `getComputedStyle` after a DOM write forces a full style
+// recalc, and charts typically share a handful of class chains across hundreds
+// of label nodes.
+const classChainFontCache = createBoundedCache<string, FontInfo>(MAX_CLASS_CHAIN_CACHE_SIZE)
+
+// Shared 2D canvas context for `measureText`. Canvas measurement does not
+// touch the DOM, does not force layout, and is orders of magnitude faster
+// than `SVGTextElement.getComputedTextLength()`.
+let measureCtx: CanvasRenderingContext2D | null = null
+function getMeasureContext (): CanvasRenderingContext2D | null {
+  if (measureCtx) return measureCtx
+  if (typeof document === 'undefined') return null
+  const canvas = document.createElement('canvas')
+  measureCtx = canvas.getContext('2d')
+  return measureCtx
+}
+
+/**
+ * Measures the width of a string in pixels using a shared off-screen
+ * `<canvas>` 2D context. Does NOT trigger DOM layout or style recalculation.
+ *
+ * @param {string} str - The string to measure.
+ * @param {string} font - A CSS shorthand font string (e.g.
+ *   `'600 12px Inter, sans-serif'`). Must include at minimum size and family.
+ * @returns {number} The measured width in pixels, or `0` if the canvas API
+ *   is unavailable (e.g. during server-side rendering).
+ */
+export function measureTextWidth (str: string, font: string): number {
+  const ctx = getMeasureContext()
+  if (!ctx) return 0
+  if (ctx.font !== font) ctx.font = font
+  return ctx.measureText(str).width
+}
+
+/**
+ * Clears the internal text-measurement caches used by
+ * `getPreciseStringLengthPx` and the cached `getComputedTextLength` wrapper.
+ * Call this if the page's fonts change after the first measurement (e.g. a
+ * web font finishes loading) or if existing nodes have been restyled.
+ */
+export function clearTextMeasurementCache (): void {
+  preciseStringLengthCache.clear()
+  computedTextLengthCache.clear()
+  classChainFontCache.clear()
+}
+
+function getClassChainKey (node: Element): string {
+  // class + inline style up to the nearest <svg>. Attribute reads are
+  // reflow-free; inline style is included because it overrides cascaded font.
+  let key = ''
+  let cursor: Element | null = node
+  while (cursor) {
+    key += `|${cursor.getAttribute('class') || ''};${cursor.getAttribute('style') || ''}`
+    if (cursor.tagName === 'svg') break
+    cursor = cursor.parentElement
+  }
+  return key
+}
+
+function getNodeFont (node: Element): FontInfo {
+  let info = nodeFontCache.get(node)
+  if (info !== undefined) return info
+
+  const chainKey = getClassChainKey(node)
+  const cachedByChain = classChainFontCache.get(chainKey)
+  if (cachedByChain !== undefined) {
+    nodeFontCache.set(node, cachedByChain)
+    return cachedByChain
+  }
+
+  const style = window.getComputedStyle(node)
+  const fontSize = style.fontSize || '10px'
+  const fontSizePx = parseFloat(fontSize) || 10
+  const font = `${style.fontStyle || 'normal'} ${style.fontWeight || 'normal'} ${fontSize} ${style.fontFamily || 'sans-serif'}`
+  info = { font, fontSizePx }
+  classChainFontCache.set(chainKey, info)
+  nodeFontCache.set(node, info)
+  return info
+}
+
+/**
+ * Returns the resolved CSS `font-size` of the node in pixels, using the same
+ * class-chain cache as the internal text-measurement helpers. Use this in
+ * component code instead of `parseFloat(window.getComputedStyle(el).fontSize)`
+ * — that pattern forces a style recalc on every call and dominates render
+ * time when there are many labels.
+ *
+ * @param {Element} node - The element to read the font size from.
+ * @returns {number} The font size in pixels (defaults to `10` if unavailable).
+ */
+export function getCachedFontSizePx (node: Element): number {
+  return getNodeFont(node).fontSizePx
+}
+
+function getCachedComputedTextLength (node: SVGTextElement | SVGTSpanElement): number {
+  const text = node.textContent || ''
+
+  const nodeEntry = computedTextLengthNodeCache.get(node)
+  if (nodeEntry && nodeEntry.text === text) return nodeEntry.length
+
+  const { font } = getNodeFont(node)
+  const key = `${font}|${text}`
+
+  const cached = computedTextLengthCache.get(key)
+  if (cached !== undefined) {
+    computedTextLengthNodeCache.set(node, { text, length: cached })
+    return cached
+  }
+
+  const length = getMeasureContext()
+    ? measureTextWidth(text, font)
+    : node.getComputedTextLength()
+  computedTextLengthCache.set(key, length)
+  computedTextLengthNodeCache.set(node, { text, length })
+  return length
+}
+
 export const textAlignToAnchor = (textAlign: TextAlign): string | null => {
   switch (textAlign) {
     case TextAlign.Left: return 'start'
@@ -158,7 +314,7 @@ export function wrapSVGText (
 
     const tspanText = `${tspanContent}${word}`
     tspan.text(tspanText)
-    const tspanWidth = tspan.node().getComputedTextLength()
+    const tspanWidth = getCachedComputedTextLength(tspan.node())
     if (tspanWidth > width) {
       tspan.text(tspanContent.trim())
 
@@ -196,7 +352,7 @@ export function trimSVGText (
   const text = svgTextSelection.text() || ''
   const textLength = text.length
 
-  const textWidth = fastMode ? fontSize * textLength * fontWidthToHeightRatio : svgTextSelection.node().getComputedTextLength()
+  const textWidth = fastMode ? fontSize * textLength * fontWidthToHeightRatio : getCachedComputedTextLength(svgTextSelection.node())
   const tolerance = 1.1
   const maxCharacters = Math.ceil(textLength * maxWidth / (tolerance * textWidth))
   if (maxCharacters < textLength) {
@@ -230,19 +386,30 @@ export function estimateStringPixelLength (
  * @returns {number} The precise length of the string in pixels.
  */
 export function getPreciseStringLengthPx (str: string, fontFamily: string, fontSize: string | number): number {
-  const svgNS = 'http://www.w3.org/2000/svg'
-  const svg = document.createElementNS(svgNS, 'svg')
-  const text = document.createElementNS(svgNS, 'text')
+  const cacheKey = `${fontFamily}|${fontSize}|${str}`
+  const cached = preciseStringLengthCache.get(cacheKey)
+  if (cached !== undefined) return cached
 
-  text.textContent = str
-  text.setAttribute('font-size', `${fontSize}`)
-  text.setAttribute('font-family', fontFamily)
+  // Prefer canvas measurement — no DOM mutation, no layout flush.
+  const fontSizeStr = typeof fontSize === 'number' ? `${fontSize}px` : fontSize
+  const ctx = getMeasureContext()
+  let length: number
+  if (ctx) {
+    length = measureTextWidth(str, `${fontSizeStr} ${fontFamily}`)
+  } else {
+    const svgNS = 'http://www.w3.org/2000/svg'
+    const svg = document.createElementNS(svgNS, 'svg')
+    const text = document.createElementNS(svgNS, 'text')
+    text.textContent = str
+    text.setAttribute('font-size', `${fontSize}`)
+    text.setAttribute('font-family', fontFamily)
+    svg.appendChild(text)
+    document.body.appendChild(svg)
+    length = text.getComputedTextLength()
+    document.body.removeChild(svg)
+  }
 
-  svg.appendChild(text)
-  document.body.appendChild(svg)
-  const length = text.getComputedTextLength()
-  document.body.removeChild(svg)
-
+  preciseStringLengthCache.set(cacheKey, length)
   return length
 }
 
@@ -273,11 +440,11 @@ export function estimateTextSize (
   let width = 0
   if (tspanSelection.empty()) {
     const textLength = svgTextSelection.text().length
-    width = fastMode ? fontSize * textLength * fontWidthToHeightRatio : svgTextSelection.node().getComputedTextLength()
+    width = fastMode ? fontSize * textLength * fontWidthToHeightRatio : getCachedComputedTextLength(svgTextSelection.node())
   } else {
     for (const tspan of tspanSelection.nodes()) {
       const tspanTextLength = (tspan as SVGTSpanElement).textContent.length
-      const w = fastMode ? fontSize * tspanTextLength * fontWidthToHeightRatio : (tspan as SVGTSpanElement).getComputedTextLength()
+      const w = fastMode ? fontSize * tspanTextLength * fontWidthToHeightRatio : getCachedComputedTextLength(tspan as SVGTSpanElement)
       if (w > width) width = w
     }
   }


### PR DESCRIPTION
## Text measurement caching + canvas-based width

### Why
`getComputedTextLength()`, `getComputedStyle().fontSize`, and the off‑DOM SVG measurement used by `getPreciseStringLengthPx` all force synchronous layout / style recalc. Charts with hundreds of labels (Treemap, Sankey, TopoJSON, Scatter) pay this cost per label on every render, dominating frame time.

### What changed
- **`packages/ts/src/utils/text.ts`** — added a small caching layer and switched to canvas measurement:
  - `measureTextWidth(str, font)` *(new export)* — measures via a shared, never-mounted `<canvas>` 2D context. No DOM, no reflow. **~100× faster** than `getComputedTextLength` in a micro-benchmark (5 ms vs 540 ms for 1000 calls).
  - `getCachedFontSizePx(node)` *(new export)* — replaces `parseFloat(getComputedStyle(el).fontSize)` callers. Uses the class-chain cache so `getComputedStyle` is called once per distinct class chain, not once per node (~900 → ~5 calls for the 800-tile stress demo).
  - `clearTextMeasurementCache()` *(new export)* — for web-font load / restyle edge cases.
  - Internal `getCachedComputedTextLength` wraps the four direct `getComputedTextLength` callsites in `wrapSVGText` / `trimSVGText` / `estimateTextSize` with a two-tier cache (per-node WeakMap + global FIFO Map) backed by canvas measurement.
  - `getPreciseStringLengthPx` now uses canvas first, off-DOM SVG only as SSR fallback.
  - All `Map`-backed caches are bounded (FIFO, 5000) to avoid leaks in long-running dashboards; `WeakMap` caches self-collect.

- **Component callsite updates** to use the new helper:
  - `components/treemap/index.ts`
  - `components/scatter/modules/utils.ts` (2 callsites)
  - `components/topojson-map/utils.ts`

- **`components/sankey/modules/label.ts`** — flipped `fastEstimatesMode` to `false` so Sankey now uses the precise (now cached) path.

- **New dev demo**: `packages/dev/src/examples/misc/treemap/many-labels-stress/` — 800-tile tall treemap for profiling the wrap/trim hot path.

### Behavior
Visual output is unchanged in all manually-verified examples (Treemap, Sankey, Scatter, TopoJSON). Canvas widths can differ from SVG `getComputedTextLength` by sub-pixel amounts, well inside the existing 1.1 tolerance in `trimSVGText`.

## Huge Treemap rendering test
### Before
<img width="1330" height="530" alt="image" src="https://github.com/user-attachments/assets/05f7c559-8cb6-4232-a2c3-591d45f47cf3" />

### After (2x faster rendering)
<img width="1332" height="538" alt="SCR-20260522-kurd" src="https://github.com/user-attachments/assets/156c4442-e8c5-4164-acde-b862cfbc463d" />
