### PR TITLE
Component | Graph: Add configurable node label and sub-label wrapping

### DIFF
--- a/packages/angular/src/components/graph/graph.component.ts
+++ b/packages/angular/src/components/graph/graph.component.ts
@@ -297,11 +297,23 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   /** Defines whether to trim the node labels or not. Default: `true` */
   @Input() nodeLabelTrim?: BooleanAccessor<N>
 
+  /** Defines whether to wrap the node labels or not. When enabled, wrapping takes precedence over trimming. Default: `false` */
+  @Input() nodeLabelWrap?: BooleanAccessor<N>
+
   /** Node label trimming mode. Default: `TrimMode.Middle` */
   @Input() nodeLabelTrimMode?: GenericAccessor<TrimMode | string, N>
 
   /** Node label maximum allowed text length above which the label will be trimmed. Default: `15` */
   @Input() nodeLabelTrimLength?: NumericAccessor<N>
+
+  /** Maximum width of the wrapped node label in pixels. When not set, wrapped labels use a width derived from the node size. Default: `undefined` */
+  @Input() nodeLabelWidth?: NumericAccessor<N>
+
+  /** Node label text wrapping separator. String or array of strings. Default: `undefined` */
+  @Input() nodeLabelWrapSeparator?: string | string[]
+
+  /** Force word break for node labels when they don't fit. Default: `false` */
+  @Input() nodeLabelForceWordBreak?: boolean
 
   /** Node sub-label accessor function or constant value: Default: `''` */
   @Input() nodeSubLabel?: StringAccessor<N>
@@ -309,11 +321,23 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   /** Defines whether to trim the node sub-labels or not. Default: `true` */
   @Input() nodeSubLabelTrim?: BooleanAccessor<N>
 
+  /** Defines whether to wrap the node sub-labels or not. When enabled, wrapping takes precedence over trimming. Default: `false` */
+  @Input() nodeSubLabelWrap?: BooleanAccessor<N>
+
   /** Node sub-label trimming mode. Default: `TrimMode.Middle` */
   @Input() nodeSubLabelTrimMode?: GenericAccessor<TrimMode | string, N>
 
   /** Node sub-label maximum allowed text length above which the label will be trimmed. Default: `15` */
   @Input() nodeSubLabelTrimLength?: NumericAccessor<N>
+
+  /** Maximum width of the wrapped node sub-label in pixels. When not set, wrapped labels use a width derived from the node size. Default: `undefined` */
+  @Input() nodeSubLabelWidth?: NumericAccessor<N>
+
+  /** Node sub-label text wrapping separator. String or array of strings. Default: `undefined` */
+  @Input() nodeSubLabelWrapSeparator?: string | string[]
+
+  /** Force word break for node sub-labels when they don't fit. Default: `false` */
+  @Input() nodeSubLabelForceWordBreak?: boolean
 
   /** Node circular side labels accessor function. The function should return an array of GraphCircleLabel objects. Default: `undefined` */
   @Input() nodeSideLabels?: GenericAccessor<GraphCircleLabel[], N>
