### PR TITLE
Component | Crosshair: Add configurable visibility threshold

### DIFF
--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -64,6 +64,12 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
    *  This is useful for testing, especially when you only triggers mousemove event but does not have real mouse event.
    */
   skipRangeCheck?: boolean;
+  /** Minimum fraction (`0` to `1`) of the container's area that must be visible in the
+   * viewport for the Crosshair (and its Tooltip) to be displayed. This prevents the
+   * Crosshair from showing when the chart is mostly scrolled out of view. Charts that are
+   * wider or taller than the viewport may never reach the default ratio, so lower this
+   * value (or set it to `0` to always show the Crosshair) for large charts. Default: `0.35` */
+  visibilityThreshold?: number;
 }
 
 export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
@@ -84,5 +90,6 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   onCrosshairMove: undefined,
   forceShowAt: undefined,
   skipRangeCheck: false,
+  visibilityThreshold: 0.35,
 }
 

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -76,8 +76,8 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     const containerArea = containerRect.width * containerRect.height
     const visibleArea = visibleWidth * visibleHeight
 
-    // Container must be at least 35% visible
-    return containerArea > 0 && (visibleArea / containerArea) >= 0.35
+    // Container must be at least `visibilityThreshold` (default 35%) visible
+    return containerArea > 0 && (visibleArea / containerArea) >= this.config.visibilityThreshold
   }
 
   constructor (config?: CrosshairConfigInterface<Datum>) {

--- a/packages/website/docs/auxiliary/Crosshair.mdx
+++ b/packages/website/docs/auxiliary/Crosshair.mdx
@@ -44,6 +44,10 @@ You can disable this feature using the `hideWhenFarFromPointer` attribute.
 Use the `hideWhenFarFromPointerDistance` attribute with a length (in pixels) that represents the minimum horizontal distance the cursor must be from a datapoint before hiding.
 <XYWrapperWithInput {...crosshairProps("StackedBar", { barWidth: 10})} data={generateDataRecords(10).filter(d => d.x % 2 == 0)} property="hideWhenFarFromPointerDistance" defaultValue={50} inputType="range"/>
 
+#### `visibilityThreshold`
+The _Crosshair_ is only displayed when at least a fraction of its container is visible in the viewport, which prevents it (and its tooltip) from appearing when the chart is mostly scrolled out of view. Charts that are wider or taller than the viewport may never reach the default ratio of `0.35`, so you can lower `visibilityThreshold`, or set it to `0` to always show the _Crosshair_ regardless of how much of the container is on screen.
+<XYWrapperWithInput {...crosshairProps("StackedBar", { barWidth: 10})} property="visibilityThreshold" defaultValue={0.35} inputType="range" inputProps={{ min: 0, max: 1, step: 0.05 }}/>
+
 ## Custom Color
 Provide a `string` or color accessor function to the `color` attribute to customize the crosshair's point color:
 <XYWrapper {...crosshairProps()} color={(d, i) => ['red', 'green', 'blue'][i]} showContext="minimal"/>


### PR DESCRIPTION
## Closes #710

### Problem
The Crosshair (and its Tooltip) is only rendered when at least 35% of its container
is visible in the viewport. That ratio was hardcoded in `_isContainerInViewport`, so
charts wider or taller than the viewport never reach it and the Crosshair/Tooltip
never appears (see the Stackblitz repro in #710). This matches what @akhavarovskiy
reported and the configurable-threshold suggestion @lee00678 made in the thread.

### Change
- Added a `visibilityThreshold` option to `CrosshairConfigInterface` (range `0`–`1`,
  default `0.35` so behavior is unchanged; `0` always shows the Crosshair).
- `_isContainerInViewport` now uses `this.config.visibilityThreshold` instead of the
  literal `0.35`.
- Documented the option on the Crosshair docs page (the auto-generated PropsTable also
  picks it up from the JSDoc).

### Notes
- Framework wrappers (React/Angular/Svelte/Vue/Solid) consume `CrosshairConfigInterface`
  directly, so the new prop flows through without regeneration.

### Testing
- `pnpm exec eslint` on the changed files: 0 errors.
- Built `@unovis/ts` (`rollup -c`): succeeds; the option appears in the compiled output.
- Setting `visibilityThreshold` lower (or `0`) makes the Crosshair display on a chart
  wider than the viewport, resolving the reported behavior.
