### PR TITLE
Component | Area: Fix gradient clipping with non-zero y-domain (#548)

### DIFF
--- a/packages/ts/src/components/area/index.ts
+++ b/packages/ts/src/components/area/index.ts
@@ -7,7 +7,7 @@ import { interpolatePath } from 'd3-interpolate-path'
 import { XYComponentCore } from 'core/xy-component'
 
 // Utils
-import { getNumber, getString, isArray, isNumber, getStackedExtent, getStackedData, filterDataByRange, getValue } from 'utils/data'
+import { getNumber, getString, isArray, isNumber, getStackedExtent, getStackedData, filterDataByRange, getValue, clamp } from 'utils/data'
 import { smartTransition } from 'utils/d3'
 import { getColor } from 'utils/color'
 
@@ -90,13 +90,19 @@ export class Area<Datum> extends XYComponentCore<Datum, AreaConfigInterface<Datu
 
     const stacked = getStackedData(data, config.baseline, yAccessors, this._prevNegative)
     this._prevNegative = stacked.map(s => !!s.isMostlyNegative)
+
+    // Clamp to the visible y range so the area and its fill stay within the container
+    const yRange = this.yScale.range()
+    const yRangeMin = Math.min(yRange[0], yRange[1])
+    const yRangeMax = Math.max(yRange[0], yRange[1])
+
     const minHeightCumulativeArray: number[] = []
     const stackedData: AreaDatum[][] = stacked.map(
       arr => arr.map(
         (d, j) => {
           const x = areaDataX[j]
-          const y0 = this.yScale(d[0])
-          const y1 = this.yScale(d[1])
+          const y0 = clamp(this.yScale(d[0]), yRangeMin, yRangeMax)
+          const y1 = clamp(this.yScale(d[1]), yRangeMin, yRangeMax)
           const isNegativeArea = y1 > y0
 
           // Only apply cumulative adjustment if `config.stackMinHeight` is true


### PR DESCRIPTION
Fixes #548 

When a custom `y-domain` doesn't include `0`, `VisArea` is still drawn down to the `0` baseline, far outside the visible range. The fix clamps the area to the y scale's range. Default zero-based case is unaffected.

Before:
<img width="351" height="396" alt="image" src="https://github.com/user-attachments/assets/e9843f8e-d82f-4def-8312-9c978359e28f" />

After:
<img width="351" height="396" alt="image" src="https://github.com/user-attachments/assets/86b94fdc-a324-4554-855b-13c6d98c56d9" />