### PR TITLE
Component | Donut: Fix jump before animation when switching between full and half

### DIFF
--- a/packages/ts/src/components/donut/index.ts
+++ b/packages/ts/src/components/donut/index.ts
@@ -1,4 +1,6 @@
 import { Selection } from 'd3-selection'
+import { Transition } from 'd3-transition'
+import { interpolate } from 'd3-interpolate'
 import { pie, arc } from 'd3-shape'
 
 // Core
@@ -20,7 +22,7 @@ import { DonutArcDatum, DonutArcAnimState, DonutDatum } from './types'
 import { DonutDefaultConfig, DonutConfigInterface } from './config'
 
 // Modules
-import { createArc, updateArc, removeArc } from './modules/arc'
+import { createArc, updateArc, removeArc, ArcNode } from './modules/arc'
 
 // Constants
 import { DONUT_HALF_ANGLE_RANGES } from './constants'
@@ -43,6 +45,9 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
 
   events = {
   }
+
+  // Skip position animation on the first render, nothing to morph from yet.
+  private _firstRender = true
 
   constructor (config?: DonutConfigInterface<Datum>) {
     super()
@@ -100,7 +105,11 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
     const translateX = this._width / 2 + (isHalfDonutLeft ? outerRadius / 2 : isHalfDonutRight ? -outerRadius / 2 : 0)
     const translate = `translate(${translateX},${translateY})`
 
-    this.arcGroup.attr('transform', translate)
+    const positionDuration = this._firstRender ? 0 : duration
+
+    // Animate position together with the arcs. Otherwise switching between
+    // full and half jumps to the new layout first and animates after.
+    smartTransition(this.arcGroup, positionDuration).attr('transform', translate)
 
     this.arcGen
       .startAngle(d => d.startAngle)
@@ -178,21 +187,44 @@ export class Donut<Datum> extends ComponentCore<Datum[], DonutConfigInterface<Da
       labelTranslateY = halfDonutLabelOffsetY + translateY
     }
     const labelTranslate = `translate(${labelTranslateX},${labelTranslateY})`
-    this.centralLabel.attr('transform', labelTranslate)
-    this.centralSubLabel.attr('transform', labelTranslate)
+    smartTransition(this.centralLabel, positionDuration).attr('transform', labelTranslate)
+    smartTransition(this.centralSubLabel, positionDuration).attr('transform', labelTranslate)
 
     // Background
     this.arcBackground.attr('class', s.background)
       .attr('visibility', config.showBackground ? null : 'hidden')
-      .attr('transform', translate)
 
-    smartTransition(this.arcBackground, duration)
-      .attr('d', this.arcGen({
-        startAngle: config.backgroundAngleRange?.[0] ?? config.angleRange?.[0] ?? 0,
-        endAngle: config.backgroundAngleRange?.[1] ?? config.angleRange?.[1] ?? 2 * Math.PI,
-        innerRadius,
-        outerRadius,
-      }))
+    const backgroundAnimState: DonutArcAnimState = {
+      startAngle: config.backgroundAngleRange?.[0] ?? config.angleRange?.[0] ?? 0,
+      endAngle: config.backgroundAngleRange?.[1] ?? config.angleRange?.[1] ?? 2 * Math.PI,
+      innerRadius,
+      outerRadius,
+    }
+
+    if (positionDuration) {
+      // Tween the angle/radius values and rebuild the path each tick, same
+      // as the arc segments do via updateArc. Letting D3 interpolate the d
+      // string directly breaks the arc flags, they become non-integer
+      // mid-transition and the browser rejects them.
+      const node = this.arcBackground.node() as ArcNode
+      const prevAnimState = node._animState ?? backgroundAnimState
+      const interpolateState = interpolate(prevAnimState, backgroundAnimState)
+      const transition = smartTransition(this.arcBackground, positionDuration)
+        .attr('transform', translate) as Transition<SVGPathElement, unknown, SVGGElement, unknown>
+
+      transition.attrTween('d', () => (t: number): string => {
+        node._animState = interpolateState(t)
+        return this.arcGen(node._animState as DonutArcAnimState)
+      })
+    } else {
+      const node = this.arcBackground.node() as ArcNode
+      node._animState = backgroundAnimState
+      this.arcBackground
+        .attr('transform', translate)
+        .attr('d', this.arcGen(backgroundAnimState))
+    }
+
+    this._firstRender = false
   }
 }
 


### PR DESCRIPTION
## Summary
Animate the group, label, and background transforms together with the arc segments instead of setting them instantly, so switching angleRange (e.g. full to half) morphs continuously instead of snapping to the new layout before the arcs animate. Also fixes the background's `d` attribute being interpolated as a plain string, which produced invalid arc flags mid-transition (`Expected arc flag ('0' or '1')` console errors), by tweening the underlying angle/radius state and rebuilding the path each tick like the arc segments already do via `updateArc`.

## Preview
<img width="532" height="640" alt="ezgif-57d33d47bb15fd15" src="https://github.com/user-attachments/assets/db9d7450-a8e2-4e8d-9038-d8acfe098978" />
