### PR TITLE
Component | Crosshair: XY snapping; Horizontal line (1.7)

### DIFF
--- a/packages/angular/src/components/crosshair/crosshair.component.ts
+++ b/packages/angular/src/components/crosshair/crosshair.component.ts
@@ -10,6 +10,7 @@ import {
   ColorAccessor,
   ContinuousScale,
   Tooltip,
+  CrosshairSnapMode,
   CrosshairCircle,
 } from '@unovis/ts'
 import { VisXYComponent } from '../../core'
@@ -108,6 +109,11 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
   /** Radius of crosshair circles in pixels. Default: `3` */
   @Input() circleRadius?: number
 
+  /** When `true`, the Crosshair also renders a horizontal line. The line is placed at the Y position of the
+   * crosshair circle closest to the mouse pointer (i.e. the snapped data point), or follows the pointer
+   * when there are no circles to snap to (e.g. when `snapToData` is `false`). Default: `false` */
+  @Input() showHorizontalLine?: boolean
+
   /** Separate array of accessors for stacked components (eg StackedBar, Area). Default: `undefined` */
   @Input() yStacked?: NumericAccessor<Datum>[]
 
@@ -133,6 +139,16 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
    * for getting the underlying data records and crosshair circles (see the `getCircles` configuration option).
    * Default: `true` */
   @Input() snapToData?: boolean
