### PR TITLE
Vue | Crosshair | Timeline | Boxplot: Fix data prop dropped by misplaced @vue-ignore annotation

### DIFF
--- a/packages/vue/autogen/component.ts
+++ b/packages/vue/autogen/component.ts
@@ -34,7 +34,7 @@ ${isStandAlone ? '' : `import { ${elementSuffix}AccessorKey } from '../../utils/
 ${isStandAlone ? '' : `const accessor = inject(${elementSuffix}AccessorKey)\n`}
 // data and required props ${isComplexPropComponent ? '\n// !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412' : ''}
 ${isComplexPropComponent
-    ? `const props = defineProps</** @vue-ignore */ ${componentName}ConfigInterface${genericsStr} & { data?: ${dataType} }>()`
+    ? `const props = defineProps<{ data?: ${dataType} } & /** @vue-ignore */ ${componentName}ConfigInterface${genericsStr}>()`
     : `type Props = ${componentName}ConfigInterface${genericsStr}\nconst props = defineProps<Props & { data?: ${dataType} }>()`}
 
 ${propDefs.length && !isStandAlone ? `${propDefs.join('\n')}` : isStandAlone ? 'const data = computed(() => props.data)' : ''}

--- a/packages/vue/src/components/boxplot/index.vue
+++ b/packages/vue/src/components/boxplot/index.vue
@@ -6,12 +6,12 @@ import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from '
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 
+// data and required props
 // !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412
-const props = defineProps</** @vue-ignore */ BoxplotConfigInterface<Datum> & { data?: Datum[] }>()
+const props = defineProps<{ data?: Datum[] } & /** @vue-ignore */ BoxplotConfigInterface<Datum>>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)

--- a/packages/vue/src/components/crosshair/index.vue
+++ b/packages/vue/src/components/crosshair/index.vue
@@ -8,7 +8,7 @@ import { arePropsEqual, useForwardProps } from '../../utils/props'
 
 // data and required props
 // !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412
-const props = defineProps</** @vue-ignore */ CrosshairConfigInterface<Datum> & { data?: Datum[] }>()
+const props = defineProps<{ data?: Datum[] } & /** @vue-ignore */ CrosshairConfigInterface<Datum>>()
 
 const accessor = inject(crosshairAccessorKey)
 

--- a/packages/vue/src/components/timeline/index.vue
+++ b/packages/vue/src/components/timeline/index.vue
@@ -8,7 +8,7 @@ import { arePropsEqual, useForwardProps } from '../../utils/props'
 
 // data and required props
 // !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412
-const props = defineProps</** @vue-ignore */ TimelineConfigInterface<Datum> & { data?: Datum[] }>()
+const props = defineProps<{ data?: Datum[] } & /** @vue-ignore */ TimelineConfigInterface<Datum>>()
 
 const accessor = inject(componentAccessorKey)
 


### PR DESCRIPTION
Addresses #855

Since 1.6.5, the Vue wrappers for the three "complex prop" components (Crosshair, Timeline, Boxplot) compiled with no runtime props at all, so their own `data` prop was silently ignored: `props.data` was always undefined and, for example, the crosshair tooltip template received `undefined` unless data was set on the container instead.

Root cause: commit d4a22d21 changed the autogen output from an interface-extends pattern to an inline intersection with the ignore annotation in front:
```
  defineProps</** @vue-ignore */ Config<Datum> & { data?: Datum[] }>()
```

Babel attaches a leading comment at the start of a type to the whole TSIntersectionType node, and @vue/compiler-sfc checks for @vue-ignore on a node before recursing into its members - so the entire type, including { data?: Datum[] }, resolved to zero props.

Fix: reorder the intersection so the annotation attaches only to the config member:
```
  defineProps<{ data?: Datum[] } & /** @vue-ignore */ Config<Datum>>()
```
The compiled components now declare `props: { data: {} }` again, byte-identical to the 1.6.4 output, while config props keep flowing through as fallthrough attrs (which useForwardProps reads from attrs). The emitted d.ts still exposes the full Config<Datum> & { data } typing.

Note: reverting to the 1.6.4 interface-extends form is not possible - current vue-tsc fails it with TS4082 (private name 'Props' in the default export), which is the build error that motivated d4a22d21. The reordered intersection avoids both problems.