### PR TITLE
Component | Sankey: Fix single node label rendering

### DIFF
--- a/packages/dev/src/examples/networks-and-flows/sankey/sankey-single-node-long-label/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/sankey/sankey-single-node-long-label/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { VisSingleContainer, VisSankey } from '@unovis/react'
+import { FitMode } from '@unovis/ts'
+
+export const title = 'Sankey: Single Node Long Label'
+export const subTitle = 'Label wrapping'
+
+const data = {
+  nodes: [
+    {
+      id: 'A',
+      label: 'A single node with an exceptionally long label that should wrap across multiple lines',
+      subLabel: 'And a fairly long sub-label too, to verify wrapping behavior',
+    },
+  ],
+  links: [],
+}
+
+export const component = (): React.ReactNode => (
+  <VisSingleContainer data={data}>
+    <VisSankey
+      label={(d: typeof data.nodes[0]) => d.label}
+      subLabel={(d: typeof data.nodes[0]) => d.subLabel}
+      labelFit={FitMode.Wrap}
+      labelForceWordBreak={false}
+    />
+  </VisSingleContainer>
+)

--- a/packages/ts/src/components/sankey/modules/label.ts
+++ b/packages/ts/src/components/sankey/modules/label.ts
@@ -169,9 +169,17 @@ export function getLabelMaxWidth<N extends SankeyInputNode, L extends SankeyInpu
 ): number {
   const labelHorizontalPadding = 2 * SANKEY_LABEL_SPACING + 2 * SANKEY_LABEL_BLOCK_PADDING
 
+  // Single-layer layouts (e.g. linkless nodes) are rendered centered rather than pinned to a
+  // container edge, so the label doesn't spill into the bleed margin — it has roughly half of the
+  // free horizontal space on its side.
+  if (sankeyMaxLayer === 0) {
+    return clamp(layerSpacing / 2 - labelHorizontalPadding, 0, config.labelMaxWidth ?? Infinity)
+  }
+
   if (d.layer === 0 && labelOrientation === Position.Left) {
     return bleed.left - labelHorizontalPadding
   }
+
   if (d.layer === sankeyMaxLayer && labelOrientation === Position.Right) {
     return bleed.right - labelHorizontalPadding
   }


### PR DESCRIPTION
### Before
<img width="1511" height="345" alt="SCR-20260618-ochz" src="https://github.com/user-attachments/assets/a6a8971e-76df-4c95-ab95-defe457aa059" />

### After
<img width="1506" height="324" alt="SCR-20260618-ocjv" src="https://github.com/user-attachments/assets/4326a70a-59e3-48a3-90c4-e87567ec01f4" />
