### PR TITLE
Component | Scatter: Point hover performance fix

### DIFF
--- a/packages/ts/src/components/scatter/index.ts
+++ b/packages/ts/src/components/scatter/index.ts
@@ -147,21 +147,13 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
     removePoints(points.exit<ScatterPoint<Datum>>(), this.xScale, this.yScale, duration)
 
     // Take care of overlapping labels
-    if (this._hasLabels()) {
-      this._resolveLabelOverlap()
-    }
-  }
-
-  private _hasLabels (): boolean {
-    // If label config is not defined, no labels will be shown
-    if (!this.config.label) return false
-
-    // Check if any point in the flattened data has a label
-    const pointDataFlat: ScatterPoint<Datum>[] = flatten(this._pointData)
-    return pointDataFlat.some(d => d._point.label)
+    this._resolveLabelOverlap()
   }
 
   private _resolveLabelOverlap (): void {
+    // If label config is not defined, no labels will be shown
+    if (!this.config.label) return
+
     if (!this.config.labelHideOverlapping) {
       const label = this._points.selectAll<SVGTextElement, ScatterPoint<Datum>>('text')
       label.attr('opacity', null)
@@ -170,7 +162,9 @@ export class Scatter<Datum> extends XYComponentCore<Datum, ScatterConfigInterfac
 
     cancelAnimationFrame(this._collideLabelsAnimFrameId)
     this._collideLabelsAnimFrameId = requestAnimationFrame(() => {
-      collideLabels(this._points, this.config, this.xScale, this.yScale)
+      // Filter out points that don't have a label
+      const pointsSelectionWithLabels = this._points.filter(d => !!d._point.label)
+      collideLabels(pointsSelectionWithLabels, this.config, this.xScale, this.yScale)
     })
   }
 


### PR DESCRIPTION
Currently, when you hover over a point, we trigger `_resolveLabelOverlap` for all the points, even when they don't have labels. That can be extremely slow when the number of points is large. This PR fixes that by filtering out the points without labels and includes a small refactoring.

### Before
<img width="1341" height="388" alt="SCR-20260526-kfwm" src="https://github.com/user-attachments/assets/31737453-7614-40d6-af0e-b88affa11ac1" />


### After
<img width="1336" height="441" alt="SCR-20260526-kgmp" src="https://github.com/user-attachments/assets/0d1fc187-ba3e-48b9-b74b-edc8f998dcf4" />
