### PR TITLE
Component | Tooltip: Fix fade-in animation and follow-cursor freeze over trigger gaps

### DIFF
--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -135,9 +135,9 @@ export class Tooltip {
 
   private _display (): void {
     window.clearTimeout(this._hideDelayTimeoutId)
-    this.div
-      .classed(s.hidden, false) // The `hidden` class sets `display: none;`
-      .classed(s.show, true) // The `show` class triggers the opacity transition
+    this.div.classed(s.hidden, false) // The `hidden` class sets `display: none;`
+    this.element.getBoundingClientRect() // force a reflow so it has a frame to fade in from
+    this.div.classed(s.show, true) // The `show` class triggers the opacity transition
 
     this._isShown = true
   }
@@ -348,8 +348,11 @@ export class Tooltip {
     // We use the Event Delegation pattern to set up Tooltip events
     // Every component will have single `mousemove` and `mouseleave` event listener functions, where we'll check
     // the `path` of the event and trigger corresponding callbacks
-    this.components.forEach(component => {
-      const selection = select(component.element)
+    // We also attach to the container itself: a gap between triggers (e.g. between bars) can be
+    // covered by a sibling component's element, which the per-component listener below never sees
+    const elements = [...this.components.map(c => c.element), this._container]
+    elements.forEach(element => {
+      const selection = select(element)
       selection
         .on('mousemove.tooltip', (e: MouseEvent) => {
           const { config: currentConfig } = this // get latest config because it could have been changed after the event was triggered
@@ -388,6 +391,13 @@ export class Tooltip {
                 return
               }
             }
+          }
+
+          // No match: keep following the cursor so the tooltip doesn't freeze while it fades out
+          // `_isShown` flips false as soon as `_hide` starts the fade, so check `hidden` instead
+          if (currentConfig.followCursor && !this.div.classed(s.hidden)) {
+            const [x, y] = this.isContainerBody() ? [e.clientX, e.clientY] : pointer(e, this._container)
+            this.place({ x, y })
           }
 
           // Hide the tooltip if the event didn't pass through any of the configured triggers.

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -358,6 +358,10 @@ export class Tooltip {
           const { config: currentConfig } = this // get latest config because it could have been changed after the event was triggered
           const path: (HTMLElement | SVGGElement)[] = (e.composedPath && e.composedPath()) || (e as any).path || [e.target]
 
+          // Events coming from the tooltip itself (possible when `allowHover` is enabled, because the tooltip
+          // lives inside the container) are handled by the tooltip's own hover listeners, see below
+          if (path.includes(this.element)) return
+
           // Go through all of the configured triggers
           for (const className of Object.keys(currentConfig.triggers)) {
             const template = currentConfig.triggers[className]


### PR DESCRIPTION
## Problems

  **1. Fade-in didn't always animate.** `_display()` removes the `hidden` class and adds the `show` class in the same synchronous tick. Without a paint in between, the browser can coalesce both changes into one style recalc, so the opacity transition has no "before" state to animate from. So the tooltip just appears at full opacity instead of fading in.

  **2. Tooltip froze while fading out over gaps.** With `followCursor: true`, moving the cursor from a trigger into a gap between triggers (e.g. between bars, or space covered by an axis/another sibling component) doesn't fire any of the per-trigger `mousemove` listeners, since each one only listens on its own component's element. The tooltip would freeze at its last position instead of tracking the cursor while it fades out.

## Fixes

**For (1):** insert `this.element.getBoundingClientRect()` between the two `classed()` calls in `_display()` to force a reflow, guaranteeing the browser paints the pre-transition frame before `show` is applied.

**For (2):** `Tooltip._setUpEvents()` already sets up per-component delegated `mousemove`/`mouseleave` listeners. This extends that same loop to also attach to the shared container, so gap movements are seen too. When such a move doesn't match any configured trigger and the tooltip is still fading out, we reposition it to keep it tracking the cursor.

The `hidden` class (not `_isShown`) gates the reposition: `_isShown` flips to `false` the instant `_hide()` starts the fade, while `hidden` is only added once the fade-out has actually finished (in the `transitionend` callback). Gating on `_isShown` would silently skip repositioning for the whole visible fade duration.

No new event listener lifecycle is introduced. This reuses the existing delegation mechanism, adding one more attachment target and one fallback branch.

## Preview

<img width="651" height="546" alt="ezgif-8df5a684c6acc341" src="https://github.com/user-attachments/assets/37c21060-b9bf-4ed0-a228-45d7c5d6c81b" />
