### PR TITLE
Misc | Webiste, Vue, cmds-report updates

### DIFF
--- a/packages/angular/src/components/boxplot/boxplot.component.ts
+++ b/packages/angular/src/components/boxplot/boxplot.component.ts
@@ -80,6 +80,11 @@ export class VisBoxplotComponent<Datum> implements BoxplotConfigInterface<Datum>
   /** Box fill color accessor function. Default: `d => d.color` */
   @Input() color?: ColorAccessor<Datum>
 
+  /** Array of data color keys. Use to map data keys to colors.
+   * Expected to the same length as the `y` accessors array.
+   * Default: `undefined` */
+  @Input() colorKeys?: string[]
+
   /** Scale for X dimension, e.g. Scale.scaleLinear(). If you set xScale you'll be responsible for setting it's `domain` and `range` as well.
    * Only continuous scales are supported.
    * Default: `undefined` */
@@ -148,8 +153,8 @@ export class VisBoxplotComponent<Datum> implements BoxplotConfigInterface<Datum>
   }
 
   private getConfig (): BoxplotConfigInterface<Datum> {
-    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor } = this
-    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor }
+    const { duration, events, attributes, x, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor } = this
+    const config = { duration, events, attributes, x, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor }
     const keys = Object.keys(config) as (keyof BoxplotConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/react/src/components/radial-bar/index.tsx
+++ b/packages/react/src/components/radial-bar/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { RadialBar, RadialBarConfigInterface } from '@unovis/ts'
+import { RadialBar } from '@unovis/ts/components/radial-bar'
+import { RadialBarConfigInterface } from '@unovis/ts/components/radial-bar/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/shared/integrations/utils.ts
+++ b/packages/shared/integrations/utils.ts
@@ -75,13 +75,6 @@ export function getTypeName (type: ts.Node | undefined): string {
       const generics = (type as ts.TypeReferenceNode).typeArguments?.map(getTypeName).join(', ')
       return name + (generics ? `<${generics}>` : '')
     }
-    case (ts.SyntaxKind.TemplateLiteralType): {
-      const t = type as ts.TemplateLiteralTypeNode
-      const spans = t.templateSpans
-        .map(span => `\${${getTypeName(span.type)}}${span.literal.text}`)
-        .join('')
-      return `\`${t.head.text}${spans}\``
-    }
     case (ts.SyntaxKind.ArrayType): return `${getTypeName((type as ts.ArrayTypeNode).elementType)}[]`
     case (ts.SyntaxKind.TupleType): return `[${(type as ts.TupleTypeNode).elements.map(getTypeName).join(', ')}]`
     case (ts.SyntaxKind.TemplateLiteralType): {
@@ -218,9 +211,14 @@ export function getImportStatements (
         importSources[typeName] = importSourceMap[typeName]
       } else {
         let importSource: string = (importDec.moduleSpecifier as ts.StringLiteral).text
+        // Strip @/ prefix to check the actual path
+        const pathToCheck = importSource.replace(/^@\//, '')
         if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
           importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
-          importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
+          importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/') ||
+          pathToCheck.startsWith('core/') || pathToCheck.startsWith('types/') || pathToCheck.startsWith('utils/') ||
+          pathToCheck.startsWith('components/') || pathToCheck.startsWith('styles/') || pathToCheck.startsWith('data-models/') ||
+          pathToCheck.startsWith('data/')
         ) importSource = '@unovis/ts'
 
         importSources[typeName] = importSource
@@ -338,9 +336,15 @@ export function getConfigSummary (
         importSource.startsWith('core/') || importSource.startsWith('types/') ||
         importSource.startsWith('utils/') || importSource.startsWith('components/') ||
         importSource.startsWith('styles/') || importSource.startsWith('data-models/') ||
-        importSource.startsWith('data/')
+        importSource.startsWith('data/') ||
+        importSource.startsWith('@/core/') || importSource.startsWith('@/types/') ||
+        importSource.startsWith('@/utils/') || importSource.startsWith('@/components/') ||
+        importSource.startsWith('@/styles/') || importSource.startsWith('@/data-models/') ||
+        importSource.startsWith('@/data/')
       ) {
-        importSource = `@unovis/ts/${importSource}`
+        // Strip @/ prefix if present, then normalize to @unovis/ts
+        const normalizedSource = importSource.replace(/^@\//, '')
+        importSource = `@unovis/ts/${normalizedSource}`
       }
       for (const importEl of importDec.importClause.namedBindings.elements) {
         importSourceMap[importEl.name.escapedText] = importSource

--- a/packages/shared/licences.md
+++ b/packages/shared/licences.md
@@ -1,29 +1,34 @@
-| Name                         | License period | License type | Installed version | Author                                          |
-| :--------------------------- | :------------- | :----------- | :---------------- | :---------------------------------------------- |
-| @angular/core                | perpetual      | MIT          | 12.2.17           | angular                                         |
-| @angular/common              | perpetual      | MIT          | 12.2.17           | angular                                         |
-| @angular/platform-browser    | perpetual      | MIT          | 12.2.17           | angular                                         |
-| @sveltejs/vite-plugin-svelte | perpetual      | MIT          | 3.1.2             | dominikg                                        |
-| @tsconfig/svelte             | perpetual      | MIT          | 2.0.1             | n/a                                             |
-| @types/d3-scale              | perpetual      | MIT          | 4.0.9             | n/a                                             |
-| @types/d3-selection          | perpetual      | MIT          | 3.0.11            | n/a                                             |
-| @types/react                 | perpetual      | MIT          | 18.3.31           | n/a                                             |
-| @types/react-dom             | perpetual      | MIT          | 18.3.7            | n/a                                             |
-| @vitejs/plugin-react         | perpetual      | MIT          | 4.7.0             | Evan You                                        |
-| @vitejs/plugin-vue           | perpetual      | MIT          | 5.2.4             | Evan You                                        |
-| tslib                        | perpetual      | 0BSD         | 2.8.1             | Microsoft Corp.                                 |
-| d3-format                    | perpetual      | ISC          | 3.1.2             | Mike Bostock http://bost.ocks.org/mike          |
-| d3-scale                     | perpetual      | ISC          | 4.0.2             | Mike Bostock https://bost.ocks.org/mike         |
-| d3-selection                 | perpetual      | ISC          | 3.0.0             | Mike Bostock https://bost.ocks.org/mike         |
-| react-dom                    | perpetual      | MIT          | 18.3.1            | n/a                                             |
-| react                        | perpetual      | MIT          | 18.3.1            | n/a                                             |
-| solid-js                     | perpetual      | MIT          | 1.9.11            | Ryan Carniato                                   |
-| svelte                       | perpetual      | MIT          | 4.2.20            | Rich Harris                                     |
-| svelte-preprocess            | perpetual      | MIT          | 4.10.7            | Christian Kaisermann <christian@kaisermann.me>  |
-| typescript                   | perpetual      | Apache-2.0   | 4.2.4             | Microsoft Corp.                                 |
-| d3-array                     | perpetual      | ISC          | 3.2.4             | Mike Bostock http://bost.ocks.org/mike          |
-| @emotion/css                 | perpetual      | MIT          | 11.13.5           | Kye Hohenberger                                 |
-| vite                         | perpetual      | MIT          | 7.3.2             | Evan You                                        |
-| vite-plugin-solid            | perpetual      | MIT          | 2.11.10           | Alexandre Mouton-Brady <amoutonbrady@gmail.com> |
-| vue                          | perpetual      | MIT          | 3.5.30            | Evan You                                        |
+| Name                              | License period | License type | Installed version | Author                                                           |
+| :-------------------------------- | :------------- | :----------- | :---------------- | :--------------------------------------------------------------- |
+| @angular/core                     | perpetual      | MIT          | 12.2.17           | angular                                                          |
+| @angular/common                   | perpetual      | MIT          | 12.2.17           | angular                                                          |
+| @angular/compiler                 | perpetual      | MIT          | 12.2.17           | angular                                                          |
+| @angular/platform-browser         | perpetual      | MIT          | 12.2.17           | angular                                                          |
+| @angular/platform-browser-dynamic | perpetual      | MIT          | 12.2.17           | angular                                                          |
+| reflect-metadata                  | perpetual      | Apache-2.0   | 0.1.14            | Ron Buckton ron.buckton@microsoft.com http://github.com/rbuckton |
+| rxjs                              | perpetual      | Apache-2.0   | 7.8.2             | Ben Lesh <ben@benlesh.com>                                       |
+| zone.js                           | perpetual      | MIT          | 0.11.8            | Brian Ford                                                       |
+| @sveltejs/vite-plugin-svelte      | perpetual      | MIT          | 3.1.2             | dominikg                                                         |
+| @tsconfig/svelte                  | perpetual      | MIT          | 2.0.1             | n/a                                                              |
+| @types/d3-scale                   | perpetual      | MIT          | 4.0.9             | n/a                                                              |
+| @types/d3-selection               | perpetual      | MIT          | 3.0.11            | n/a                                                              |
+| @types/react                      | perpetual      | MIT          | 18.3.31           | n/a                                                              |
+| @types/react-dom                  | perpetual      | MIT          | 18.3.7            | n/a                                                              |
+| @vitejs/plugin-react              | perpetual      | MIT          | 4.7.0             | Evan You                                                         |
+| @vitejs/plugin-vue                | perpetual      | MIT          | 5.2.4             | Evan You                                                         |
+| tslib                             | perpetual      | 0BSD         | 2.8.1             | Microsoft Corp.                                                  |
+| d3-format                         | perpetual      | ISC          | 3.1.2             | Mike Bostock http://bost.ocks.org/mike                           |
+| d3-scale                          | perpetual      | ISC          | 4.0.2             | Mike Bostock https://bost.ocks.org/mike                          |
+| d3-selection                      | perpetual      | ISC          | 3.0.0             | Mike Bostock https://bost.ocks.org/mike                          |
+| react-dom                         | perpetual      | MIT          | 18.3.1            | n/a                                                              |
+| react                             | perpetual      | MIT          | 18.3.1            | n/a                                                              |
+| solid-js                          | perpetual      | MIT          | 1.9.11            | Ryan Carniato                                                    |
+| svelte                            | perpetual      | MIT          | 4.2.20            | Rich Harris                                                      |
+| svelte-preprocess                 | perpetual      | MIT          | 4.10.7            | Christian Kaisermann <christian@kaisermann.me>                   |
+| typescript                        | perpetual      | Apache-2.0   | 4.2.4             | Microsoft Corp.                                                  |
+| d3-array                          | perpetual      | ISC          | 3.2.4             | Mike Bostock http://bost.ocks.org/mike                           |
+| @emotion/css                      | perpetual      | MIT          | 11.13.5           | Kye Hohenberger                                                  |
+| vite                              | perpetual      | MIT          | 7.3.2             | Evan You                                                         |
+| vite-plugin-solid                 | perpetual      | MIT          | 2.11.10           | Alexandre Mouton-Brady <amoutonbrady@gmail.com>                  |
+| vue                               | perpetual      | MIT          | 3.5.30            | Evan You                                                         |
 

--- a/packages/svelte/src/components/boxplot/boxplot.svelte
+++ b/packages/svelte/src/components/boxplot/boxplot.svelte
@@ -12,12 +12,11 @@
   // eslint-disable-next-line no-undef-init
   export let data: Datum[] = undefined
   export let x: NumericAccessor<Datum>
-  export let y: NumericAccessor<Datum> | NumericAccessor<Datum>[]
 
   // config
   let prevConfig: BoxplotConfigInterface<Datum>
   let config: BoxplotConfigInterface<Datum>
-  $: config = { x, y, ...$$restProps }
+  $: config = { x, ...$$restProps }
 
   // component declaration
   let component: Boxplot<Datum>

--- a/packages/vue/src/components/boxplot/index.vue
+++ b/packages/vue/src/components/boxplot/index.vue
@@ -6,12 +6,12 @@ import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from '
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 
+// data and required props
 // !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412
 const props = defineProps</** @vue-ignore */ BoxplotConfigInterface<Datum> & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)

--- a/packages/vue/src/components/heatmap/index.vue
+++ b/packages/vue/src/components/heatmap/index.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import { Heatmap, HeatmapConfigInterface, NumericAccessor } from '@unovis/ts'
-import { onMounted, onUnmounted, computed, ref, watch, nextTick, inject } from 'vue'
-import { arePropsEqual, useForwardProps } from '../../utils/props'
+import type { HeatmapConfigInterface } from '@unovis/ts'
+import { Heatmap } from '@unovis/ts'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
+import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+const props = defineProps<Props & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props 
+// data and required props
 type Props = HeatmapConfigInterface<Datum>
-const props = defineProps<Props & { data?: Datum[] }>()
-
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)
 
 // component declaration
 const component = ref<Heatmap<Datum>>()
-
 
 onMounted(() => {
   nextTick(() => {
@@ -44,7 +44,7 @@ watch(data, () => {
 })
 
 defineExpose({
-  component
+  component,
 })
 </script>
 
@@ -55,5 +55,3 @@ export const VisHeatmapSelectors = Heatmap.selectors
 <template>
   <div data-vis-component />
 </template>
-
-

--- a/packages/vue/src/components/radial-bar/index.vue
+++ b/packages/vue/src/components/radial-bar/index.vue
@@ -1,23 +1,23 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import { RadialBar, RadialBarConfigInterface, NumericAccessor } from '@unovis/ts'
-import { onMounted, onUnmounted, computed, ref, watch, nextTick, inject } from 'vue'
-import { arePropsEqual, useForwardProps } from '../../utils/props'
+import type { RadialBarConfigInterface } from '@unovis/ts'
+import { RadialBar } from '@unovis/ts'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
+import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+const props = defineProps<Props & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props 
+// data and required props
 type Props = RadialBarConfigInterface<Datum>
-const props = defineProps<Props & { data?: Datum[] }>()
-
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)
 
 // component declaration
 const component = ref<RadialBar<Datum>>()
-
 
 onMounted(() => {
   nextTick(() => {
@@ -44,7 +44,7 @@ watch(data, () => {
 })
 
 defineExpose({
-  component
+  component,
 })
 </script>
 
@@ -55,5 +55,3 @@ export const VisRadialBarSelectors = RadialBar.selectors
 <template>
   <div data-vis-component />
 </template>
-
-

--- a/packages/website/docs/containers/Single_Container.mdx
+++ b/packages/website/docs/containers/Single_Container.mdx
@@ -200,7 +200,7 @@ users a text summary of the visualization:
 ## SVG Defs
 You can use the `svgDefs` property to inject custom SVG definitions — gradients, patterns, clip paths, and
 filters — that your component can reference by `id`. See our
-<a href="/docs/guides/tips-and-tricks#custom-fills-with-svg-defs">Tips and Tricks</a>, or the
+<a href="/docs/guides/theming#gradient-fills-with-svg-defs">Theming guide</a>, or the
 [Gradient Fills](/docs/guides/theming#gradient-fills-with-svg-defs) and
 [SVG Filters](/docs/guides/theming#svg-filters-glow-bevel-3d) sections of the _Theming_ guide, for details.
 

--- a/packages/website/docs/containers/XY_Container.mdx
+++ b/packages/website/docs/containers/XY_Container.mdx
@@ -356,7 +356,7 @@ users a text summary of the visualization:
 ## SVG Defs
 You can use the `svgDefs` property to inject custom SVG definitions — gradients, patterns, clip paths, and
 filters — that your components can reference by `id`. See our
-<a href="/docs/guides/tips-and-tricks#custom-fills-with-svg-defs">Tips and Tricks</a>, or the
+<a href="/docs/guides/theming#gradient-fills-with-svg-defs">Theming guide</a>, or the
 [Gradient Fills](/docs/guides/theming#gradient-fills-with-svg-defs) and
 [SVG Filters](/docs/guides/theming#svg-filters-glow-bevel-3d) sections of the _Theming_ guide, for details.
 

--- a/packages/website/docs/networks-and-flows/Graph.mdx
+++ b/packages/website/docs/networks-and-flows/Graph.mdx
@@ -109,7 +109,7 @@ Alternatively, you can provide `nodeShape` property with custom SVGs to get the 
 You can either provide it directly as a string in your _StringAccessor_ or for better control over the
 element, put the shape(s) definition in the container's `svgDefs` property and reference it with
 [`use`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) tag. For more information on
-providing custom `svgDefs`, visit our [doc](/docs/guides/tips-and-tricks#custom-fills-with-svg-defs) about it.
+providing custom `svgDefs`, visit our [doc](/docs/guides/theming#gradient-fills-with-svg-defs) about it.
 
 Here is an example using the `svgDefs` approach and where every _node_ has the following type:
 

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -176,6 +176,13 @@ const config = {
         path: 'contributing',
         routeBasePath: 'contributing',
         include: ['**/*.md', '**/*.mdx', '../../**.md'],
+        exclude: [
+          '**/node_modules/**',
+          '../../**/node_modules/**',
+          '../../**/.cache/**',
+          '../../**/dist/**',
+          '../../**/build/**',
+        ],
       },
     ],
     [

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -214,10 +214,22 @@ const config = {
             alias: {
               // eslint-disable-next-line @typescript-eslint/no-var-requires
               '@unovis/ts': require('path').resolve(__dirname, '../../packages/ts/dist'),
+              // eslint-disable-next-line @typescript-eslint/no-var-requires
+              '@unovis/react$': require('path').resolve(__dirname, '../../packages/react/src/index.ts'),
+              // eslint-disable-next-line @typescript-eslint/no-var-requires
+              '@unovis/react': require('path').resolve(__dirname, '../../packages/react/src'),
+              // eslint-disable-next-line @typescript-eslint/no-var-requires
+              src: require('path').resolve(__dirname, '../../packages/react/src'),
             },
           },
           module: {
             rules: [
+              {
+                test: /\.m?js$/,
+                resolve: {
+                  fullySpecified: false,
+                },
+              },
               {
                 test: /\.module.ts|component.ts|.svelte|-solid.tsx$/,
                 loader: 'file-loader',

--- a/packages/website/releases/1.3.md
+++ b/packages/website/releases/1.3.md
@@ -13,7 +13,7 @@ Unovis 1.3 introduces [Vue](http://vuejs.org) support and a new pattern theme to
 Long-awaited support for Vue, the third most popular front-end UI framework. Kudos to our community member [@zernonia](https://github.com/zernonia) for this amazing [contribution](https://github.com/f5/unovis/pull/272)!
 
 ### 👨‍🎨 Patterns
-A new theme with pattern fills that can be enabled by adding the `theme-patterns` class to the `body` element of your document. See the [documentation](/docs/guides/theming#applying-patterns) and [this pull request](https://github.com/f5/unovis/pull/275) for more details.
+A new theme with pattern fills that can be enabled by adding the `theme-patterns` class to the `body` element of your document. See the [documentation](/docs/guides/theming#patterns) and [this pull request](https://github.com/f5/unovis/pull/275) for more details.
 
 <img alt="unovis-patterns" src="https://github.com/f5/unovis/assets/52078477/6450b1ac-f95d-4fcf-bf30-fe87a8a375e8"/>
 <img alt="unovis-patterns" src="https://github.com/f5/unovis/assets/52078477/8a0b8f8d-9a28-4352-8b3b-918928241841"/>

--- a/packages/website/releases/1.5.md
+++ b/packages/website/releases/1.5.md
@@ -47,7 +47,7 @@ A ton of new features were added to _Graph_:
 ### 📏 Axis
 <video muted  autoPlay loop style={{ width: "100%" }} src="https://github.com/user-attachments/assets/5cf322a5-b9b6-4e0c-94b4-76c35f6175d1"/>
 
-Axis now automatically hides overlapping labels ([docs](/docs/auxiliary/Axis#hide-overlapping-ticks-15)) and supports label rotation ([docs](/docs/auxiliary/Axis#label-rotation)).
+Axis now automatically hides overlapping labels ([docs](/docs/auxiliary/Axis#hide-overlapping-ticks-15)) and supports label rotation ([docs](/docs/auxiliary/Axis#tick-label-rotation)).
 
 ### 🔵 Bullet Legend
 You can set the orientation of _Bullet Legend_ to `'vertical'` ([docs](/docs/auxiliary/BulletLegend#orientation)).

--- a/scripts/commands-report.js
+++ b/scripts/commands-report.js
@@ -70,7 +70,7 @@ const ROOT_SKIP_EXACT = new Set([
   'lint', // temporarily disabled
   'cmds-report'
 ])
-const ROOT_SKIP_CONTAINS = ['publish', 'update-version']
+const ROOT_SKIP_CONTAINS = ['publish', 'update-version', 'gallery']
 const ROOT_SKIP_STARTS = ['build'] // 'build' and 'build:*'
 
 // Workspace: publish & gallery variants are out. Long-running servers,


### PR DESCRIPTION
This PR fixes the following issues: (See commits for each issue)

- The Vue components were importing types from incorrect paths:
	import type { GraphInputLink, GraphInputNode } from '@/types/graph'
        import type { GenericDataRecord } from '@/types/data'
   Updating [packages/shared/integrations/utils.ts](https://github.com/f5/unovis/compare/qian/fix-path-issue?expand=1#diff-2b33b0a4e1d1c771657adbdcc4b758bbde73ffa450cea790dfe287042f0da9ad) fixes this issue

- Website build was failing, updated docusaurus config file for the fix.
- We have a few anchor that's broken, this PR also addresses that.
- cmds report Phase 4 auto add dev:gallery and the build will hang, removed that from the script.
