### PR TITLE
Website | Docs: SVG Filters

### DIFF
--- a/packages/dev/src/examples/misc/theming/svg-filters/index.tsx
+++ b/packages/dev/src/examples/misc/theming/svg-filters/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Line, Scatter, StackedBar } from '@unovis/ts'
+import { VisXYContainer, VisAxis, VisStackedBar, VisBulletLegend, VisCrosshair, VisLine, VisScatter } from '@unovis/react'
+
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Visual Effects (SVG Filters)'
+export const subTitle = 'Glow & bevel via svgDefs + attributes'
+
+// Custom SVG filters injected into the container via `svgDefs`.
+// Both are built on `SourceGraphic`, so they're a pure rendering overlay that enhances
+// the rendered shapes without changing their colors.
+const svgDefs = `
+  <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+    <feGaussianBlur stdDeviation="3" result="blur"/>
+    <feMerge>
+      <feMergeNode in="blur"/>
+      <feMergeNode in="SourceGraphic"/>
+    </feMerge>
+  </filter>
+
+  <filter id="bevel" x="-20%" y="-20%" width="140%" height="140%">
+    <!-- Inner shadow for depth -->
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+    <feOffset in="blur" dx="0" dy="2" result="offsetBlur"/>
+    <feComposite in="SourceAlpha" in2="offsetBlur" operator="out" result="innerShadowMask"/>
+    <feFlood flood-color="black" flood-opacity="0.4" result="shadowColor"/>
+    <feComposite in="shadowColor" in2="innerShadowMask" operator="in" result="shadow"/>
+    <!-- Top highlight for the embossed look -->
+    <feOffset in="SourceAlpha" dx="0" dy="-2" result="highlightOffset"/>
+    <feComposite in="SourceAlpha" in2="highlightOffset" operator="out" result="highlightMask"/>
+    <feFlood flood-color="white" flood-opacity="0.5" result="highlightColor"/>
+    <feComposite in="highlightColor" in2="highlightMask" operator="in" result="highlight"/>
+    <!-- Merge source + shadow + highlight, then clip everything to the shape -->
+    <feMerge result="merged">
+      <feMergeNode in="SourceGraphic"/>
+      <feMergeNode in="shadow"/>
+      <feMergeNode in="highlight"/>
+    </feMerge>
+    <feComposite in="merged" in2="SourceGraphic" operator="in"/>
+  </filter>
+`
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  type Datum = { x: number; azure: number; aws: number; google: number };
+  const data: Datum[] = Array(20).fill(0).map((_, i) => {
+    const t = i / 5
+    return {
+      x: i,
+      azure: 80 + 15 * Math.sin(t) * t + i * 2,
+      aws: 150 + 80 * Math.sin(t * 0.7) + i * 1.5,
+      google: 200 + 60 * Math.cos(t * 1.2) + i * 3,
+    }
+  })
+
+  const keys = ['azure', 'aws', 'google']
+  const accessors = keys.map(key => (d: Datum) => d[key as keyof Datum])
+
+  // Styles
+  const blockStyle = { display: 'flex', flexDirection: 'column', gap: 24, flex: 1, minWidth: 0 } as const
+  const wrapperStyle = { display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'flex-start' } as const
+
+  return (
+    <div style={wrapperStyle}>
+      <div style={blockStyle}>
+        <p>A <code>bevel</code> filter (inner shadow + top highlight) applied to bars via{' '}
+          <code>attributes</code>. The filter is a pure overlay — it adds depth without
+          changing the chart&apos;s colors.</p>
+        <VisXYContainer<Datum> data={data} svgDefs={svgDefs}>
+          <VisStackedBar
+            x={d => d.x}
+            y={accessors}
+            barPadding={0.1}
+            attributes={{ [StackedBar.selectors.bar]: { filter: 'url(#bevel)' } }}
+            duration={props.duration}
+          />
+          <VisAxis type='x'/>
+          <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
+        </VisXYContainer>
+      </div>
+      <div style={blockStyle}>
+        <p>A <code>glow</code> filter applied to lines and scatter points via{' '}
+          <code>attributes</code> for a neon dashboard look.</p>
+        <VisBulletLegend
+          items={keys.map(key => ({ name: key }))}
+        />
+        <VisXYContainer<Datum> data={data} svgDefs={svgDefs}>
+          <VisLine
+            x={d => d.x}
+            y={accessors}
+            attributes={{ [Line.selectors.line]: { filter: 'url(#glow)' } }}
+            duration={props.duration}
+          />
+          <VisScatter
+            x={d => d.x}
+            y={accessors}
+            attributes={{ [Scatter.selectors.point]: { filter: 'url(#glow)' } }}
+            duration={props.duration}
+          />
+          <VisAxis type='x'/>
+          <VisCrosshair template={(d: Datum) => `x: ${d.x}`} />
+        </VisXYContainer>
+      </div>
+    </div>
+  )
+}

--- a/packages/website/docs/guides/theming.mdx
+++ b/packages/website/docs/guides/theming.mdx
@@ -428,3 +428,44 @@ Alternatively, you can place the defs in a hidden `<svg>` element anywhere on th
 
 :::
 
+## SVG Filters (glow, bevel, 3D)
+The same `svgDefs` property can hold custom SVG `<filter>` definitions for advanced visual effects —
+glow, bevel, inner shadow, or neon styling — that aren't possible with plain CSS. Combine it with the
+`attributes` config, available on every component, to apply a `filter` to the rendered shapes by their
+selector.
+
+Because the filter is built on `SourceGraphic`, it acts as a pure rendering overlay: it enhances what's
+already drawn without touching the chart's colors.
+
+```tsx
+import { StackedBar } from '@unovis/ts'
+
+// A bevel filter (inner shadow + top highlight), clipped to each shape.
+const svgDefs = `
+  <filter id="bevel" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+    <feOffset in="blur" dx="0" dy="2" result="offsetBlur"/>
+    <feComposite in="SourceAlpha" in2="offsetBlur" operator="out" result="innerShadowMask"/>
+    <feFlood flood-color="black" flood-opacity="0.4" result="shadowColor"/>
+    <feComposite in="shadowColor" in2="innerShadowMask" operator="in" result="shadow"/>
+    <feMerge result="merged">
+      <feMergeNode in="SourceGraphic"/>
+      <feMergeNode in="shadow"/>
+    </feMerge>
+    <feComposite in="merged" in2="SourceGraphic" operator="in"/>
+  </filter>`
+
+<VisXYContainer data={data} svgDefs={svgDefs}>
+  <VisStackedBar
+    x={d => d.x}
+    y={accessors}
+    attributes={{ [StackedBar.selectors.bar]: { filter: 'url(#bevel)' } }}
+  />
+</VisXYContainer>
+```
+
+The `filter` is set per shape (`.bar`, `.point`, `.line`, `.area`, `.segmentArc`, …) rather than on a
+wrapping group, so effects like inner shadow and bevel that rely on each shape's own `SourceGraphic`
+render correctly. See the **Visual Effects (SVG Filters)** gallery example for glow and bevel applied to
+bars, lines, and scatter points.
+


### PR DESCRIPTION
An update to the documentation and a dev example showing how to use SVG filters

<img width="1296" height="478" alt="SCR-20260609-kwbf" src="https://github.com/user-attachments/assets/e0f2692a-1268-40c2-85d1-e50e6a831c29" />
