### PR TITLE
Component | Sankey: Fix label overlap

### DIFF
--- a/packages/ts/src/components/sankey/modules/node.ts
+++ b/packages/ts/src/components/sankey/modules/node.ts
@@ -236,9 +236,12 @@ export function renderNodeLabels<N extends SankeyInputNode, L extends SankeyInpu
     }
   }
 
-  // Hide intersecting labels
+  // Hide intersecting labels.
+  // Also clear any hover-forced visibility.
   for (const b of labelGroupBBoxes) {
-    b.selection.classed(s.hidden, b.hidden)
+    b.selection
+      .classed(s.hidden, b.hidden)
+      .classed(s.forceShow, false)
   }
 }
 


### PR DESCRIPTION
this PR fixes a bug that was caused by labels stuck in hovered state

### Before:

https://github.com/user-attachments/assets/9fd4543b-d3f9-4e3f-b997-37520a984144

### After:

https://github.com/user-attachments/assets/36c78b57-ffd1-47c1-8fc1-056e689327ba

