### PR TITLE
Misc: Fix dev gallery issue

### DIFF
--- a/packages/angular/src/components.ts
+++ b/packages/angular/src/components.ts
@@ -50,6 +50,9 @@ export { VisPlotlineModule } from './components/plotline/plotline.module'
 export { VisSankeyComponent } from './components/sankey/sankey.component'
 export { VisSankeyModule } from './components/sankey/sankey.module'
 
+export { VisRadialBarComponent } from './components/radial-bar/radial-bar.component'
+export { VisRadialBarModule } from './components/radial-bar/radial-bar.module'
+
 export { VisScatterComponent } from './components/scatter/scatter.component'
 export { VisScatterModule } from './components/scatter/scatter.module'
 
@@ -64,6 +67,9 @@ export { VisXYLabelsModule } from './components/xy-labels/xy-labels.module'
 
 export { VisTopoJSONMapComponent } from './components/topojson-map/topojson-map.component'
 export { VisTopoJSONMapModule } from './components/topojson-map/topojson-map.module'
+
+export { VisTreemapComponent } from './components/treemap/treemap.component'
+export { VisTreemapModule } from './components/treemap/treemap.module'
 
 export { VisPlotbandComponent } from './components/plotband/plotband.component'
 export { VisPlotbandModule } from './components/plotband/plotband.module'

--- a/packages/shared/examples/advanced-leaflet-map/advanced-leaflet-map.svelte
+++ b/packages/shared/examples/advanced-leaflet-map/advanced-leaflet-map.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { VisLeafletMap } from '@unovis/svelte'
-  import { LeafletMap, LeafletMapClusterDatum } from '@unovis/ts'
+  import { LeafletMap } from '@unovis/ts'
+  import type { LeafletMapClusterDatum } from '@unovis/ts'
 
   // Data
-  import { MapPointDataRecord, data, totalEvents, mapStyleLight, mapStyleDark } from './data'
+  import type { MapPointDataRecord } from './data'
+  import { data, totalEvents, mapStyleLight, mapStyleDark } from './data'
 
   let map: VisLeafletMap | undefined
 

--- a/packages/shared/examples/basic-annotations/basic-annotations.svelte
+++ b/packages/shared/examples/basic-annotations/basic-annotations.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Scale } from '@unovis/ts'
   import { VisXYContainer, VisLine, VisStackedBar, VisAxis, VisAnnotations } from '@unovis/svelte'