@@ -434,8 +458,8 @@ export class VisGraphComponent<N extends GraphInputNode, L extends GraphInputLin
   }
 
   private getConfig (): GraphConfigInterface<N, L> {
-    const { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelNodeSpacing, layoutParallelSubGroupSpacing, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate } = this
-    const config = { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelNodeSpacing, layoutParallelSubGroupSpacing, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate }
+    const { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelNodeSpacing, layoutParallelSubGroupSpacing, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelWrap, nodeLabelTrimMode, nodeLabelTrimLength, nodeLabelWidth, nodeLabelWrapSeparator, nodeLabelForceWordBreak, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelWrap, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSubLabelWidth, nodeSubLabelWrapSeparator, nodeSubLabelForceWordBreak, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate } = this
+    const config = { duration, events, attributes, zoomScaleExtent, disableZoom, zoomEventFilter, disableDrag, disableBrush, zoomThrottledUpdateNodeThreshold, fitViewPadding, fitViewAlign, layoutType, layoutAutofit, layoutAutofitTolerance, layoutNonConnectedAside, layoutNodeGroup, layoutGroupOrder, layoutParallelNodesPerColumn, layoutParallelNodeSubGroup, layoutParallelSubGroupsPerRow, layoutParallelNodeSpacing, layoutParallelSubGroupSpacing, layoutParallelGroupSpacing, layoutParallelSortConnectionsByGroup, forceLayoutSettings, dagreLayoutSettings, layoutElkSettings, layoutElkNodeGroups, layoutElkGetNodeShape, linkWidth, linkStyle, linkBandWidth, linkArrow, linkStroke, linkDisabled, linkFlow, linkFlowAnimDuration, linkFlowParticleSize, linkFlowParticleSpeed, linkLabel, linkLabelShiftFromCenter, linkNeighborSpacing, linkCurvature, linkHighlightOnHover, linkSourcePointOffset, linkTargetPointOffset, selectedLinkId, nodeSize, nodeStrokeWidth, nodeShape, nodeGaugeValue, nodeGaugeFill, nodeGaugeAnimDuration, nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelWrap, nodeLabelTrimMode, nodeLabelTrimLength, nodeLabelWidth, nodeLabelWrapSeparator, nodeLabelForceWordBreak, nodeSubLabel, nodeSubLabelTrim, nodeSubLabelWrap, nodeSubLabelTrimMode, nodeSubLabelTrimLength, nodeSubLabelWidth, nodeSubLabelWrapSeparator, nodeSubLabelForceWordBreak, nodeSideLabels, nodeBottomIcon, nodeDisabled, nodeFill, nodeStroke, nodeSort, nodeEnterPosition, nodeEnterScale, nodeExitPosition, nodeExitScale, nodeEnterCustomRenderFunction, nodeUpdateCustomRenderFunction, nodePartialUpdateCustomRenderFunction, nodeExitCustomRenderFunction, nodeOnZoomCustomRenderFunction, nodeSelectionHighlightMode, selectedNodeId, selectedNodeIds, panels, onNodeDragStart, onNodeDrag, onNodeDragEnd, onZoom, onZoomStart, onZoomEnd, onLayoutCalculated, onNodeSelectionBrush, onNodeSelectionDrag, onRenderComplete, shouldDataUpdate }
     const keys = Object.keys(config) as (keyof GraphConfigInterface<N, L>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
+++ b/packages/dev/src/examples/networks-and-flows/graph/graph-node-labels/index.tsx
@@ -12,7 +12,7 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
   const data = generateNodeLinkData(15)
   const regions = ['Australian', 'South American', 'Siberian', 'European', 'Asian']
   const colors = ['Vermilion', 'Verdigris', 'Bisque', 'Cattleya']
-  const animals = ['Elephant', 'Mountain Lion', 'Sea Otter', 'Bear']
+  const animals = ['Elephant', 'Mountain Lionnnnnnnnnnnnnnnnnnnnnnnnnn', 'Sea Otter', 'Bear']
   const trimModes = Object.values(TrimMode)
   const labels = data.nodes.map((d, i) => ({
     label: `${sample(animals)} ${sample(colors)}`,
@@ -23,18 +23,28 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
     subLabelTrim: randomNumberGenerator() > 0.2,
     subLabelTrimMode: sample(trimModes),
     subLabelTrimLength: Math.round(3 + 12 * randomNumberGenerator()),
+    labelWrap: randomNumberGenerator() > 0.5,
+    labelWrapLength: 120,
+    subLabelWrap: randomNumberGenerator() > 0.5,
+    subLabelWrapLength: 40,
   }))
   return (
     <VisSingleContainer data={data} height={600}>
       <VisGraph<NodeDatum, LinkDatum>
         nodeLabel={(_, i) => labels[i].label}
         nodeLabelTrim={(_, i) => labels[i].labelTrim}
+        nodeLabelWrap={(_, i) => labels[i].labelWrap}
+        nodeLabelWidth={(_, i) => labels[i].labelWrapLength}
+        nodeLabelWrapSeparator={[' ']}
         nodeLabelTrimMode={(_, i) => labels[i].labelTrimMode}
         nodeLabelTrimLength={(_, i) => labels[i].labelTrimLength}
         nodeSubLabel={(_, i) => labels[i].subLabel}
+        nodeSubLabelWrap={(_, i) => labels[i].subLabelWrap}
+        nodeSubLabelWidth={(_, i) => labels[i].subLabelWrapLength}
         nodeSubLabelTrim={(_, i) => labels[i].subLabelTrim}
         nodeSubLabelTrimMode={(_, i) => labels[i].subLabelTrimMode}
         nodeSubLabelTrimLength={(_, i) => labels[i].subLabelTrimLength}
+        nodeSubLabelForceWordBreak={true}
         duration={props.duration}
       />
     </VisSingleContainer>

--- a/packages/ts/src/components/graph/config.ts
+++ b/packages/ts/src/components/graph/config.ts
@@ -204,18 +204,34 @@ export interface GraphConfigInterface<N extends GraphInputNode, L extends GraphI
   nodeLabel?: StringAccessor<N>;
   /** Defines whether to trim the node labels or not. Default: `true` */
   nodeLabelTrim?: BooleanAccessor<N>;
+  /** Defines whether to wrap the node labels or not. When enabled, wrapping takes precedence over trimming. Default: `false` */
+  nodeLabelWrap?: BooleanAccessor<N>;
   /** Node label trimming mode. Default: `TrimMode.Middle` */
   nodeLabelTrimMode?: GenericAccessor<TrimMode | string, N>;
   /** Node label maximum allowed text length above which the label will be trimmed. Default: `15` */
   nodeLabelTrimLength?: NumericAccessor<N>;
+  /** Maximum width of the wrapped node label in pixels. When not set, wrapped labels use a width derived from the node size. Default: `undefined` */
+  nodeLabelWidth?: NumericAccessor<N>;
+  /** Node label text wrapping separator. String or array of strings. Default: `undefined` */
+  nodeLabelWrapSeparator?: string | string[];
+  /** Force word break for node labels when they don't fit. Default: `false` */
+  nodeLabelForceWordBreak?: boolean;
   /** Node sub-label accessor function or constant value: Default: `''` */
   nodeSubLabel?: StringAccessor<N>;
   /** Defines whether to trim the node sub-labels or not. Default: `true` */
   nodeSubLabelTrim?: BooleanAccessor<N>;
+  /** Defines whether to wrap the node sub-labels or not. When enabled, wrapping takes precedence over trimming. Default: `false` */
+  nodeSubLabelWrap?: BooleanAccessor<N>;
   /** Node sub-label trimming mode. Default: `TrimMode.Middle` */
   nodeSubLabelTrimMode?: GenericAccessor<TrimMode | string, N>;
   /** Node sub-label maximum allowed text length above which the label will be trimmed. Default: `15` */
   nodeSubLabelTrimLength?: NumericAccessor<N>;
+  /** Maximum width of the wrapped node sub-label in pixels. When not set, wrapped labels use a width derived from the node size. Default: `undefined` */
+  nodeSubLabelWidth?: NumericAccessor<N>;
+  /** Node sub-label text wrapping separator. String or array of strings. Default: `undefined` */
+  nodeSubLabelWrapSeparator?: string | string[];
+  /** Force word break for node sub-labels when they don't fit. Default: `false` */
+  nodeSubLabelForceWordBreak?: boolean;
   /** Node circular side labels accessor function. The function should return an array of GraphCircleLabel objects. Default: `undefined` */
   nodeSideLabels?: GenericAccessor<GraphCircleLabel[], N>;
   /** Node bottom icon accessor function. Default: `undefined` */
@@ -382,12 +398,20 @@ export const GraphDefaultConfig: GraphConfigInterface<GraphInputNode, GraphInput
   nodeIconSize: undefined,
   nodeLabel: (n: GraphInputNode): string => (n as { label: string }).label,
   nodeLabelTrim: true,
+  nodeLabelWrap: false,
   nodeLabelTrimLength: 15,
   nodeLabelTrimMode: TrimMode.Middle,
+  nodeLabelWidth: undefined,
+  nodeLabelWrapSeparator: undefined,
+  nodeLabelForceWordBreak: false,
   nodeSubLabel: '',
   nodeSubLabelTrim: true,
+  nodeSubLabelWrap: false,
   nodeSubLabelTrimLength: 15,
   nodeSubLabelTrimMode: TrimMode.Middle,
+  nodeSubLabelWidth: undefined,
+  nodeSubLabelWrapSeparator: undefined,
+  nodeSubLabelForceWordBreak: false,
   nodeSideLabels: undefined,
   nodeBottomIcon: undefined,
   nodeDisabled: false,

--- a/packages/ts/src/components/graph/modules/node/helper.ts
+++ b/packages/ts/src/components/graph/modules/node/helper.ts
@@ -100,23 +100,43 @@ export function polyTween<N extends GraphInputNode, L extends GraphInputLink> (
 }
 
 export function setLabelRect<T, K extends BaseType, L> (
-  labelSelection: Selection<SVGGElement, T, K, L>,
-  label: string,
-  selector: string
+  labelSelection: Selection<SVGGElement, T, K, L>
 ): Selection<SVGRectElement, T, K, L> {
-  // Set label background rectangle size by text size
-  const labelIsEmpty = isEmpty(label)
-  const labelTextSelection = labelSelection.select<SVGTextElement>(`.${selector}`)
-  const labelTextBBox = (labelTextSelection.node() as SVGGraphicsElement).getBBox()
+  const labelTextElements = labelSelection.selectAll<SVGTextElement, unknown>('text').nodes()
+    .filter(node => !isEmpty(node.textContent))
+
+  let minX = 0
+  let minY = 0
+  let maxX = 0
+  let maxY = 0
+
+  labelTextElements.forEach((node, index) => {
+    const bbox = (node as SVGGraphicsElement).getBBox()
+    if (index === 0) {
+      minX = bbox.x
+      minY = bbox.y
+      maxX = bbox.x + bbox.width
+      maxY = bbox.y + bbox.height
+      return
+    }
+
+    minX = Math.min(minX, bbox.x)
+    minY = Math.min(minY, bbox.y)
+    maxX = Math.max(maxX, bbox.x + bbox.width)
+    maxY = Math.max(maxY, bbox.y + bbox.height)
+  })
+
+  const labelWidth = maxX - minX
+  const labelHeight = maxY - minY
   const backgroundRect = labelSelection.select<SVGRectElement>('rect')
-    .attr('visibility', labelIsEmpty ? 'hidden' : null)
+    .attr('visibility', labelTextElements.length ? null : 'hidden')
     .attr('rx', 4)
     .attr('ry', 4)
-    .attr('x', -labelTextBBox.width / 2 - LABEL_RECT_HORIZONTAL_PADDING)
-    .attr('y', '-0.64em')
-    .attr('width', labelTextBBox.width + 2 * LABEL_RECT_HORIZONTAL_PADDING)
-    .attr('height', labelTextBBox.height + 2 * LABEL_RECT_VERTICAL_PADDING)
-    .style('transform', `translateY(${-LABEL_RECT_VERTICAL_PADDING}px)`)
+    .attr('x', minX - LABEL_RECT_HORIZONTAL_PADDING)
+    .attr('y', minY - LABEL_RECT_VERTICAL_PADDING)
+    .attr('width', labelWidth + 2 * LABEL_RECT_HORIZONTAL_PADDING)
+    .attr('height', labelHeight + 2 * LABEL_RECT_VERTICAL_PADDING)
+    .style('transform', null)
 
   return backgroundRect
 }

--- a/packages/ts/src/components/graph/modules/node/index.ts
+++ b/packages/ts/src/components/graph/modules/node/index.ts
@@ -7,7 +7,7 @@ import { GraphInputLink, GraphInputNode } from '@/types/graph'
 import { TrimMode } from '@/types/text'
 
 // Utils
-import { trimString } from '@/utils/text'
+import { renderTextToSvgTextElement, trimString } from '@/utils/text'
 import { polygon } from '@/utils/path'
 import { smartTransition, Selection$Transition } from '@/utils/d3'
 import { getBoolean, getNumber, getString, getValue, throttle } from '@/utils/data'
@@ -92,14 +92,12 @@ export function createNodes<N extends GraphInputNode, L extends GraphInputLink> 
     const label = group.append('g').attr('class', nodeSelectors.label)
     label.append('rect').attr('class', nodeSelectors.labelBackground)
 
-    const labelText = label.append('text')
-      .attr('class', nodeSelectors.labelText)
+    label.append('text')
+      .attr('class', `${nodeSelectors.labelText} ${nodeSelectors.labelTextContent}`)
       .attr('dy', '0.32em')
-    labelText.append('tspan').attr('class', nodeSelectors.labelTextContent)
-    labelText.append('tspan')
+    label.append('text')
       .attr('class', nodeSelectors.subLabelTextContent)
-      .attr('dy', '1.1em')
-      .attr('x', '0')
+      .attr('dy', '0.32em')
   })
 }
 