+
+  /** When `snapToData` is enabled, controls how the nearest datum is found:
+   * - `CrosshairSnapMode.XY`: snap to the datum closest to the mouse pointer in both X and Y (measured in pixel space).
+   *  This is the right choice for Scatter charts where many points can share similar X values.
+   * - `CrosshairSnapMode.X`: snap to the datum closest along the X axis only. Best for time series / line / area
+   *  charts where the crosshair is a vertical line tracking the X position.
+   *
+   * Has no effect when `forceShowAt` is set (no pointer Y is available — it falls back to `CrosshairSnapMode.X`).
+   * Default: `CrosshairSnapMode.X` */
+  @Input() snapMode?: CrosshairSnapMode | `${CrosshairSnapMode}`
 
   /** Custom function for setting up the crosshair circles, usually needed when `snapToData` is set to `false`.
    * The function receives the horizontal position of the crosshair (in the data space, not in pixels), the data array,
@@ -185,8 +201,8 @@ export class VisCrosshairComponent<Datum> implements CrosshairConfigInterface<Da
   }
 
   private getConfig (): CrosshairConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, circleRadius, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck, visibilityThreshold } = this
-    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, circleRadius, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck, visibilityThreshold }
+    const { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, circleRadius, showHorizontalLine, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, snapMode, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck, visibilityThreshold } = this
+    const config = { duration, events, attributes, x, y, id, color, xScale, yScale, excludeFromDomainCalculation, strokeColor, strokeWidth, circleRadius, showHorizontalLine, yStacked, baseline, tooltip, template, hideWhenFarFromPointer, hideWhenFarFromPointerDistance, snapToData, snapMode, getCircles, onCrosshairMove, forceShowAt, skipRangeCheck, visibilityThreshold }
     const keys = Object.keys(config) as (keyof CrosshairConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/crosshair/scatter-snap-modes/index.tsx
+++ b/packages/dev/src/examples/xy-components/crosshair/scatter-snap-modes/index.tsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react'
+import { CrosshairSnapMode } from '@unovis/ts'
+import { VisXYContainer, VisScatter, VisAxis, VisCrosshair, VisTooltip } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+const NUM_POINTS = 1500
+
+type ScatterRecord = {
+  x: number;
+  y: number;
+}
+
+// Seeded RNG so the layout is stable across renders (mirrors `scatter-performance`).
+function generateScatterData (seed = 42): ScatterRecord[] {
+  let s = seed
+  const random = (): number => {
+    s = (s * 1664525 + 1013904223) % 4294967296
+    return s / 4294967296
+  }
+
+  // Points are clustered into a handful of X bands so that many points share a similar X.
+  // This is exactly the case where X-only snapping picks a point that's far away in Y.
+  return Array.from({ length: NUM_POINTS }, () => {
+    const band = Math.floor(random() * 12)
+    return {
+      x: band * 8 + random() * 4,
+      y: random() * 100,
+    }
+  })
+}
+
+const tooltipTemplate = (d: ScatterRecord): string =>
+  `x: ${d.x.toFixed(1)}, y: ${d.y.toFixed(1)}`
+
+export const title = 'Scatter Crosshair Snap (X vs XY)'
+export const subTitle = `${NUM_POINTS.toLocaleString()} clustered points`
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const data = useMemo(() => generateScatterData(), [])
+
+  return (
+    <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+      <div style={{ flex: '1 1 360px', minWidth: 320 }}>
+        <strong>CrosshairSnapMode.X</strong> (default — snaps along X only)
+        <VisXYContainer<ScatterRecord> data={data} margin={{ top: 5, left: 5 }} height={400}>
+          <VisScatter<ScatterRecord> x={d => d.x} y={d => d.y} size={5} duration={props.duration}/>
+          <VisAxis type='x' duration={props.duration}/>
+          <VisAxis type='y' duration={props.duration}/>
+          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.X} template={tooltipTemplate}/>
+          <VisTooltip/>
+        </VisXYContainer>
+      </div>
+      <div style={{ flex: '1 1 360px', minWidth: 320 }}>
+        <strong>CrosshairSnapMode.XY</strong> (snaps to the closest point in X and Y)
+        <VisXYContainer<ScatterRecord> data={data} margin={{ top: 5, left: 5 }} height={400}>
+          <VisScatter<ScatterRecord> x={d => d.x} y={d => d.y} size={5} duration={props.duration}/>
+          <VisAxis type='x' duration={props.duration}/>
+          <VisAxis type='y' duration={props.duration}/>
+          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.XY} template={tooltipTemplate}/>
+          <VisTooltip/>
+        </VisXYContainer>
+      </div>
+    </div>
+  )
+}

--- a/packages/dev/src/examples/xy-components/crosshair/scatter-snap-modes/index.tsx
+++ b/packages/dev/src/examples/xy-components/crosshair/scatter-snap-modes/index.tsx
@@ -32,6 +32,13 @@ function generateScatterData (seed = 42): ScatterRecord[] {
 const tooltipTemplate = (d: ScatterRecord): string =>
   `x: ${d.x.toFixed(1)}, y: ${d.y.toFixed(1)}`
 
+const chartStyle = {
+  flex: '1 1 360px',
+  minWidth: 320,
+  '--vis-crosshair-line-stroke-color': '#aaa',
+  '--vis-crosshair-line-stroke-dasharray': '8 4',
+} as React.CSSProperties
+
 export const title = 'Scatter Crosshair Snap (X vs XY)'
 export const subTitle = `${NUM_POINTS.toLocaleString()} clustered points`
 
@@ -40,23 +47,23 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
 
   return (
     <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
-      <div style={{ flex: '1 1 360px', minWidth: 320 }}>
+      <div style={chartStyle}>
         <strong>CrosshairSnapMode.X</strong> (default — snaps along X only)
         <VisXYContainer<ScatterRecord> data={data} margin={{ top: 5, left: 5 }} height={400}>
           <VisScatter<ScatterRecord> x={d => d.x} y={d => d.y} size={5} duration={props.duration}/>
           <VisAxis type='x' duration={props.duration}/>
           <VisAxis type='y' duration={props.duration}/>
-          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.X} template={tooltipTemplate}/>
+          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.X} showHorizontalLine={true} template={tooltipTemplate}/>
           <VisTooltip/>
         </VisXYContainer>
       </div>
-      <div style={{ flex: '1 1 360px', minWidth: 320 }}>
+      <div style={chartStyle}>
         <strong>CrosshairSnapMode.XY</strong> (snaps to the closest point in X and Y)
         <VisXYContainer<ScatterRecord> data={data} margin={{ top: 5, left: 5 }} height={400}>
           <VisScatter<ScatterRecord> x={d => d.x} y={d => d.y} size={5} duration={props.duration}/>
           <VisAxis type='x' duration={props.duration}/>
           <VisAxis type='y' duration={props.duration}/>
-          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.XY} template={tooltipTemplate}/>
+          <VisCrosshair<ScatterRecord> snapMode={CrosshairSnapMode.XY} showHorizontalLine={true} template={tooltipTemplate}/>
           <VisTooltip/>
         </VisXYContainer>
       </div>

--- a/packages/ts/src/components.ts
+++ b/packages/ts/src/components.ts
@@ -37,6 +37,7 @@ export { Treemap } from './components/treemap'
 
 // Constants
 export * from './components/donut/constants'
+export * from './components/crosshair/constants'
 
 // Config Interfaces
 export type { LineConfigInterface } from './components/line/config'

--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -6,6 +6,7 @@ import { NumericAccessor, ColorAccessor } from 'types/accessor'
 import { ContinuousScale } from 'types/scale'
 import { WithOptional } from 'types/misc'
 import { CrosshairCircle } from './types'
+import { CrosshairSnapMode } from './constants'
 
 // We extend partial XY config interface because x and y properties are optional for Crosshair
 export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponentConfigInterface<Datum>, 'x' | 'y'> {
@@ -42,6 +43,16 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
    * Default: `true`
   */
   snapToData?: boolean;
