### PR TITLE
Misc: Add npm version and downloads/month badges to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ Svelte and TypeScript.
 
 ## Repository structure
 
-* `packages/ts` Core TypeScript package
-* `packages/angular` Angular components
-* `packages/react` React components
-* `packages/svelte` Svelte components
-* `packages/vue` Vue components
-* `packages/solid` Solid components
-* `packages/website` Website, docs and examples
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
+| Package | Description | Version | Downloads |
+|---------|-------------|---------|-----------|
+| [`@unovis/ts`](packages/ts) | Core TypeScript package | <a href="https://npmx.dev/package/@unovis/ts"><img src="https://npmx.dev/api/registry/badge/version/@unovis/ts" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/ts"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/ts" alt="Downloads"></a> |
+| [`@unovis/react`](packages/react) | React components | <a href="https://npmx.dev/package/@unovis/react"><img src="https://npmx.dev/api/registry/badge/version/@unovis/react" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/react"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/react" alt="Downloads"></a> |
+| [`@unovis/angular`](packages/angular) | Angular components | <a href="https://npmx.dev/package/@unovis/angular"><img src="https://npmx.dev/api/registry/badge/version/@unovis/angular" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/angular"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/angular" alt="Downloads"></a> |
+| [`@unovis/svelte`](packages/svelte) | Svelte components | <a href="https://npmx.dev/package/@unovis/svelte"><img src="https://npmx.dev/api/registry/badge/version/@unovis/svelte" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/svelte"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/svelte" alt="Downloads"></a> |
+| [`@unovis/vue`](packages/vue) | Vue components | <a href="https://npmx.dev/package/@unovis/vue"><img src="https://npmx.dev/api/registry/badge/version/@unovis/vue" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/vue"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/vue" alt="Downloads"></a> |
+| [`@unovis/solid`](packages/solid) | Solid components | <a href="https://npmx.dev/package/@unovis/solid"><img src="https://npmx.dev/api/registry/badge/version/@unovis/solid" alt="Version"></a> | <a href="https://npmx.dev/package/@unovis/solid"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/solid" alt="Downloads"></a> |
+| [`packages/website`](packages/website) | Website, docs and examples | — | — |
 
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/angular"><img src="https://npmx.dev/api/registry/badge/version/@unovis/angular" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/angular"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/angular" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript.
 
 `@unovis/angular` provides Angular modules to `@unovis/ts`, which makes Unovis integration into an Angular

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/react"><img src="https://npmx.dev/api/registry/badge/version/@unovis/react" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/react"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/react" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript.
 
 `@unovis/react` provides React components for `@unovis/ts`, which makes Unovis integration into a React

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/solid"><img src="https://npmx.dev/api/registry/badge/version/@unovis/solid" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/solid"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/solid" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, Vue, Solid and vanilla TypeScript or JavaScript.
 
 `@unovis/solid` provides Solid components for `@unovis/ts`, which makes Unovis integration into a Solid

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/svelte"><img src="https://npmx.dev/api/registry/badge/version/@unovis/svelte" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/svelte"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/svelte" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript.
 
 `@unovis/svelte` provides Svelte components for `@unovis/ts`, which makes Unovis integration into a Svelte

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/ts"><img src="https://npmx.dev/api/registry/badge/version/@unovis/ts" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/ts"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/ts" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, and vanilla TypeScript or JavaScript.
 
 `@unovis/ts` is the main package of Unovis. It contains the actual source code of all the components and

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,5 +1,9 @@
 ![cover](https://user-images.githubusercontent.com/755708/194946760-13db0396-c429-4abb-8324-a5efae0455e2.png)
 
+<a href="https://npmx.dev/package/@unovis/vue"><img src="https://npmx.dev/api/registry/badge/version/@unovis/vue" alt="Version"></a>
+<a href="https://npmx.dev/package/@unovis/vue"><img src="https://npmx.dev/api/registry/badge/downloads/@unovis/vue" alt="Downloads"></a>
+<a href="https://github.com/f5/unovis/blob/main/LICENSE"><img src="https://img.shields.io/github/license/f5/unovis" alt="License"></a>
+
 🟨 **Unovis** is a modular data visualization framework for React, Angular, Svelte, Vue and vanilla TypeScript or JavaScript.
 
 `@unovis/vue` provides Vue components for `@unovis/ts`, which makes Unovis integration into a Vue


### PR DESCRIPTION
## Summary

- Root `README.md`: replaces the plain package list in "Repository structure" with a table that includes live npm **version** and **downloads/month** badges for each published package
- Each package `README.md` (`@unovis/ts`, `@unovis/react`, `@unovis/angular`, `@unovis/svelte`, `@unovis/vue`, `@unovis/solid`): adds **version** and **downloads/month** badges (shields.io) below the cover image

Examples preview:
* Root README: 
<img width="500" alt="2026-08-04 at 12 05 32" src="https://github.com/user-attachments/assets/3eaf7caf-f4c8-48c7-84b3-08cf7a1efd6f" />

* Package README: 
<img width="320" alt="2026-08-04 at 12 05 47" src="https://github.com/user-attachments/assets/c63822d4-c777-4fba-b56d-d48b13d35010" />

## Checklist
- [ ] Dev examples
- [ ] Wrappers
- [ ] Gallery example
- [x] Docs / README ✅