@@ -148,6 +146,77 @@ export function updateNodePositions<N extends GraphInputNode, L extends GraphInp
     .attr('opacity', 1)
 }
 
+function renderNodeLabelText<N extends GraphInputNode, L extends GraphInputLink> (
+  label: Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown>,
+  node: GraphNode<N, L>,
+  config: GraphConfigInterface<N, L>,
+  nodeSizeValue: number,
+  labelFontSize: number,
+  context: SVGElement,
+  expand = false
+): void {
+  const labelTextSelection = label.select<SVGTextElement>(`.${nodeSelectors.labelTextContent}`)
+  const sublabelTextSelection = label.select<SVGTextElement>(`.${nodeSelectors.subLabelTextContent}`)
+  const labelTextNode = labelTextSelection.node() as SVGTextElement
+  const sublabelTextNode = sublabelTextSelection.node() as SVGTextElement
+  const labelText = getString(node, config.nodeLabel, node._index) || ''
+  const sublabelText = getString(node, config.nodeSubLabel, node._index) || ''
+  const shouldWrapLabel = getBoolean(node, config.nodeLabelWrap, node._index)
+  const shouldWrapSublabel = getBoolean(node, config.nodeSubLabelWrap, node._index)
+  const labelWrapSeparator = config.nodeLabelWrapSeparator
+  const sublabelWrapSeparator = config.nodeSubLabelWrapSeparator
+
+  const visibleLabelText = (!expand && !shouldWrapLabel && getBoolean(node, config.nodeLabelTrim, node._index))
+    ? trimString(labelText, getNumber(node, config.nodeLabelTrimLength, node._index), getValue(node, config.nodeLabelTrimMode as TrimMode, node._index))
+    : labelText
+  const visibleSublabelText = (!expand && !shouldWrapSublabel && getBoolean(node, config.nodeSubLabelTrim, node._index))
+    ? trimString(sublabelText, getNumber(node, config.nodeSubLabelTrimLength, node._index), getValue(node, config.nodeSubLabelTrimMode as TrimMode, node._index))
+    : sublabelText
+
+  if (shouldWrapLabel && visibleLabelText) {
+    const labelWidth = getNumber(node, config.nodeLabelWidth, node._index) ?? Math.max(nodeSizeValue * 2.5, labelFontSize * 4)
+    labelTextSelection
+      .attr('x', 0)
+      .attr('y', 0)
+    renderTextToSvgTextElement(labelTextNode, { text: visibleLabelText, fontSize: labelFontSize, lineHeight: 1.2 }, {
+      x: 0,
+      y: 0,
+      width: labelWidth,
+      separator: labelWrapSeparator,
+      wordBreak: config.nodeLabelForceWordBreak,
+    })
+  } else {
+    labelTextSelection
+      .attr('x', 0)
+      .attr('y', 0)
+      .text(visibleLabelText)
+  }
+
+  const labelBBox = (labelTextSelection.node() as SVGGraphicsElement).getBBox()
+  const hasLabel = Boolean(visibleLabelText)
+  const sublabelYOffset = hasLabel ? labelBBox.height + labelFontSize * 0.2 : 0
+  const subLabelFontSize = getCSSVariableValueInPixels('var(--vis-graph-node-sublabel-font-size)', context) || labelFontSize
+  const sublabelY = !hasLabel && visibleSublabelText ? subLabelFontSize * 0.1 : sublabelYOffset
+
+  sublabelTextSelection
+    .attr('visibility', visibleSublabelText ? null : 'hidden')
+    .attr('x', 0)
+    .attr('y', sublabelY)
+
+  if (shouldWrapSublabel && visibleSublabelText) {
+    const sublabelWidth = getNumber(node, config.nodeSubLabelWidth, node._index) ?? Math.max(nodeSizeValue * 2.5, subLabelFontSize * 4)
+    renderTextToSvgTextElement(sublabelTextNode, { text: visibleSublabelText, fontSize: subLabelFontSize, lineHeight: 1.2 }, {
+      x: 0,
+      y: sublabelY,
+      width: sublabelWidth,
+      separator: sublabelWrapSeparator,
+      wordBreak: config.nodeSubLabelForceWordBreak,
+    })
+  } else {
+    sublabelTextSelection.text(visibleSublabelText)
+  }
+}
+
 export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> (
   selection: Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown>,
   config: GraphConfigInterface<N, L>,
@@ -156,8 +225,7 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
 ): Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> | Transition<SVGGElement, GraphNode<N, L>, SVGGElement, unknown> {
   const {
     nodeGaugeAnimDuration, nodeStrokeWidth, nodeShape, nodeSize, nodeGaugeValue, nodeGaugeFill,
-    nodeIcon, nodeIconSize, nodeLabel, nodeLabelTrim, nodeLabelTrimMode, nodeLabelTrimLength,
-    nodeSubLabel, nodeSubLabelTrim, nodeSubLabelTrimMode, nodeSubLabelTrimLength,
+    nodeIcon, nodeIconSize,
     nodeSideLabels, nodeStroke, nodeFill, nodeBottomIcon,
   } = config
 
@@ -199,8 +267,6 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
     const icon = group.select<SVGTextElement>(`.${nodeSelectors.nodeIcon}`)
     const sideLabelsGroup = group.select<SVGGElement>(`.${nodeSelectors.sideLabelsGroup}`)
     const label = group.select<SVGGElement>(`.${nodeSelectors.label}`)
-    const labelTextContent = label.select<SVGTextElement>(`.${nodeSelectors.labelTextContent}`)
-    const sublabelTextContent = label.select<SVGTextElement>(`.${nodeSelectors.subLabelTextContent}`)
     const bottomIcon = group.select<SVGTextElement>(`.${nodeSelectors.nodeBottomIcon}`)
     const nodeSelectionOutline = group.select<SVGGElement>(`.${nodeSelectors.nodeSelection}`)
     const nodeSizeValue = getNodeSize(d, nodeSize, d._index)
@@ -321,37 +387,24 @@ export function updateNodes<N extends GraphInputNode, L extends GraphInputLink> 
 
     sideLabels.exit().remove()
 
-    // Set label and sub-label text
-    const labelText = getString(d, nodeLabel, d._index)
-    const sublabelText = getString(d, nodeSubLabel, d._index)
-    const labelTextTrimmed = getBoolean(d, nodeLabelTrim, d._index)
-      ? trimString(labelText, getNumber(d, nodeLabelTrimLength, d._index), getValue(d, nodeLabelTrimMode as TrimMode, d._index))
-      : labelText
-    const sublabelTextTrimmed = getBoolean(d, nodeSubLabelTrim, d._index)
-      ? trimString(sublabelText, getNumber(d, nodeSubLabelTrimLength, d._index), getValue(d, nodeSubLabelTrimMode as TrimMode, d._index))
-      : sublabelText
-
-    labelTextContent.text(labelTextTrimmed)
-    sublabelTextContent.text(sublabelTextTrimmed)
+    const labelFontSize = getCSSVariableValueInPixels('var(--vis-graph-node-label-font-size)', groupElement) || 12
+    renderNodeLabelText(label, d, config, nodeSizeValue, labelFontSize, groupElement, false)
     group
       .on('mouseenter', () => {
-        labelTextContent.text(labelText)
-        sublabelTextContent.text(sublabelText)
-        setLabelRect(label, labelText, nodeSelectors.labelText)
+        renderNodeLabelText(label, d, config, nodeSizeValue, labelFontSize, groupElement, true)
+        setLabelRect(label)
         group.raise()
       })
       .on('mouseleave', () => {
-        labelTextContent.text(labelTextTrimmed)
-        sublabelTextContent.text(sublabelTextTrimmed)
-        setLabelRect(label, labelTextTrimmed, nodeSelectors.labelText)
+        renderNodeLabelText(label, d, config, nodeSizeValue, labelFontSize, groupElement, false)
+        setLabelRect(label)
       })
 
     // Position label
-    const labelFontSize = getCSSVariableValueInPixels('var(--vis-graph-node-label-font-size)', groupElement) || 12
     const labelMargin = LABEL_RECT_VERTICAL_PADDING + 1.25 * labelFontSize ** 1.03
     const nodeHeight = isStringSvg((getString(d, nodeShape, d._index)) as GraphNodeShape) ? nodeBBox.height : nodeSizeValue
     label.attr('transform', `translate(0, ${nodeHeight / 2 + labelMargin})`)
-    if (scale >= ZoomLevel.Level3) setLabelRect(label, getString(d, nodeLabel, d._index), nodeSelectors.labelText)
+    if (scale >= ZoomLevel.Level3) setLabelRect(label)
 
     // Bottom Icon
     bottomIcon.html(getString(d, nodeBottomIcon, d._index))
@@ -390,15 +443,12 @@ export function removeNodes<N extends GraphInputNode, L extends GraphInputLink> 
 }
 
 function setLabelBackgroundRect<N extends GraphInputNode, L extends GraphInputLink> (
-  selection: Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown>,
-  config: GraphConfigInterface<N, L>
+  selection: Selection<SVGGElement, GraphNode<N, L>, SVGGElement, unknown>
 ): void {
-  const { nodeLabel } = config
-
   selection.each((d, i, elements) => {
     const group: Selection<SVGGElement, N, SVGGElement, N> = select(elements[i])
     const label: Selection<SVGGElement, N, SVGGElement, N> = group.select(`.${nodeSelectors.label}`)
-    setLabelRect(label, getString(d, nodeLabel, i), nodeSelectors.labelText)
+    setLabelRect(label)
   })
 }
 


### PR DESCRIPTION
Our graph node does not support label wrapping, this PR adds it to label and sublabels. Following the style of sankey and axis, also added the option to force word break. 
<!-- A short description of the change and the motivation behind it. Link any related issues. -->

## Screenshots / recordings
<img width="1119" height="572" alt="Screenshot 2026-08-04 at 1 57 15 PM" src="https://github.com/user-attachments/assets/3e0aea57-b308-4e67-b9e8-7fee3a86b09a" />