+  /** When `snapToData` is enabled, controls how the nearest datum is found:
+   * - `CrosshairSnapMode.XY`: snap to the datum closest to the mouse pointer in both X and Y (measured in pixel space).
+   *   This is the right choice for Scatter charts where many points can share similar X values.
+   * - `CrosshairSnapMode.X`: snap to the datum closest along the X axis only. Best for time series / line / area
+   *   charts where the crosshair is a vertical line tracking the X position.
+   *
+   * Has no effect when `forceShowAt` is set (no pointer Y is available — it falls back to `CrosshairSnapMode.X`).
+   * Default: `CrosshairSnapMode.X`
+  */
+  snapMode?: CrosshairSnapMode | `${CrosshairSnapMode}`;
   /** Custom function for setting up the crosshair circles, usually needed when `snapToData` is set to `false`.
    * The function receives the horizontal position of the crosshair (in the data space, not in pixels), the data array,
    * the `yScale` instance to help you calculate the correct vertical position of the circles, and the nearest datum index.
@@ -82,6 +93,7 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   hideWhenFarFromPointer: true,
   hideWhenFarFromPointerDistance: 100,
   snapToData: true,
+  snapMode: CrosshairSnapMode.X,
   getCircles: undefined,
   color: undefined,
   strokeColor: undefined,

--- a/packages/ts/src/components/crosshair/config.ts
+++ b/packages/ts/src/components/crosshair/config.ts
@@ -22,6 +22,10 @@ export interface CrosshairConfigInterface<Datum> extends WithOptional<XYComponen
   strokeWidth?: NumericAccessor<Datum>;
   /** Radius of crosshair circles in pixels. Default: `3` */
   circleRadius?: number;
+  /** When `true`, the Crosshair also renders a horizontal line. The line is placed at the Y position of the
+   * crosshair circle closest to the mouse pointer (i.e. the snapped data point), or follows the pointer
+   * when there are no circles to snap to (e.g. when `snapToData` is `false`). Default: `false` */
+  showHorizontalLine?: boolean;
   /** Separate array of accessors for stacked components (eg StackedBar, Area). Default: `undefined` */
   yStacked?: NumericAccessor<Datum>[];
   /** Baseline accessor function for stacked values, useful with stacked areas. Default: `null` */