-  import { data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { data } from './data'
 
   // Scales
   const xScale = Scale.scaleTime()

--- a/packages/shared/examples/basic-boxplot/basic-boxplot.vue
+++ b/packages/shared/examples/basic-boxplot/basic-boxplot.vue
@@ -4,8 +4,8 @@ import { data } from './data'
 </script>
 
 <template>
-  <VisXYContainer :height="600">
-    <VisBoxplot :data :x="d => d.x" :median="d => d.median" :quartiles="d => d.quartiles" :whiskers="d => d.whiskers" />
+  <VisXYContainer :data :height="600">
+    <VisBoxplot :x="d => d.x" :median="d => d.median" :quartiles="d => d.quartiles" :whiskers="d => d.whiskers" />
     <VisAxis type="x" />
     <VisAxis type="y" />
   </VisXYContainer>

--- a/packages/shared/examples/basic-donut-chart/basic-donut-chart.svelte
+++ b/packages/shared/examples/basic-donut-chart/basic-donut-chart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { VisSingleContainer, VisDonut, VisBulletLegend } from '@unovis/svelte'
-  import { data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { data } from './data'
 
   const legendItems = Object.entries(data).map(([_, data]) => ({
     name: data.key.charAt(0).toUpperCase() + data.key.slice(1),

--- a/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.svelte
+++ b/packages/shared/examples/basic-grouped-bar/basic-grouped-bar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { VisXYContainer, VisGroupedBar, VisAxis, VisBulletLegend } from '@unovis/svelte'
-  import { data, colors, capitalize, ElectionDatum } from './data'
+  import type { ElectionDatum } from './data'
+  import { data, colors, capitalize } from './data'
 
   const items = Object.entries(colors).map(([n, c]) => ({
     name: capitalize(n),

--- a/packages/shared/examples/basic-leaflet-map/basic-leaflet-map.svelte
+++ b/packages/shared/examples/basic-leaflet-map/basic-leaflet-map.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisLeafletMap } from '@unovis/svelte'
   // Data
-  import { MapPointDataRecord, data } from './data'
+  import type { MapPointDataRecord } from './data'
+  import { data } from './data'
 
   // !!! Get your own access key from https://maptiler.com
   import { mapKey } from './constants'

--- a/packages/shared/examples/basic-radial-bar-chart/basic-radial-bar-chart.svelte
+++ b/packages/shared/examples/basic-radial-bar-chart/basic-radial-bar-chart.svelte
@@ -2,7 +2,8 @@
   import { VisSingleContainer, VisRadialBar, VisTooltip, VisBulletLegend } from '@unovis/svelte'
   import { RadialBar } from '@unovis/ts'
   import type { RadialBarArcDatum } from '@unovis/ts'
-  import { data, DataRecord, maxValue, completion } from './data'
+  import type { DataRecord } from './data'
+  import { data, maxValue, completion } from './data'
 
   const legendItems = data.map(d => ({ name: d.key }))
 

--- a/packages/shared/examples/basic-sankey/basic-sankey.svelte
+++ b/packages/shared/examples/basic-sankey/basic-sankey.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { FitMode } from '@unovis/ts'
   import { VisSingleContainer, VisSankey } from '@unovis/svelte'
-  import { data, NodeDatum } from './data'
+  import type { NodeDatum } from './data'
+  import { data } from './data'
 
   const subLabel = (d: NodeDatum) => `£${d.value.toFixed(2)}`
 </script>

--- a/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.svelte
+++ b/packages/shared/examples/basic-scatter-plot/basic-scatter-plot.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { NumericAccessor, StringAccessor } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisBulletLegend } from '@unovis/svelte'
-  import { data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { data } from './data'
 
   const legendItems = [
     { name: 'Male', color: '#1fc3aa' },

--- a/packages/shared/examples/basic-timeline/basic-timeline.svelte
+++ b/packages/shared/examples/basic-timeline/basic-timeline.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Timeline } from '@unovis/ts'
   import { VisXYContainer, VisBulletLegend, VisTooltip, VisTimeline, VisAxis } from '@unovis/svelte'
-  import { colorMap, data, DataRecord, ProductType } from './data'
+  import type { DataRecord } from './data'
+  import { colorMap, data, ProductType } from './data'
 
   const labelWidth = 220
   const dateFormatter = Intl.DateTimeFormat().format

--- a/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.svelte
+++ b/packages/shared/examples/brush-grouped-bar/brush-grouped-bar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { BulletLegendItemInterface } from '@unovis/ts'
+  import type { BulletLegendItemInterface } from '@unovis/ts'
   import { VisXYContainer, VisAxis, VisBrush, VisGroupedBar, VisBulletLegend } from '@unovis/svelte'
-  import { data, groups, GroupItem, DataRecord } from './data'
+  import type { GroupItem, DataRecord } from './data'
+  import { data, groups } from './data'
 
   type LegendItem = BulletLegendItemInterface & GroupItem
 

--- a/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.svelte
+++ b/packages/shared/examples/crosshair-stacked-bar/crosshair-stacked-bar.svelte
@@ -2,7 +2,8 @@
   // eslint-disable svelte/no-at-html-tags
   import { Position } from '@unovis/ts'
   import { VisAxis, VisCrosshair, VisStackedBar, VisTooltip, VisXYContainer } from '@unovis/svelte'
-  import { data, labels, DataRecord, FormatConfig } from './data'
+  import type { DataRecord, FormatConfig } from './data'
+  import { data, labels } from './data'
 
   const height = 450
   const x = (d: DataRecord) => d.year

--- a/packages/shared/examples/custom-nodes-graph/custom-nodes-graph.svelte
+++ b/packages/shared/examples/custom-nodes-graph/custom-nodes-graph.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Selection } from 'd3-selection'
-  import { GraphNode, Graph, GraphNodeSelectionHighlightMode } from '@unovis/ts'
+  import { Graph, GraphNodeSelectionHighlightMode } from '@unovis/ts'
+  import type { GraphNode } from '@unovis/ts'
   import { VisSingleContainer, VisGraph, VisTooltip } from '@unovis/svelte'
   import {
     globalControlsContainer,
@@ -11,7 +12,8 @@
     renderSwimlanes,
     updateSwimlanes,
   } from './constants'
-  import { data, DEFAULT_NODE_SIZE, nodeTypeColorMap, CustomGraphNodeType, CustomGraphLink, CustomGraphNode } from './data'
+  import type { CustomGraphLink, CustomGraphNode } from './data'
+  import { data, DEFAULT_NODE_SIZE, nodeTypeColorMap, CustomGraphNodeType } from './data'
 
   let graphRef: any = null
   let selectedNodeId: string | undefined

--- a/packages/shared/examples/dagre-graph/dagre-graph.svelte
+++ b/packages/shared/examples/dagre-graph/dagre-graph.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { GraphLayoutType, GraphNodeShape } from '@unovis/ts'
-  import { data, NodeDatum, LinkDatum } from './data'
+  import type { NodeDatum, LinkDatum } from './data'
+  import { data } from './data'
 
   const layoutType = GraphLayoutType.Dagre
   const nodeLabel = (n: NodeDatum) => n.label

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.component.html
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.component.html
@@ -1,35 +1,39 @@
-<vis-xy-container
-  [data]="data"
-  [margin]="margin"
-  [autoMargin]="false"
-  [width]="'100%'"
-  [height]="'40vh'"
->
-  <vis-area [x]="chartX" [y]="chartAY" opacity="0.9" />
-  <vis-axis type='x' [numTicks]="3" [tickFormat]="xTicks" label="Time"/>
-  <vis-axis type='y'
-    [tickFormat]="chartAYTicks"
-    [tickTextWidth]="60"
-    [tickTextColor]="'#FF6B7E'"
-    [labelColor]="'#FF6B7E'"
-    label="Traffic"
-  />
+<div style="position: relative;">
+  <vis-xy-container
+    [data]="data"
+    [margin]="margin"
+    [autoMargin]="false"
+    [width]="'100%'"
+    [height]="'40vh'"
+  >
+    <vis-area [x]="chartX" [y]="chartAY" opacity="0.9" />
+    <vis-axis type='x' [numTicks]="3" [tickFormat]="xTicks" label="Time"/>
+    <vis-axis type='y'
+      [tickFormat]="chartAYTicks"
+      [tickTextWidth]="60"
+      [tickTextColor]="'#4D8CFD'"
+      [labelColor]="'#4D8CFD'"
+      label="Traffic"
+    />
   </vis-xy-container>
-<vis-xy-container
-  [data]="data"
-  [yDomain]="[0, 150]"
-  [margin]="margin"
-  [autoMargin]="false"
-  [style]="style"
->
-  <vis-line [x]="chartX" [y]="chartBY" color='#FF6B7E' />
-  <vis-axis
-    type="y"
-    [position]="'right'"
-    [tickFormat]="chartBYTicks"
-    [gridLine]="false"
-    [tickTextColor]="'#4D8CFD'"
-    [labelColor]="'#4D8CFD'"
-    label="Signal Strength"
-  />
-</vis-xy-container>
+  <vis-xy-container
+    class="chart-overlay"
+    [data]="data"
+    [yDomain]="[0, 150]"
+    [margin]="margin"
+    [autoMargin]="false"
+    [width]="'100%'"
+    [height]="'40vh'"
+  >
+    <vis-line [x]="chartX" [y]="chartBY" color='#FF6B7E' />
+    <vis-axis
+      type="y"
+      [position]="'right'"
+      [tickFormat]="chartBYTicks"
+      [gridLine]="false"
+      [tickTextColor]="'#FF6B7E'"
+      [labelColor]="'#FF6B7E'"
+      label="Signal Strength"
+    />
+  </vis-xy-container>
+</div>

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.component.ts
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.component.ts
@@ -1,15 +1,23 @@
-import { Component } from '@angular/core'
+import { Component, ViewEncapsulation } from '@angular/core'
 import { XYDataRecord, generateXYDataRecords } from './data'
 
 @Component({
   selector: 'dual-axis-chart',
   templateUrl: './dual-axis-chart.component.html',
+  encapsulation: ViewEncapsulation.None,
+  styles: [`
+    dual-axis-chart .chart-overlay {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+    }
+  `],
 })
 export class DualAxisChartComponent {
   data = generateXYDataRecords(150)
 
   margin = { left: 100, right: 100, top: 40, bottom: 60 }
-  style = { position: 'absolute', top: 0, left: 0, width: '100%', height: '40vh' }
 
   chartX = (d: XYDataRecord): number => d.x
   chartAY = (d: XYDataRecord, i: number): number => i * (d.y || 0)

--- a/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
+++ b/packages/shared/examples/dual-axis-chart/dual-axis-chart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 
   import { VisXYContainer, VisArea, VisAxis, VisLine } from '@unovis/svelte'
-  import { XYDataRecord, generateXYDataRecords } from './data'
+  import type { XYDataRecord } from './data'
+  import { generateXYDataRecords } from './data'
 
   const margin = { left: 100, right: 100, top: 40, bottom: 60 }
   const chartX = d => d.x

--- a/packages/shared/examples/elk-layered-graph/elk-layered-graph.svelte
+++ b/packages/shared/examples/elk-layered-graph/elk-layered-graph.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { GraphLayoutType, GraphNodeShape } from '@unovis/ts'
-  import { data, NodeDatum, LinkDatum, panels } from './data'
+  import type { NodeDatum, LinkDatum } from './data'
+  import { data, panels } from './data'
 
   const layoutElkSettings = {
     'layered.crossingMinimization.forceNodeModelOrder': 'true',

--- a/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
+++ b/packages/shared/examples/expandable-sankey/expandable-sankey.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { FitMode, Sankey, SankeyLink, SankeyNode, SankeySubLabelPlacement, VerticalAlign } from '@unovis/ts'
+  import { FitMode, Sankey, SankeySubLabelPlacement, VerticalAlign } from '@unovis/ts'
+  import type { SankeyLink, SankeyNode } from '@unovis/ts'
   import { VisSingleContainer, VisSankey } from '@unovis/svelte'
-  import { sankeyData, root, Node, Link } from './data'
+  import type { Node, Link } from './data'
+  import { sankeyData, root } from './data'
 
   let data = { nodes: sankeyData.nodes, links: sankeyData.links }
 

--- a/packages/shared/examples/force-graph/force-graph.svelte
+++ b/packages/shared/examples/force-graph/force-graph.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
-  import { GraphForceLayoutSettings, GraphLayoutType } from '@unovis/ts'
-  import { data, LinkDatum, NodeDatum } from './data'
+  import { GraphLayoutType } from '@unovis/ts'
+  import type { GraphForceLayoutSettings } from '@unovis/ts'
+  import type { LinkDatum, NodeDatum } from './data'
+  import { data } from './data'
 
   const forceLayoutSettings: GraphForceLayoutSettings = {
     forceXStrength: 0.2,

--- a/packages/shared/examples/free-brush-scatters/free-brush-scatters.svelte
+++ b/packages/shared/examples/free-brush-scatters/free-brush-scatters.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { FreeBrushMode, Scale, Position } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisBulletLegend, VisFreeBrush } from '@unovis/svelte'
-  import { palette, data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { palette, data } from './data'
 
   const categories = [...new Set(data.map((d: DataRecord) => d.category))].sort()
   const colorScale = Scale.scaleOrdinal(palette).domain(categories)

--- a/packages/shared/examples/github-style-heatmap/github-style-heatmap.svelte
+++ b/packages/shared/examples/github-style-heatmap/github-style-heatmap.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisSingleContainer, VisHeatmap } from '@unovis/svelte'
   import { Sizing } from '@unovis/ts'
-  import { data, DataRecord, numRows, offset, columnLabel, rowLabel } from './data'
+  import type { DataRecord } from './data'
+  import { data, numRows, offset, columnLabel, rowLabel } from './data'
 
   const value = (d: DataRecord): number | undefined => d.count || undefined
 </script>

--- a/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.svelte
+++ b/packages/shared/examples/hierarchical-chord-diagram/hierarchical-chord-diagram.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { VisSingleContainer, VisChordDiagram } from '@unovis/svelte'
-  import { ChordHierarchyNode, ChordLabelAlignment } from '@unovis/ts'
-  import { colorMap, links, nodes, LinkDatum, NodeDatum } from './data'
+  import { ChordLabelAlignment } from '@unovis/ts'
+  import type { ChordHierarchyNode } from '@unovis/ts'
+  import type { LinkDatum, NodeDatum } from './data'
+  import { colorMap, links, nodes } from './data'
 
   const data = { links, nodes }
   const linkColor = (l: LinkDatum) => colorMap.get(l.source.country)

--- a/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.svelte
+++ b/packages/shared/examples/horizontal-stacked-bar-chart/horizontal-stacked-bar-chart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisXYContainer, VisStackedBar, VisAxis, VisBulletLegend, VisTooltip } from '@unovis/svelte'
   import { FitMode, Direction, Orientation, StackedBar } from '@unovis/ts'
-  import { data, labels, EducationDatum } from './data'
+  import type { EducationDatum } from './data'
+  import { data, labels } from './data'
 
   const chartLabels = Object.entries(labels).map(([k, v], i) => ({
     key: k,

--- a/packages/shared/examples/leaflet-flow-map/leaflet-flow-map.svelte
+++ b/packages/shared/examples/leaflet-flow-map/leaflet-flow-map.svelte
@@ -2,7 +2,8 @@
   import { VisLeafletFlowMap } from '@unovis/svelte'
 
   // Data
-  import { MapPointDataRecord, MapFlowDataRecord, data } from './data'
+  import type { MapPointDataRecord, MapFlowDataRecord } from './data'
+  import { data } from './data'
 
   // !!! Get your own access key from https://maptiler.com
   import { mapKey } from './constants'

--- a/packages/shared/examples/multi-line-chart/multi-line-chart.svelte
+++ b/packages/shared/examples/multi-line-chart/multi-line-chart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Scale } from '@unovis/ts'
   import { VisXYContainer, VisLine, VisAxis, VisBulletLegend } from '@unovis/svelte'
-  import { data, labels, CityTemps } from './data'
+  import type { CityTemps } from './data'
+  import { data, labels } from './data'
 
   const x = (d: CityTemps) => +(new Date(d.date))
   const y = [

--- a/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
+++ b/packages/shared/examples/non-stacked-area-chart/non-stacked-area-chart.svelte
@@ -2,7 +2,8 @@
   import type { NumericAccessor } from '@unovis/ts'
   import { CurveType } from '@unovis/ts'
   import { VisXYContainer, VisAxis, VisArea, VisBulletLegend } from '@unovis/svelte'
-  import { countries, Country, data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { countries, Country, data } from './data'
 
   const x = (_: DataRecord, i: number) => i
   const accessors = (id: Country): { y: NumericAccessor<DataRecord>; color: string } => ({

--- a/packages/shared/examples/parallel-graph/parallel-graph.svelte
+++ b/packages/shared/examples/parallel-graph/parallel-graph.svelte
@@ -2,7 +2,8 @@
   import { VisSingleContainer, VisGraph } from '@unovis/svelte'
   import { Graph, GraphLayoutType } from '@unovis/ts'
 
-  import { nodes, links, sites, StatusMap, NodeDatum, LinkDatum } from './data'
+  import type { NodeDatum, LinkDatum } from './data'
+  import { nodes, links, sites, StatusMap } from './data'
 
   const mainSite = nodes[0].site
 

--- a/packages/shared/examples/parallel-graph/parallel-graph.ts
+++ b/packages/shared/examples/parallel-graph/parallel-graph.ts
@@ -9,7 +9,7 @@ container.classList.add('chart')
 const mainSite = nodes[0].site
 
 const chart = new SingleContainer(container, {
-  height: '65h',
+  height: '65vh',
   component: new Graph<NodeDatum, LinkDatum>({
     layoutType: GraphLayoutType.Parallel,
     layoutGroupOrder: ['west', mainSite, 'east'],

--- a/packages/shared/examples/plotband-plotline/plotband-plotline.svelte
+++ b/packages/shared/examples/plotband-plotline/plotband-plotline.svelte
@@ -3,14 +3,12 @@
   import { data } from './data'
 </script>
 
-<template>
-  <VisXYContainer :height="600">
-    <VisLine {data} x={d => d.x} y={d => d.y} />
-    <VisAxis type="x" />
-    <VisAxis type="y" />
-    <VisPlotband from={4} to={6} labelText="Plot band on x-axis" axis="x" labelPosition="top-inside" />
-    <VisPlotband from={1} to={3} color="rgba(34, 99, 182, 0.3)" labelText="Plot band on y-axis" labelPosition="left-inside" />
-    <VisPlotline value={6} color="rgba(7, 114, 21, 1)" labelText="Plot line on y-axis" labelPosition="top-left" />
-    <VisPlotline value={10} color="rgba(220, 114, 0, 1)" axis="x" labelOrientation="vertical" labelText="Plot line on x-axis" />
-  </VisXYContainer>
-</template>
+<VisXYContainer height={600}>
+  <VisLine {data} x={d => d.x} y={d => d.y} />
+  <VisAxis type="x" />
+  <VisAxis type="y" />
+  <VisPlotband from={4} to={6} labelText="Plot band on x-axis" axis="x" labelPosition="top-inside" />
+  <VisPlotband from={1} to={3} color="rgba(34, 99, 182, 0.3)" labelText="Plot band on y-axis" labelPosition="left-inside" />
+  <VisPlotline value={6} color="rgba(7, 114, 21, 1)" labelText="Plot line on y-axis" labelPosition="top-left" />
+  <VisPlotline value={10} color="rgba(220, 114, 0, 1)" axis="x" labelOrientation="vertical" labelText="Plot line on x-axis" />
+</VisXYContainer>

--- a/packages/shared/examples/range-plot/range-plot.svelte
+++ b/packages/shared/examples/range-plot/range-plot.svelte
@@ -2,7 +2,8 @@
 
   import { VisXYContainer, VisBulletLegend, VisTooltip, VisAxis, VisScatter, VisLine } from '@unovis/svelte'
   import { Scale, Scatter } from '@unovis/ts'
-  import { data, DataRecord, processLineData } from './data'
+  import type { DataRecord } from './data'
+  import { data, processLineData } from './data'
 
   const height = 1600
   const yScale = Scale.scalePoint([0, 800]).domain(data.map(d => d.occupation))

--- a/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.svelte
+++ b/packages/shared/examples/shaped-scatter-plot/shaped-scatter-plot.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Position, Scale, Scatter, colors } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisTooltip, VisBulletLegend } from '@unovis/svelte'
-  import { data, DataRecord, shapes, categories, sumCategories } from './data'
+  import type { DataRecord } from './data'
+  import { data, shapes, categories, sumCategories } from './data'
 
   const shapeScale = Scale.scaleOrdinal(shapes).domain(categories)
   const colorScale = Scale.scaleOrdinal(colors).domain(categories)

--- a/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.svelte
+++ b/packages/shared/examples/sized-scatter-plot/sized-scatter-plot.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Position, Scale, Scatter } from '@unovis/ts'
   import { VisXYContainer, VisScatter, VisAxis, VisTooltip, VisBulletLegend } from '@unovis/svelte'
-  import { palette, data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { palette, data } from './data'
 
   const categories = [...new Set(data.map((d: DataRecord) => d.category))].sort()
   const colorScale = Scale.scaleOrdinal(palette).domain(categories)

--- a/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.svelte
+++ b/packages/shared/examples/stacked-area-chart-with-attributes/stacked-area-chart-with-attributes.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { Area } from '@unovis/ts'
   import { VisXYContainer, VisBulletLegend, VisAxis, VisArea } from '@unovis/svelte'
-  import { data, countries, FoodExportData, bulletLegends } from './data'
+  import type { FoodExportData } from './data'
+  import { data, countries, bulletLegends } from './data'
 
   const x = (d: FoodExportData) => d.year
   const y = countries.map(g => (d: FoodExportData) => d[g])

--- a/packages/shared/examples/stacked-area-chart/stacked-area-chart.svelte
+++ b/packages/shared/examples/stacked-area-chart/stacked-area-chart.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { VisXYContainer, VisAxis, VisArea, VisXYLabels } from '@unovis/svelte'
-  import { data, formats, DataRecord, getLabels } from './data'
+  import type { DataRecord } from './data'
+  import { data, formats, getLabels } from './data'
 
   const labels = getLabels(data)
 

--- a/packages/shared/examples/step-area-chart/step-area-chart.svelte
+++ b/packages/shared/examples/step-area-chart/step-area-chart.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { BulletLegendItemInterface } from '@unovis/ts'
+  import type { BulletLegendItemInterface } from '@unovis/ts'
   import { VisXYContainer, VisArea, VisAxis, VisBulletLegend } from '@unovis/svelte'
-  import { candidates, data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { candidates, data } from './data'
 
   let curr = candidates[0].name
 

--- a/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
+++ b/packages/shared/examples/sunburst-nested-donut/sunburst-nested-donut.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { VisSingleContainer, VisNestedDonut } from '@unovis/svelte'
-  import { NestedDonutSegment } from '@unovis/ts'
-  import { colors, data, Datum } from './data'
+  import type { NestedDonutSegment } from '@unovis/ts'
+  import type { Datum } from './data'
+  import { colors, data } from './data'
 
   const layers = [
     (d: Datum) => d.type,

--- a/packages/shared/examples/synced-crosshairs/synced-crosshairs.svelte
+++ b/packages/shared/examples/synced-crosshairs/synced-crosshairs.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { VisXYContainer, VisArea, VisLine, VisAxis, VisCrosshair, VisTooltip } from '@unovis/svelte'
-  import { data, accessors, XYDataRecord } from './data'
+  import type { XYDataRecord } from './data'
+  import { data, accessors } from './data'
 
   let forcePosition: number | undefined = 75
 

--- a/packages/shared/examples/topojson-map/topojson-map.svelte
+++ b/packages/shared/examples/topojson-map/topojson-map.svelte
@@ -2,7 +2,8 @@
   import { Orientation, Scale, TopoJSONMap } from '@unovis/ts'
   import { WorldMapTopoJSON } from '@unovis/ts/maps'
   import { VisSingleContainer, VisTopoJSONMap, VisTooltip, VisAxis, VisXYContainer, VisStackedBar } from '@unovis/svelte'
-  import { palette, data, ageRange, yearRange, AreaDatum } from './data'
+  import type { AreaDatum } from './data'
+  import { palette, data, ageRange, yearRange } from './data'
 
   const mapData = { areas: data }
   const range = yearRange[1] - yearRange[0]

--- a/packages/shared/examples/treemap/treemap.svelte
+++ b/packages/shared/examples/treemap/treemap.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { VisSingleContainer, VisTreemap, VisBulletLegend, VisTooltip } from '@unovis/svelte'
-  import { data, DataRecord } from './data'
+  import type { DataRecord } from './data'
+  import { data } from './data'
   import { colors, Position, Treemap } from '@unovis/ts'
   import { format } from 'd3-format'
 

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, transformWithEsbuild } from 'vite'
 import { fileURLToPath } from 'node:url'
 import { resolve, dirname } from 'node:path'
 import { readFile } from 'node:fs/promises'
@@ -8,7 +8,6 @@ import react from '@vitejs/plugin-react'
 import vue from '@vitejs/plugin-vue'
 import solid from 'vite-plugin-solid'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
-import sveltePreprocess from 'svelte-preprocess'
 
 const here = fileURLToPath(new URL('.', import.meta.url))
 const pkgSrc = (name: string): string => resolve(here, '..', name, 'src')
@@ -118,14 +117,88 @@ export default defineConfig({
     }),
     vue(),
     // The @unovis/svelte source uses TS syntax in <script> blocks WITHOUT
-    // declaring `lang="ts"`. `svelte-preprocess` (also used by the published
-    // build via packages/svelte/svelte.config.js) treats every script as TS,
-    // strips type-only imports, and handles `$$Generic`.
+    // declaring `lang="ts"`. We use a lightweight custom preprocessor that
+    // strips types via `transformWithEsbuild` — the old `svelte-preprocess@4`
+    // hardcodes the removed `importsNotUsedAsValues` compiler option which
+    // errors on TypeScript 5.5+.
     // `hot: false` disables svelte-hmr's proxy wrapping. The proxy breaks
     // Svelte's lifecycle when we mount via `new Component({target})` outside a
     // tracked container — onMount callbacks never fire under the proxy here.
     svelte({
-      preprocess: sveltePreprocess({ typescript: { tsconfigFile: false } }),
+      preprocess: {
+        async script ({ content, attributes, filename }) {
+          // Treat all <script> blocks as TS (the @unovis/svelte source omits lang="ts" on some files)
+          if (attributes.lang && attributes.lang !== 'ts' && attributes.lang !== 'typescript') return
+
+          // Example files live in packages/shared/examples/ — their imports are
+          // only referenced in the Svelte template. Internal @unovis/svelte
+          // components reference their imports in the script body, so esbuild
+          // can safely tree-shake unused (type-only) imports for those.
+          const isExample = !!filename && /[/\\]examples[/\\]/.test(filename)
+
+          if (!isExample) {
+            // Internal components: just strip types, let esbuild elide type imports
+            const result = await transformWithEsbuild(content, filename ?? 'script.ts', {
+              loader: 'ts',
+              sourcemap: false,
+              tsconfigRaw: { compilerOptions: {} },
+            })
+            return { code: result.code }
+          }
+
+          // Example files: imports are only referenced in the Svelte template,
+          // so esbuild considers them unused. Append a synthetic re-export to
+          // force preservation, then strip it from the output.
+          //
+          // IMPORTANT: only add names from regular `import { }` statements to
+          // the sentinel — never names from `import type { }`. The sentinel
+          // makes esbuild keep the import statement (because the name now has a
+          // value usage), but `export type Foo` is not a real runtime binding.
+          // If such a name survives the sentinel strip Vite raises at load time:
+          // "does not provide an export named 'Foo'".
+          //
+          // Rule: use `import type { TypeName }` (separate from value imports)
+          // for any TypeScript-only name from local modules — then the regex
+          // below never captures it and esbuild correctly elides it.
+          const importNames = new Set<string>()
+          const importRe = /import\s+\{([^}]+)\}\s+from\s+['"][^'"]+['"]/g
+          let m: RegExpExecArray | null
+          while ((m = importRe.exec(content)) !== null) {
+            for (const name of m[1].split(',')) {
+              const raw = name.trim()
+              // Skip inline `type` modifiers: `import { type Foo, Bar }` → skip Foo
+              if (raw.startsWith('type ')) continue
+              const trimmed = raw.split(/\s+as\s+/).pop()!.trim()
+              if (trimmed) importNames.add(trimmed)
+            }
+          }
+          // Also handle default imports: import Foo from '...'
+          // Only PascalCase/UPPER_CASE names — lowercase defaults (e.g. `import d3 from 'd3'`)
+          // are never used as template-level bindings so we intentionally skip them.
+          const defaultRe = /import\s+([A-Z_$][\w$]*)\s+from\s+['"][^'"]+['"]/g
+          while ((m = defaultRe.exec(content)) !== null) {
+            importNames.add(m[1])
+          }
+          // Use a uniquely-named const as the sentinel so we can strip it by name
+          // rather than relying on "last export statement" position, which would
+          // silently corrupt files that already end with a legitimate export {}.
+          const MARKER = '__UNOVIS_SENTINEL__'
+          const sentinel = importNames.size
+            ? `\nconst ${MARKER} = { ${[...importNames].join(', ')} }`
+            : ''
+          const input = sentinel ? content + sentinel : content
+          const result = await transformWithEsbuild(input, filename ?? 'script.ts', {
+            loader: 'ts',
+            sourcemap: false,
+            tsconfigRaw: { compilerOptions: {} },
+          })
+          // Strip the synthetic sentinel const
+          const code = sentinel
+            ? result.code.replace(new RegExp(`\\nconst ${MARKER}[^;]+;\\n?`), '\n')
+            : result.code
+          return { code }
+        },
+      },
       hot: false,
     }),
   ],
@@ -142,14 +215,14 @@ export default defineConfig({
       // Mirror the workspace path aliases that `@unovis/ts` uses internally via
       // tsconfig `paths` (see packages/ts/tsconfig.json). Webpack does the same
       // in packages/dev/webpack.config.js. Order matters — more specific first.
-      'types/': `${pkgSrc('ts')}/types/`,
-      'utils/': `${pkgSrc('ts')}/utils/`,
-      'core/': `${pkgSrc('ts')}/core/`,
-      'components/': `${pkgSrc('ts')}/components/`,
-      'containers/': `${pkgSrc('ts')}/containers/`,
-      'styles/': `${pkgSrc('ts')}/styles/`,
-      'data-models/': `${pkgSrc('ts')}/data-models/`,
-      'data/': `${pkgSrc('ts')}/data/`,
+      '@/types/': `${pkgSrc('ts')}/types/`,
+      '@/utils/': `${pkgSrc('ts')}/utils/`,
+      '@/core/': `${pkgSrc('ts')}/core/`,
+      '@/components/': `${pkgSrc('ts')}/components/`,
+      '@/containers/': `${pkgSrc('ts')}/containers/`,
+      '@/styles/': `${pkgSrc('ts')}/styles/`,
+      '@/data-models/': `${pkgSrc('ts')}/data-models/`,
+      '@/data/': `${pkgSrc('ts')}/data/`,
       // Used in packages/react/src/html-components/**/index.tsx
       'src/utils/react': `${pkgSrc('react')}/utils/react`,
       '@unovis/ts': pkgSrc('ts'),

--- a/packages/ts/src/components.ts
+++ b/packages/ts/src/components.ts
@@ -74,6 +74,7 @@ export type {
   MapFeature,
 } from './components/topojson-map/types'
 export type { LeafletMapConfigInterface } from './components/leaflet-map/config'
+export type { LeafletMapClusterDatum } from './components/leaflet-map/types'
 export type { LeafletFlowMapConfigInterface } from './components/leaflet-flow-map/config'
 export type { ChordDiagramConfigInterface } from './components/chord-diagram/config'
 export type { GraphConfigInterface } from './components/graph/config'

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -433,12 +433,14 @@ export class XYContainer<Datum> extends ContainerCore {
 
   private _getMargin (): Spacing {
     const { config: { margin } } = this
+    const defaultMargin = { top: 0, bottom: 0, left: 0, right: 0 }
+    const m = margin || defaultMargin
 
     return {
-      top: margin.top + this._axisMargin.top,
-      bottom: margin.bottom + this._axisMargin.bottom,
-      left: margin.left + this._axisMargin.left,
-      right: margin.right + this._axisMargin.right,
+      top: m.top + this._axisMargin.top,
+      bottom: m.bottom + this._axisMargin.bottom,
+      left: m.left + this._axisMargin.left,
+      right: m.right + this._axisMargin.right,
     }
   }
 

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -437,10 +437,10 @@ export class XYContainer<Datum> extends ContainerCore {
     const m = margin || defaultMargin
 
     return {
-      top: m.top + this._axisMargin.top,
-      bottom: m.bottom + this._axisMargin.bottom,
-      left: m.left + this._axisMargin.left,
-      right: m.right + this._axisMargin.right,
+      top: (m.top || 0) + this._axisMargin.top,
+      bottom: (m.bottom || 0) + this._axisMargin.bottom,
+      left: (m.left || 0) + this._axisMargin.left,
+      right: (m.right || 0) + this._axisMargin.right,
     }
   }
 


### PR DESCRIPTION
# pnpm dev:gallery  command got broken After TypeScript 5.5 Upgrade

## Problem

The Vite-based dev gallery (multi-framework preview server) broke after upgrading to TypeScript 5.5+. The root cause: `svelte-preprocess@4` hardcodes the `importsNotUsedAsValues` compiler option, which was removed in TS 5.5, causing a compile error on startup.

## Impact

| Area | Before | After |
|------|--------|-------|
| Dev gallery startup | ❌ Crashes (TS 5.5 error) | ✅ Starts correctly |
| `@/types/` aliases | ❌ Not resolved (wrong prefix) | ✅ Resolved |
| Angular Treemap | ❌ Not importable from `@unovis/angular` | ✅ Exported |
| Angular RadialBar | ❌ Not importable from `@unovis/angular` | ✅ Exported |
| `LeafletMapClusterDatum` | ❌ Missing from public API | ✅ Exported |
| Angular dual-axis-chart | ❌ Second axis rendered outside chart | ✅ Correctly overlaid |
| Vue basic-boxplot | ❌ Empty chart (no data) | ✅ Renders correctly |


## Before
<img width="1366" height="811" alt="image" src="https://github.com/user-attachments/assets/c1fd6d18-8432-4f55-b8d1-28b67ed4013f" />

## After
<img width="1721" height="1040" alt="image" src="https://github.com/user-attachments/assets/0e2c5023-1748-4bde-b669-2bf51255ce4b" />