@@ -99,6 +103,7 @@ export const CrosshairDefaultConfig: CrosshairConfigInterface<unknown> = {
   strokeColor: undefined,
   strokeWidth: undefined,
   circleRadius: 4,
+  showHorizontalLine: false,
   onCrosshairMove: undefined,
   forceShowAt: undefined,
   skipRangeCheck: false,

--- a/packages/ts/src/components/crosshair/constants.ts
+++ b/packages/ts/src/components/crosshair/constants.ts
@@ -1,0 +1,8 @@
+/** Controls how the nearest datum is found when `snapToData` is enabled. */
+export enum CrosshairSnapMode {
+  /** Snap to the datum closest along the X axis only. */
+  X = 'x',
+  /** Snap to the datum closest to the mouse pointer in both X and Y (measured in pixel space). */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  XY = 'xy',
+}

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -6,7 +6,7 @@ import { XYComponentCore } from 'core/xy-component'
 import { Tooltip } from 'components/tooltip'
 
 // Utils
-import { isNumber, isArray, getNumber, clamp, getStackedValues, getNearest, isFunction } from 'utils/data'
+import { isNumber, isArray, getNumber, clamp, getStackedValues, getNearest, getNearest2D, isFunction } from 'utils/data'
 import { smartTransition } from 'utils/d3'
 import { getColor } from 'utils/color'
 
@@ -17,6 +17,7 @@ import { Spacing } from 'types/spacing'
 
 // Local Types
 import { CrosshairAccessors, CrosshairCircle } from './types'
+import { CrosshairSnapMode } from './constants'
 
 // Config
 import { CrosshairDefaultConfig, CrosshairConfigInterface } from './config'
@@ -124,6 +125,9 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     // It can be from a mouse interaction or from a `forceShowAt` setting
     let nearestDatum: Datum | undefined
     let nearestDatumIndex: number | undefined
+    // Squared pixel distance from the pointer to the snapped datum (only set in `CrosshairSnapMode.XY` mode).
+    // Feeds the `nearestDistance` calculation below.
+    let nearestDistanceSq: number | undefined
     if (config.snapToData) {
       if (!this.accessors.y && !this.accessors.yStacked && datamodel.data?.length) {
         console.warn('Unovis | Crosshair: Y accessors have not been configured. Please check if they\'re present in the configuration object')
@@ -135,8 +139,21 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
         console.warn('Unovis | Crosshair: No data to snap to. Make sure the data has been passed to the container or to the crosshair itself')
       }
 
-      nearestDatum = getNearest(datamodel.data, xValue, this.accessors.x)
-      nearestDatumIndex = datamodel.data.indexOf(nearestDatum)
+      // In `CrosshairSnapMode.XY` mode we snap to the data point closest to the pointer in both X and Y (pixel space).
+      // This requires a real pointer position, so we fall back to X-only snapping when `forceShowAt` is set
+      // or there's no pointer Y available yet.
+      const useXYMode = config.snapMode === CrosshairSnapMode.XY && !isForceShowAtDefined && this._yPx !== undefined
+      if (useXYMode) {
+        const nearest = getNearest2D(datamodel.data, [this._xPx, this._yPx], this.xScale, this.yScale, this.accessors.x, this.accessors.y, this.accessors.yStacked, this.accessors.baseline)
+        if (nearest) {
+          nearestDatum = nearest.datum
+          nearestDatumIndex = nearest.index
+          nearestDistanceSq = nearest.distanceSq
+        }
+      } else {
+        nearestDatum = getNearest(datamodel.data, xValue, this.accessors.x)
+        nearestDatumIndex = datamodel.data.indexOf(nearestDatum)
+      }
     }
 
     const xRange = this.xScale.range()
@@ -149,8 +166,13 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     const isCrosshairWithinYRange = (this._yPx >= Math.min(yRange[0], yRange[1])) && (this._yPx <= Math.max(yRange[0], yRange[1]))
     let shouldShow = config.skipRangeCheck ? !!this._xPx : (this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange)
 
+    // Distance in pixels between the pointer and the snapped datum: the full 2D distance in
+    // `CrosshairSnapMode.XY` mode (so a point that's close in X but far in Y still counts as far),
+    // or the horizontal distance to the crosshair line otherwise
+    const nearestDistance = nearestDistanceSq !== undefined ? Math.sqrt(nearestDistanceSq) : Math.abs(xClamped - (+xPx))
+
     // If the crosshair is far from the mouse pointer (usually when `snapToData` is `true` and data resolution is low), hide it
-    if (config.hideWhenFarFromPointer && ((Math.abs(xClamped - (+xPx)) >= config.hideWhenFarFromPointerDistance))) {
+    if (config.hideWhenFarFromPointer && (nearestDistance >= config.hideWhenFarFromPointerDistance)) {
       shouldShow = false
     }
 

--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -1,5 +1,6 @@
 import { Selection, pointer } from 'd3-selection'
 import { easeLinear } from 'd3-ease'
+import { least } from 'd3-array'
 
 // Core
 import { XYComponentCore } from 'core/xy-component'
@@ -33,6 +34,7 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
   public config: CrosshairConfigInterface<Datum> = this._defaultConfig
   container: Selection<SVGSVGElement, any, SVGSVGElement, any>
   line: Selection<SVGLineElement, any, SVGElement, any>
+  lineHorizontal: Selection<SVGLineElement, any, SVGElement, any>
   private _xPx: number | undefined = undefined
   private _yPx: number | undefined = undefined
   private _mouseEvent: MouseEvent | undefined = undefined
@@ -88,6 +90,9 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     this.g.style('opacity', 0)
     this.line = this.g.append('line')
       .attr('class', s.line)
+    this.lineHorizontal = this.g.append('line')
+      .attr('class', s.lineHorizontal)
+      .style('display', 'none')
   }
 
   get bleed (): Spacing {
@@ -211,6 +216,10 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
     // This looks off, so we stop further rendering when the `xPx` value is not finite.
     if (!isFinite(xPx)) return
 
+    const circleData = isFunction(config.getCircles)
+      ? config.getCircles(xValue, datamodel.data, this.yScale, leftNearestDatumIndex)
+      : this.getCircleData(nearestDatum, nearestDatumIndex)
+
     this.line
       .attr('y1', 0)
       .attr('y2', this._height)
@@ -219,9 +228,17 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
       .attr('x1', xClamped)
       .attr('x2', xClamped)
 
-    const circleData = isFunction(config.getCircles)
-      ? config.getCircles(xValue, datamodel.data, this.yScale, leftNearestDatumIndex)
-      : this.getCircleData(nearestDatum, nearestDatumIndex)
+    const lineHorizontalY = config.showHorizontalLine ? this.getLineHorizontalY(circleData) : undefined
+    this.lineHorizontal
+      .style('display', lineHorizontalY === undefined ? 'none' : null)
+      .attr('x1', 0)
+      .attr('x2', this._width)
+
+    if (lineHorizontalY !== undefined) {
+      smartTransition(this.lineHorizontal, duration, easeLinear)
+        .attr('y1', lineHorizontalY)
+        .attr('y2', lineHorizontalY)
+    }
 
     const circles = this.g
       .selectAll<SVGCircleElement, CrosshairCircle>('circle')
@@ -323,6 +340,15 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
   // We don't want Crosshair to be be taken in to account in domain calculations
   getYDataExtent (): number[] {
     return [undefined, undefined]
+  }
+
+  /** Y position of the horizontal crosshair line: the circle closest to the pointer (i.e. the snapped data point),
+   * or the pointer position itself when there are no circles to snap to. `undefined` when there's nothing to draw */
+  private getLineHorizontalY (circles: CrosshairCircle[]): number | undefined {
+    const yPx = this._yPx
+    const circleYs = circles.filter(c => c.opacity !== 0 && isFinite(c.y)).map(c => c.y)
+    const y = (yPx === undefined ? circleYs[0] : least(circleYs, cy => Math.abs(cy - yPx))) ?? yPx
+    return isFinite(y) ? clamp(Math.round(y), 0, this._height) : undefined
   }
 
   private getCircleData (datum: Datum, datumIndex: number): CrosshairCircle[] {

--- a/packages/ts/src/components/crosshair/style.ts
+++ b/packages/ts/src/components/crosshair/style.ts
@@ -1,30 +1,42 @@
-import { css, injectGlobal } from '@emotion/css'
-
-export const globalStyles = injectGlobal`
-  :root {
-    --vis-crosshair-line-stroke-color: #888;
-    --vis-crosshair-line-stroke-width: 1px;
-    --vis-crosshair-line-stroke-opacity: 1;
-    --vis-crosshair-circle-stroke-color: #fff;
-    --vis-crosshair-circle-stroke-width: 1px;
-    --vis-crosshair-circle-stroke-opacity: 0.75;
-  }
-`
+import { css } from '@emotion/css'
+import { getCssVarNames, injectGlobalCssVariables } from 'utils/style'
 
 export const root = css`
   label: crosshair-component;
 `
 
+export const cssVarDefaults: Record<string, string | undefined> = {
+  '--vis-crosshair-line-stroke-color': '#888',
+  '--vis-crosshair-line-stroke-width': '1px',
+  '--vis-crosshair-line-stroke-opacity': '1',
+  '--vis-crosshair-line-stroke-dasharray': 'none',
+  '--vis-crosshair-circle-stroke-color': '#fff',
+  '--vis-crosshair-circle-stroke-width': '1px',
+  '--vis-crosshair-circle-stroke-opacity': '0.75',
+}
+
+export const variables = getCssVarNames(cssVarDefaults)
+injectGlobalCssVariables(cssVarDefaults, root)
+
 export const line = css`
-  stroke: var(--vis-crosshair-line-stroke-color);
-  stroke-width: var(--vis-crosshair-line-stroke-width);
-  stroke-opacity: var(--vis-crosshair-line-stroke-opacity);
+  stroke: var(${variables.crosshairLineStrokeColor});
+  stroke-width: var(${variables.crosshairLineStrokeWidth});
+  stroke-opacity: var(${variables.crosshairLineStrokeOpacity});
+  stroke-dasharray: var(${variables.crosshairLineStrokeDasharray});
+  pointer-events: none;
+`
+
+export const lineHorizontal = css`
+  stroke: var(${variables.crosshairLineStrokeColor});
+  stroke-width: var(${variables.crosshairLineStrokeWidth});
+  stroke-opacity: var(${variables.crosshairLineStrokeOpacity});
+  stroke-dasharray: var(${variables.crosshairLineStrokeDasharray});
   pointer-events: none;
 `
 
 export const circle = css`
-  stroke: var(--vis-crosshair-circle-stroke-color);
-  stroke-width: var(--vis-crosshair-circle-stroke-width);
-  stroke-opacity: var(--vis-crosshair-circle-stroke-opacity);
+  stroke: var(${variables.crosshairCircleStrokeColor});
+  stroke-width: var(${variables.crosshairCircleStrokeWidth});
+  stroke-opacity: var(${variables.crosshairCircleStrokeOpacity});
   pointer-events: none;
 `

--- a/packages/ts/src/utils/data.ts
+++ b/packages/ts/src/utils/data.ts
@@ -4,6 +4,7 @@ import { throttle as _throttle } from 'throttle-debounce'
 // Types
 import { NumericAccessor, StringAccessor, BooleanAccessor, ColorAccessor, GenericAccessor } from 'types/accessor'
 import { FindNearestDirection, StackValuesRecord } from 'types/data'
+import { ContinuousScale } from 'types/scale'
 
 export const isNumber = <T>(a: T): a is T extends number ? T : never => typeof a === 'number'
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -333,6 +334,69 @@ export function getNearest<Datum> (
 
   // By default (`FindNearestDirection.Auto`) return the nearest value
   return value - values[index - 1] > values[index] - value ? dataWithIndexSorted[index][0] : dataWithIndexSorted[index - 1][0]
+}
+
+/** Finds the datum nearest to a point in the scaled (pixel) space, considering all the provided Y accessors
+ * (regular and stacked) so that multi-series charts pick the nearest series point.
+ * Returns the datum, its index and the squared distance to it, or `undefined` when there's nothing to snap to */
+export function getNearest2D<Datum> (
+  data: Datum[],
+  point: [number, number],
+  xScale: ContinuousScale,
+  yScale: ContinuousScale,
+  xAccessor: NumericAccessor<Datum>,
+  yAccessors: NumericAccessor<Datum>[] = [],
+  yStackedAccessors: NumericAccessor<Datum>[] = [],
+  baselineAccessor?: NumericAccessor<Datum>
+): { datum: Datum; index: number; distanceSq: number } | undefined {
+  if (!data?.length || !xAccessor) return undefined
+
+  const [pointX, pointY] = point
+  let nearestDatum: Datum | undefined
+  let nearestIndex = -1
+  let minDistanceSq = Infinity
+
+  // Linear scan using squared distances (no `sqrt`, no sorting): O(n) per call, which is fast enough
+  // for tens of thousands of points. If a dataset ever outgrows this, a quadtree built in the scaled
+  // space (and invalidated on data / scale changes) would bring the lookup down to O(log n)
+  for (let i = 0; i < data.length; i++) {
+    const datum = data[i]
+    const x = xScale(getNumber(datum, xAccessor, i))
+    if (!isFinite(x)) continue
+    const distanceXSq = (x - pointX) ** 2
+
+    // Stacked series (e.g. StackedBar, Area)
+    if (yStackedAccessors.length) {
+      const baselineValue = getNumber(datum, baselineAccessor, i) || 0
+      const stackedValues = getStackedValues(datum, i, ...yStackedAccessors)
+      for (let j = 0; j < stackedValues.length; j++) {
+        if (!isNumber(getNumber(datum, yStackedAccessors[j], j))) continue
+        const y = yScale(stackedValues[j] + baselineValue)
+        const distanceSq = distanceXSq + (y - pointY) ** 2
+        if (distanceSq < minDistanceSq) {
+          minDistanceSq = distanceSq
+          nearestDatum = datum
+          nearestIndex = i
+        }
+      }
+    }
+
+    // Regular series
+    for (let j = 0; j < yAccessors.length; j++) {
+      const value = getNumber(datum, yAccessors[j], i)
+      if (!isNumber(value)) continue
+      const y = yScale(value)
+      const distanceSq = distanceXSq + (y - pointY) ** 2
+      if (distanceSq < minDistanceSq) {
+        minDistanceSq = distanceSq
+        nearestDatum = datum
+        nearestIndex = i
+      }
+    }
+  }
+
+  if (nearestIndex === -1) return undefined
+  return { datum: nearestDatum, index: nearestIndex, distanceSq: minDistanceSq }
 }
 
 export function filterDataByRange<Datum> (

--- a/packages/website/docs/auxiliary/Crosshair.mdx
+++ b/packages/website/docs/auxiliary/Crosshair.mdx
@@ -2,6 +2,7 @@ import CodeBlock from '@theme/CodeBlock'
 import { PropsTable } from '@site/src/components/PropsTable'
 import { generateDataRecords } from '../utils/data'
 import { XYWrapperWithInput, XYWrapper } from '../wrappers'
+import { Crosshair } from '@unovis/ts'
 
 export const crosshairProps = (chart="Line", components, n=5) => ({
   name: "Crosshair",
@@ -13,9 +14,15 @@ export const crosshairProps = (chart="Line", components, n=5) => ({
   components: [{ name: chart, props: { x: d=>d.x, y: [d=>d.y, d=>d.y1, d=>d.y2], ...components}, key: "components" }]
 })
 
+export const snapModeData = Array.from({ length: 10 }, (_, i) => ({
+  x: Math.floor(i % 12) * 8 + ((i * 17) % 40) / 10,
+  y: (i * 37) % 100,
+}))
+
 ## Basic Configuration
 The _Crosshair_ component is a special tooltip designed to work in an _XYContainer_.
 When a user is interacting with the _XYContainer_ and a crosshair is provided, the _Crosshair_ will appear as a vertical line and render circles on the corresponding `y` values in the dataset.
+You can optionally enable a horizontal line with `showHorizontalLine` (see below).
 
 <XYWrapper {...crosshairProps('Line', {}, 10)} showContext="full"/>
 
@@ -35,18 +42,48 @@ const yStacked: ((d: DataRecord) => number)[] = [d => d.y, d => d.y1, d => d.y2]
 ```
 <XYWrapper {...crosshairProps("StackedBar", { barWith: 50})} height={200} x={d => d.x + 0.5} yStacked={[d=>d.y, d=>d.y1, d=>d.y2]}/>
 
+## Snap Mode
+When `snapToData` is enabled (the default), the `snapMode` property controls how the nearest datum is selected:
+
+- `CrosshairSnapMode.X` (default): snap along the X axis only. Best for time series, line, and area charts where the crosshair tracks the X position.
+- `CrosshairSnapMode.XY`: snap to the datum closest to the pointer in both X and Y (measured in pixel space). Best for _Scatter_ charts where many points can share similar X values.
+
+When `snapMode` is `CrosshairSnapMode.XY`, `hideWhenFarFromPointerDistance` uses the full 2D distance to the snapped point (so a point that is close in X but far in Y still counts as far away).
+If `forceShowAt` is set, snapping falls back to `CrosshairSnapMode.X` because no pointer Y position is available.
+
+
+<XYWrapper
+  {...crosshairProps("Scatter", { y: d => d.y, size: 10 }, 400)}
+  data={snapModeData}
+  height={300}
+  snapMode="xy"
+  showHorizontalLine={true}
+  template={d => `x: ${d.x.toFixed(1)}, y: ${d.y.toFixed(1)}`}
+  components={crosshairProps("Scatter", { y: d => d.y, size: 10 }, 400).components.concat({
+    name: "Tooltip",
+    key: "tooltip",
+    props: {},
+  })}
+/>
+
 ## Show/Hide Behavior
 By default, the _Crosshair_ component will render if the cursor is within a certain distance in pixels from a valid `x` value.
 You can disable this feature using the `hideWhenFarFromPointer` attribute.
 <XYWrapperWithInput {...crosshairProps("StackedBar", { barWidth: 10})} property="hideWhenFarFromPointer" defaultValue={true} inputType="checkbox"/>
 
 #### `hideWhenFarFromPointerDistance`
-Use the `hideWhenFarFromPointerDistance` attribute with a length (in pixels) that represents the minimum horizontal distance the cursor must be from a datapoint before hiding.
+Use the `hideWhenFarFromPointerDistance` attribute with a length (in pixels) that represents how far the cursor can be from the snapped datum before hiding.
+With the default `snapMode` of `CrosshairSnapMode.X`, this is the horizontal distance to the crosshair line; with `CrosshairSnapMode.XY`, it is the full 2D distance to the snapped point.
 <XYWrapperWithInput {...crosshairProps("StackedBar", { barWidth: 10})} data={generateDataRecords(10).filter(d => d.x % 2 == 0)} property="hideWhenFarFromPointerDistance" defaultValue={50} inputType="range"/>
 
 #### `visibilityThreshold`
 The _Crosshair_ is only displayed when at least a fraction of its container is visible in the viewport, which prevents it (and its tooltip) from appearing when the chart is mostly scrolled out of view. Charts that are wider or taller than the viewport may never reach the default ratio of `0.35`, so you can lower `visibilityThreshold`, or set it to `0` to always show the _Crosshair_ regardless of how much of the container is on screen.
 <XYWrapperWithInput {...crosshairProps("StackedBar", { barWidth: 10})} property="visibilityThreshold" defaultValue={0.35} inputType="range" inputProps={{ min: 0, max: 1, step: 0.05 }}/>
+
+## Horizontal Line
+Set `showHorizontalLine` to `true` to render a horizontal line in addition to the vertical crosshair.
+The line is placed at the Y position of the crosshair circle closest to the pointer (i.e. the snapped data point), or follows the pointer when there are no circles to snap to (for example, when `snapToData` is `false`).
+<XYWrapperWithInput {...crosshairProps('Line', {}, 10)} property="showHorizontalLine" defaultValue={false} inputType="checkbox"/>
 
 ## Custom Color
 Provide a `string` or color accessor function to the `color` attribute to customize the crosshair's point color:
@@ -79,19 +116,19 @@ The _Crosshair_ component supports additional styling via CSS variables that you
 ```css title="styles.css"
 .visualization-container-div {
   --vis-crosshair-line-stroke-color: #f88080;
+  --vis-crosshair-line-stroke-dasharray: 8 4;
   --vis-crosshair-circle-stroke-color: #000000;
 }
 ```
 <XYWrapper {...crosshairProps()} excludeTabs className="custom-crosshair"/>
 
 <details open>
-  <summary open>All supported CSS variables and their default values</summary>
-  <CodeBlock language="css">{
-`--vis-crosshair-line-stroke-color: #888;
---vis-crosshair-line-stroke-width: 1px;
---vis-crosshair-circle-stroke-color: #fff;
---vis-crosshair-circle-stroke-width: 1px;`
-}</CodeBlock>
+  <summary>All supported CSS variables and their default values</summary>
+  <CodeBlock language="css">
+{`${
+  Object.entries(Crosshair.selectors.cssVarDefaults)
+  .map(([key, value]) => `${key}: ${value};`).join('\n')}
+`}</CodeBlock>
 </details>
 
 ## Component Props

--- a/packages/website/docs/wrappers/xy-wrapper/custom.css
+++ b/packages/website/docs/wrappers/xy-wrapper/custom.css
@@ -39,6 +39,7 @@
 
 .custom-crosshair {
   --vis-crosshair-line-stroke-color: #f88080;
+  --vis-crosshair-line-stroke-dasharray: 8 4;
   --vis-crosshair-circle-stroke-color: #000000;
 }
 


### PR DESCRIPTION
- Adding configurable XY snapping to Crosshair, which makes it work much better with Scatter
- Configurable horizontal line
- ☑️ Docs, wrappers, dev example


https://github.com/user-attachments/assets/154c7219-7a36-48e6-acb8-3c9f72b143b5


https://github.com/user-attachments/assets/f28323ee-5112-4965-8a05-d3cf1d596365

