### PR TITLE
Adaptive tick sets

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -96,9 +96,6 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
   @Input() labelTextTrimType?: TrimMode | `${TrimMode}`
 
-  /** Label text separators for wrapping. Default: `[' ', '-']` */
-  @Input() labelTextSeparator?: string[]
-
   /** Font color of the axis label as CSS string. Default: `null` */
   @Input() labelColor?: string | null
 
@@ -204,8 +201,8 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   }
 
   private getConfig (): AxisConfigInterface<Datum> {
-    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize } = this
-    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize }
+    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize } = this
+    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize }
     const keys = Object.keys(config) as (keyof AxisConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -96,6 +96,9 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
   @Input() labelTextTrimType?: TrimMode | `${TrimMode}`
 
+  /** Label text separators for wrapping. Default: `[' ', '-']` */
+  @Input() labelTextSeparator?: string[]
+
   /** Font color of the axis label as CSS string. Default: `null` */
   @Input() labelColor?: string | null
 
@@ -114,8 +117,8 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Show grid lines for the min and max axis ticks. Default: `false` */
   @Input() minMaxTicksOnlyShowGridLines?: boolean
 
-  /** Draw only the min and max axis ticks, when the chart
-   * width is less than the specified value.
+  /** Draw only the min and max axis ticks, when the chart width is less than the specified value.
+   * Has no effect when `tickTextAdaptiveSets` is enabled.
    * Default: `250` */
   @Input() minMaxTicksOnlyWhenWidthIsLess?: number
 
@@ -127,6 +130,10 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
 
   /** Set the approximate number of axis ticks (will be passed to D3's axis constructor). Default: `undefined` */
   @Input() numTicks?: number
+
+  /** Approximate spacing between ticks in pixels, used to derive the number of ticks
+   * when `numTicks` is not set. Only applies to the X axis. Default: `175` */
+  @Input() tickSpacing?: number
 
   /** Tick text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
   @Input() tickTextFitMode?: FitMode | `${FitMode}`
@@ -155,9 +162,18 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Text rotation angle for ticks. Default: `undefined` */
   @Input() tickTextAngle?: number
 
+  /** Adaptively pick the number of ticks so that their labels don't overlap: the axis renders the
+   * largest "nice" tick set that fits (measured off-screen), degrading to smaller sets on narrow
+   * charts. `numTicks` (or its width-based default) acts as the upper bound. With explicit
+   * `tickValues`, every-k-th subsets of them are fitted instead.
+   * Has no effect when `minMaxTicksOnly` is set, and disables the width-based
+   * `minMaxTicksOnlyWhenWidthIsLess` fallback. Default: `undefined` */
+  @Input() tickTextAdaptiveSets?: boolean
+
   /** Hide tick labels that overlap with each other.
    * To define overlapping, a simple bounding box collision detection algorithm is used.
    * Which means the result won't be accurate when `tickTextAngle` is specified.
+   * Consider combining with `tickTextAdaptiveSets` to keep the shown ticks evenly spaced.
    * Default: `undefined` */
   @Input() tickTextHideOverlapping?: boolean
 
@@ -188,8 +204,8 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   }
 
   private getConfig (): AxisConfigInterface<Datum> {
-    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextHideOverlapping, tickPadding, tickSize } = this
-    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextHideOverlapping, tickPadding, tickSize }
+    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize } = this
+    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize }
     const keys = Object.keys(config) as (keyof AxisConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/axis/axis-adaptive-ticks/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-adaptive-ticks/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { VisXYContainer, VisAxis } from '@unovis/react'
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+import { ContinuousScale, Scale } from '@unovis/ts'
+
+export const title = 'Adaptive Ticks'
+export const subTitle = 'Tick count fitted to the width'
+
+const timeTickFormat = Scale.scaleTime().tickFormat() as (tick: number | Date) => string
+
+type AxisExample = {
+  label: string;
+  domain: [number, number];
+  scale?: ContinuousScale;
+  tickFormat?: (tick: number | Date) => string;
+  tickTextAngle?: number;
+  tickValues?: number[];
+}
+
+const axes: AxisExample[] = [
+  { label: '[0, 1000]', domain: [0, 1000] },
+  { label: 'custom tickValues, 0..1000 by 100', domain: [0, 1000], tickValues: Array.from({ length: 11 }, (_, i) => i * 100) },
+  { label: '[-500, 500]', domain: [-500, 500] },
+  { label: '[0, 1]', domain: [0, 1] },
+  { label: '[0, 10000000]', domain: [0, 10000000] },
+  { label: '[0, 10000000], rotated labels', domain: [0, 10000000], tickTextAngle: 15 },
+  { label: 'time scale, 6 months', domain: [+new Date(2026, 0, 1), +new Date(2026, 6, 1)], scale: Scale.scaleTime(), tickFormat: timeTickFormat },
+  { label: 'time scale, 48 hours', domain: [+new Date(2026, 0, 1), +new Date(2026, 0, 3)], scale: Scale.scaleTime(), tickFormat: timeTickFormat },
+]
+
+const labelStyle: React.CSSProperties = { font: '11px monospace', color: '#888', margin: '12px 0 2px' }
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => (
+  <>
+    {axes.map(axis => (
+      <div key={axis.label}>
+        <div style={labelStyle}>{axis.label}</div>
+        <VisXYContainer xDomain={axis.domain} height={40} xScale={axis.scale}>
+          <VisAxis
+            type='x'
+            numTicks={25}
+            tickTextAdaptiveSets={true}
+            tickTextHideOverlapping={true}
+            tickFormat={axis.tickFormat}
+            tickTextAngle={axis.tickTextAngle}
+            tickValues={axis.tickValues}
+            duration={props.duration}
+          />
+        </VisXYContainer>
+      </div>
+    ))}
+  </>
+)

--- a/packages/dev/src/examples/xy-components/axis/axis-adaptive-ticks/index.tsx
+++ b/packages/dev/src/examples/xy-components/axis/axis-adaptive-ticks/index.tsx
@@ -15,12 +15,15 @@ type AxisExample = {
   tickFormat?: (tick: number | Date) => string;
   tickTextAngle?: number;
   tickValues?: number[];
+  // Fixed margin (with `autoMargin` off) for domains whose extreme labels drop in and out of
+  // the fitted set: their bleed changes the auto margin and makes the whole chart jump
+  margin?: { top: number; bottom: number; left: number; right: number };
 }
 
 const axes: AxisExample[] = [
   { label: '[0, 1000]', domain: [0, 1000] },
   { label: 'custom tickValues, 0..1000 by 100', domain: [0, 1000], tickValues: Array.from({ length: 11 }, (_, i) => i * 100) },
-  { label: '[-500, 500]', domain: [-500, 500] },
+  { label: '[-500, 500]', domain: [-500, 500], margin: { top: 0, bottom: 28, left: 24, right: 24 } },
   { label: '[0, 1]', domain: [0, 1] },
   { label: '[0, 10000000]', domain: [0, 10000000] },
   { label: '[0, 10000000], rotated labels', domain: [0, 10000000], tickTextAngle: 15 },
@@ -31,11 +34,11 @@ const axes: AxisExample[] = [
 const labelStyle: React.CSSProperties = { font: '11px monospace', color: '#888', margin: '12px 0 2px' }
 
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => (
-  <>
+  <div style={{ marginLeft: 8 }}>
     {axes.map(axis => (
       <div key={axis.label}>
         <div style={labelStyle}>{axis.label}</div>
-        <VisXYContainer xDomain={axis.domain} height={40} xScale={axis.scale}>
+        <VisXYContainer xDomain={axis.domain} height={40} xScale={axis.scale} autoMargin={!axis.margin} margin={axis.margin}>
           <VisAxis
             type='x'
             numTicks={25}
@@ -49,5 +52,5 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
         </VisXYContainer>
       </div>
     ))}
-  </>
+  </div>
 )

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -35,8 +35,8 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   minMaxTicksOnly?: boolean;
   /** Show grid lines for the min and max axis ticks. Default: `false` */
   minMaxTicksOnlyShowGridLines?: boolean;
-  /** Draw only the min and max axis ticks, when the chart
-   * width is less than the specified value.
+  /** Draw only the min and max axis ticks, when the chart width is less than the specified value.
+   * Has no effect when `tickTextAdaptiveSets` is enabled.
    * Default: `250` */
   minMaxTicksOnlyWhenWidthIsLess?: number;
   /** Tick label formatter function. Default: `undefined` */
@@ -45,6 +45,9 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickValues?: number[];
   /** Set the approximate number of axis ticks (will be passed to D3's axis constructor). Default: `undefined` */
   numTicks?: number;
+  /** Approximate spacing between ticks in pixels, used to derive the number of ticks
+   * when `numTicks` is not set. Only applies to the X axis. Default: `175` */
+  tickSpacing?: number;
   /** Tick text fit mode: `FitMode.Wrap` or `FitMode.Trim`. Default: `FitMode.Wrap`. */
   tickTextFitMode?: FitMode | `${FitMode}`;
   /** Maximum width in pixels for the tick text to be wrapped or trimmed. Default: `undefined` */
@@ -64,9 +67,17 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   tickTextColor?: string | null;
   /** Text rotation angle for ticks. Default: `undefined` */
   tickTextAngle?: number;
+  /** Adaptively pick the number of ticks so that their labels don't overlap: the axis renders the
+   * largest "nice" tick set that fits (measured off-screen), degrading to smaller sets on narrow
+   * charts. `numTicks` (or its width-based default) acts as the upper bound. With explicit
+   * `tickValues`, every-k-th subsets of them are fitted instead.
+   * Has no effect when `minMaxTicksOnly` is set, and disables the width-based
+   * `minMaxTicksOnlyWhenWidthIsLess` fallback. Default: `undefined` */
+  tickTextAdaptiveSets?: boolean;
   /** Hide tick labels that overlap with each other.
    * To define overlapping, a simple bounding box collision detection algorithm is used.
    * Which means the result won't be accurate when `tickTextAngle` is specified.
+   * Consider combining with `tickTextAdaptiveSets` to keep the shown ticks evenly spaced.
    * Default: `undefined` */
   tickTextHideOverlapping?: boolean;
   /** The spacing in pixels between the tick and it's label. Default: `8` */
@@ -88,6 +99,7 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   tickLine: true,
   domainLine: true,
   numTicks: undefined,
+  tickSpacing: 175,
   minMaxTicksOnly: false,
   minMaxTicksOnlyWhenWidthIsLess: 250,
   minMaxTicksOnlyShowGridLines: false,
@@ -107,5 +119,6 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   fullSize: true,
   tickPadding: 8,
   tickSize: 6,
+  tickTextAdaptiveSets: undefined,
   tickTextHideOverlapping: undefined,
 }

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -7,6 +7,7 @@ import { NumberValue } from 'd3-scale'
 import { XYComponentCore } from '@/core/xy-component'
 
 // Types
+import { Rect } from '@/types/misc'
 import { Position } from '@/types/position'
 import { ContinuousScale } from '@/types/scale'
 import { Spacing } from '@/types/spacing'
@@ -14,20 +15,42 @@ import { FitMode, TextAlign, TrimMode, UnovisText, UnovisTextOptions, VerticalAl
 
 // Utils
 import { smartTransition } from '@/utils/d3'
-import { renderTextToSvgTextElement, textAlignToAnchor, trimSVGText, wrapSVGText } from '@/utils/text'
-import { getCachedComputedTextLength } from '@/utils/text-measure'
+import { estimateWrappedTextHeight, getWrappedText, renderTextToSvgTextElement, textAlignToAnchor, trimSVGText, wrapSVGText } from '@/utils/text'
+import { getCachedComputedTextLength, getPreciseStringLengthPx } from '@/utils/text-measure'
 import { isEqual, isFunction } from '@/utils/data'
+import { getRotatedRectAabb } from '@/utils/misc'
 import { hideOverlappingLabels } from '@/utils/text-overlap'
-import { getFontWidthToHeightRatio } from '@/styles/index'
+import { UNOVIS_TEXT_DEFAULT } from '@/styles/index'
 
 // Local Types
-import { AxisType } from './types'
+import { AxisType, TickSets, TickValues } from './types'
+
+// Local Utils
+import {
+  findFittingTickValues,
+  getNestedTickValues,
+  getTickValueCandidates,
+  getTickValueSubsetCandidates,
+  mergeTickValues,
+  tickKey,
+} from './tick-fit'
 
 // Config
 import { AxisDefaultConfig, AxisConfigInterface } from './config'
 
 // Styles
 import * as s from './style'
+
+type TickTextStyle = {
+  fontSize: number;
+  fontFamily: string;
+  fontWeight?: number;
+}
+
+/** Minimum on-screen gap between tick labels (negative `tolerance` of `resolveRectsOverlap`
+ * expands the rects). The tick fitting and the overlap safety net must use the same value,
+ * otherwise the fitted sets wouldn't survive the overlap pass */
+const TICK_LABEL_OVERLAP_TOLERANCE_PX = -5
 
 export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datum>> {
   static selectors = s
@@ -41,11 +64,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   private _requiredMargin: Spacing
   private _defaultNumTicks = 3
   private _collideTickLabelsAnimFrameId: ReturnType<typeof requestAnimationFrame>
-  private _tickTextStyleCached: {
-    fontSize: number;
-    fontFamily: string;
-    fontWidthToHeightRatio: number;
-  }
+  private _tickTextStyleCached: TickTextStyle
 
   protected events = {}
 
@@ -65,7 +84,10 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     const { config } = this
     const axisRenderHelperGroup = this.g.append('g').attr('opacity', 0)
 
-    this._renderAxis(axisRenderHelperGroup, 0)
+    // Measure the full fitted set, so the margins account for its label bleed. Deliberately
+    // not the `labeled` subset: margins from it would depend on the extreme-label drops, which
+    // themselves depend on the margins — an unstable feedback making layout resize-path-dependent
+    this._renderAxis(axisRenderHelperGroup, 0, this._getFittingTickValues()?.fittedTicks)
 
     // Align tick text
     if (config.tickTextAlign) this._alignTickLabels(axisRenderHelperGroup)
@@ -145,15 +167,28 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   public _render (duration = this.config.duration, selection = this.axisGroup): void {
     const { config } = this
 
-    this._renderAxis(selection, duration)
+    // Adaptive tick sets: the whole original set renders as tick marks (merged with the rare
+    // fitted values missing from it, e.g. on time scales), and only the fitted subset is labeled.
+    // When `tickSets` is undefined (the option is off or not applicable), `_renderAxis` computes
+    // the tick values itself and labels all of them
+    const tickSets = this._getFittingTickValues()
+    const renderTickValues = tickSets && mergeTickValues(tickSets.originalTicks, tickSets.fittedTicks)
+    const labeledTickKeys = tickSets && new Set(tickSets.labeledTicks.map(tickKey))
+
+    this._renderAxis(selection, duration, renderTickValues, labeledTickKeys)
     this._renderAxisLabel(selection)
 
     if (config.gridLine) {
-      const gridGen = this._buildGrid()
+      // The grid renders a line per tick mark, but only the lines of the labeled ticks are
+      // visible — hiding the rest with a class keeps the elements stable across renders,
+      // so grid changes animate in CSS the same way the labels do
+      const gridGen = this._buildGrid(renderTickValues)
       // Interrupting all active transitions first to prevent them from being stuck.
       // Somehow we see it happening in Angular apps.
       this.gridGroup.selectAll('*').interrupt()
       smartTransition(this.gridGroup, duration).call(gridGen).style('opacity', 1)
+      this.gridGroup.selectAll<SVGGElement, number | Date>('g.tick')
+        .classed(s.gridTickHidden, d => labeledTickKeys ? !labeledTickKeys.has(tickKey(d)) : false)
     } else {
       smartTransition(this.gridGroup, duration).style('opacity', 0)
     }
@@ -191,7 +226,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     return axisGen
   }
 
-  private _buildGrid (): D3Axis<NumberValue | Date> {
+  private _buildGrid (tickValuesOverride?: TickValues): D3Axis<NumberValue | Date> {
     const { config } = this
 
     const gridGen = this._getAxisGen()
@@ -218,28 +253,31 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       return diff > tickValuesStep / 2 ? [...tickValues, domainMaxValue] as (number[] | Date[]) : tickValues
     }
 
-    const tickValues = config.tickValues
-      ? this._getConfiguredTickValues()
-      : this._shouldRenderMinMaxTicksOnly()
-        ? getGridMinMaxTicksOnlyValues()
-        : gridScale.ticks(numTicks)
+    const tickValues = tickValuesOverride ?? (
+      config.tickValues
+        ? this._getConfiguredTickValues()
+        : this._shouldRenderMinMaxTicksOnly()
+          ? getGridMinMaxTicksOnlyValues()
+          : gridScale.ticks(numTicks)
+    )
 
     gridGen.tickValues(tickValues)
 
     return gridGen
   }
 
-  private _renderAxis (selection = this.axisGroup, duration = this.config.duration): void {
+  private _renderAxis (selection = this.axisGroup, duration = this.config.duration, tickValuesOverride?: TickValues, labeledTickKeys?: Set<string>): void {
     const { config } = this
 
     const axisGen = this._buildAxis()
     const axisScale = axisGen.scale<ContinuousScale>()
-    const tickValues: (number[] | Date[]) =
+    const tickValues: TickValues = tickValuesOverride ?? (
       config.tickValues
         ? this._getConfiguredTickValues()
         : this._shouldRenderMinMaxTicksOnly()
           ? axisScale.domain()
           : axisScale.ticks(this._getNumTicks())
+    )
     const tickCount = tickValues.length
     axisGen.tickValues(tickValues)
 
@@ -270,8 +308,14 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .filter(tickValue => tickValues.some((t: number | Date) => isEqual(tickValue, t))) // We use isEqual to compare Dates
       .classed(s.tickLabel, true)
       .classed(s.tickLabelHideable, Boolean(config.tickTextHideOverlapping))
-      .classed(s.tickTextExiting, false)
+      // Ticks outside the fitted set render as unlabeled tick marks
+      .classed(s.tickTextHidden, tickValue => labeledTickKeys ? !labeledTickKeys.has(tickKey(tickValue)) : false)
       .style('fill', config.tickTextColor) as Selection<SVGTextElement, number, SVGGElement, unknown> | Selection<SVGTextElement, Date, SVGGElement, unknown>
+
+    // Stale inline opacity (set by the overlap pass) would override the hiding class
+    if (labeledTickKeys) {
+      tickText.filter(tickValue => !labeledTickKeys.has(tickKey(tickValue))).style('opacity', null)
+    }
 
     // Marking exiting elements
     selection.selectAll<SVGTextElement, number | Date>('g.tick > text')
@@ -283,31 +327,18 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
     const tickSize = axisGen.tickSize()
     const axisPosition = this.getPosition()
-    const textMaxWidth = config.tickTextWidth || (config.type === AxisType.X ? this._containerWidth / (tickCount + 1) : this._containerWidth / 5)
+    // Fair-share label width counts labeled ticks only, matching what the tick fitting measured
+    const textMaxWidth = this._getTickTextMaxWidth(labeledTickKeys?.size ?? tickCount)
     tickText.each((value: number | Date, i: number, elements: ArrayLike<SVGTextElement>) => {
-      let text = config.tickFormat?.(value, i, tickValues) ?? `${value}`
+      let text = config.tickFormat?.(value, i, tickValues as number[] | Date[]) ?? `${value}`
       const textElement = elements[i] as SVGTextElement
-
-      // Get and cache the tick text style
-      if (!this._tickTextStyleCached) {
-        const styleDeclaration = getComputedStyle(textElement)
-        this._tickTextStyleCached = {
-          fontSize: Number.parseFloat(styleDeclaration.fontSize),
-          fontFamily: styleDeclaration.fontFamily,
-          fontWidthToHeightRatio: getFontWidthToHeightRatio(),
-        }
-      }
+      const tickTextStyle = this._getTickTextStyle(textElement)
 
       // Calculate the text offset based on the axis position and the tick size
-      const [textOffsetX, textOffsetY] = this._getTickTextOffset(axisPosition, tickSize, this._tickTextStyleCached.fontSize)
+      const [textOffsetX, textOffsetY] = this._getTickTextOffset(axisPosition, tickSize, tickTextStyle.fontSize)
 
-      // Prepare the Unovis text options
       const textOptions: UnovisTextOptions = {
-        verticalAlign: config.type === AxisType.X ? VerticalAlign.Top : VerticalAlign.Middle,
-        width: textMaxWidth,
-        textRotationAngle: config.tickTextAngle,
-        separator: config.tickTextSeparator,
-        wordBreak: config.tickTextForceWordBreak,
+        ...this._getTickTextOptions(textMaxWidth),
         x: textOffsetX,
         y: textOffsetY,
       }
@@ -318,7 +349,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
         text = select<SVGTextElement, string>(textElement).text()
       }
 
-      const textBlock: UnovisText = { text, ...this._tickTextStyleCached }
+      const textBlock: UnovisText = { text, ...tickTextStyle }
       const dominantBaseline = config.type === AxisType.X ? 'central' : 'hanging'
       renderTextToSvgTextElement(textElement, textBlock, textOptions, dominantBaseline)
     })
@@ -336,7 +367,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
   private _resolveTickLabelOverlap (selection = this.axisGroup): void {
     const { config } = this
-    const tickTextSelection = selection.selectAll<SVGTextElement, number | Date>(`g.tick > text:not(.${s.tickTextExiting})`)
+    const tickTextSelection = selection.selectAll<SVGTextElement, number | Date>(`g.tick > text:not(.${s.tickTextExiting}):not(.${s.tickTextHidden})`)
 
     if (!config.tickTextHideOverlapping) {
       tickTextSelection.style('opacity', null)
@@ -346,25 +377,148 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
     cancelAnimationFrame(this._collideTickLabelsAnimFrameId)
     // Colliding labels in the next frame to prevent forced reflow
     this._collideTickLabelsAnimFrameId = requestAnimationFrame(() => {
-      hideOverlappingLabels(tickTextSelection, { tolerance: -5 })
+      hideOverlappingLabels(tickTextSelection, { tolerance: TICK_LABEL_OVERLAP_TOLERANCE_PX })
     })
   }
 
+  /** Finds the largest tick set whose labels don't overlap (see {@link findFittingTickValues}),
+   * along with the original tick set — its remaining ticks get rendered as unlabeled tick marks.
+   * The candidates are "nice" d3 tick sets, or every-k-th subsets when explicit `tickValues` are set.
+   * Returns `undefined` when the search is not applicable, falling back to the default tick generation. */
+  private _getFittingTickValues (): TickSets | undefined {
+    const { config } = this
+    if (!config.tickTextAdaptiveSets) return undefined
+    if (this._shouldRenderMinMaxTicksOnly()) return undefined
+
+    const scale = (config.type === AxisType.X ? this.xScale : this.yScale) as ContinuousScale
+    const maxNumTicks = Math.ceil(this._getNumTicks())
+    const configuredTickValues = this._getConfiguredTickValues()
+
+    const candidates = configuredTickValues
+      ? getTickValueSubsetCandidates(configuredTickValues)
+      : getTickValueCandidates(scale, maxNumTicks)
+    const fitting = findFittingTickValues(candidates, values => this._getTickLabelRects(values), TICK_LABEL_OVERLAP_TOLERANCE_PX)
+    if (!fitting) return undefined
+
+    const originalTicks = configuredTickValues ?? getNestedTickValues(scale, maxNumTicks, candidates[0])
+    return { ...fitting, originalTicks }
+  }
+
+  /** Fair-share width available to a tick label before it gets wrapped or trimmed */
+  private _getTickTextMaxWidth (labelCount: number): number {
+    const { config } = this
+    return config.tickTextWidth ||
+      (config.type === AxisType.X ? this._containerWidth / (labelCount + 1) : this._containerWidth / 5)
+  }
+
+  /** Label rendering options shared between `_renderAxis` and the tick fitting predictions
+   * (see `_getTickLabelRects`) — the two must stay identical for the predicted geometry
+   * to match the render. Precise (cached) measurements are used for wrapping for the same reason */
+  private _getTickTextOptions (textMaxWidth: number): UnovisTextOptions {
+    const { config } = this
+    return {
+      verticalAlign: config.type === AxisType.X ? VerticalAlign.Top : VerticalAlign.Middle,
+      width: textMaxWidth,
+      textRotationAngle: config.tickTextAngle,
+      separator: config.tickTextSeparator,
+      wordBreak: config.tickTextForceWordBreak,
+      fastMode: false,
+    }
+  }
+
+  /** Predicts tick label rects using the same text wrapping and cached measurements
+   * the renderer itself relies on. */
+  private _getTickLabelRects (values: TickValues): Rect[] {
+    const { config } = this
+    const isX = config.type === AxisType.X
+    const scale = (isX ? this.xScale : this.yScale) as ContinuousScale
+    const style = this._getTickTextStyle()
+    const textOptions = this._getTickTextOptions(this._getTickTextMaxWidth(values.length))
+    const lineHeightPx = style.fontSize * UNOVIS_TEXT_DEFAULT.lineHeight
+    const angleRad = (config.tickTextAngle ?? 0) / 180 * Math.PI
+
+    return values.map((value, i) => {
+      const text = config.tickFormat?.(value, i, values as number[] | Date[]) ?? `${value}`
+
+      // Label size, computed the same way _renderAxis will compute it
+      let width: number
+      let height: number
+      if (config.tickTextFitMode === FitMode.Trim) {
+        // Approximation of trimSVGText: a trimmed label can't be wider than its width budget
+        const fullWidth = getPreciseStringLengthPx(text, style.fontFamily, style.fontSize, style.fontWeight)
+        width = Math.min(fullWidth, textOptions.width)
+        height = lineHeightPx
+      } else {
+        const wrapped = getWrappedText({ text, ...style }, textOptions.width, undefined, textOptions.fastMode, textOptions.separator, textOptions.wordBreak)
+        const lines = wrapped.flatMap(block => block._lines)
+        const lineWidths = lines.map(line => getPreciseStringLengthPx(line, style.fontFamily, style.fontSize, style.fontWeight))
+        width = Math.max(0, ...lineWidths)
+        height = estimateWrappedTextHeight(wrapped)
+      }
+
+      // Label extent relative to its anchor at the tick position
+      const position = scale(value as never)
+      const tickPosition: [number, number] = isX ? [position, 0] : [0, position]
+      const textAlign = isFunction(config.tickTextAlign)
+        ? config.tickTextAlign(value, i, values as number[] | Date[], tickPosition, this._width, this._height)
+        : config.tickTextAlign
+
+      let x0: number
+      if (!isX) {
+        // Y axis labels extend from the axis towards the chart edge
+        x0 = this.getPosition() === Position.Left ? -width : 0
+      } else if (textAlign === TextAlign.Left) {
+        x0 = 0
+      } else if (textAlign === TextAlign.Right) {
+        x0 = -width
+      } else {
+        // X axis labels are center-anchored by default
+        x0 = -width / 2
+      }
+      const y0 = isX ? -lineHeightPx / 2 : -height / 2
+
+      const localRect = { x: x0, y: y0, width, height }
+      const rect = angleRad ? getRotatedRectAabb(localRect, angleRad) : localRect
+      return { ...rect, x: tickPosition[0] + rect.x, y: tickPosition[1] + rect.y }
+    })
+  }
+
+  /** Returns the cached tick label text style, resolving it on first use — from the given
+   * element when provided, otherwise from a throwaway element with the same classes */
+  private _getTickTextStyle (textElement?: SVGTextElement): TickTextStyle {
+    if (this._tickTextStyleCached) {
+      return this._tickTextStyleCached
+    }
+
+    const helper = textElement ? undefined : this.g.append('g')
+      .attr('class', s.tick)
+      .style('font-size', this.config.tickTextFontSize)
+    const element = textElement ?? helper.append('text').attr('class', s.tickLabel).node()
+    const styleDeclaration = getComputedStyle(element)
+    this._tickTextStyleCached = {
+      fontSize: Number.parseFloat(styleDeclaration.fontSize),
+      fontFamily: styleDeclaration.fontFamily,
+      fontWeight: Number.parseFloat(styleDeclaration.fontWeight) || undefined,
+    }
+    helper?.remove()
+    return this._tickTextStyleCached
+  }
+
   private _getNumTicks (): number {
-    const { config: { type, numTicks } } = this
+    const { config: { type, numTicks, tickSpacing } } = this
 
     if (numTicks) return numTicks
 
     if (type === AxisType.X) {
       const xRange = this.xScale.range() as [number, number]
       const width = xRange[1] - xRange[0]
-      return Math.floor(width / 175)
+      return Math.max(1, Math.floor(width / tickSpacing))
     }
 
     if (type === AxisType.Y) {
       const yRange = this.yScale.range() as [number, number]
       const height = Math.abs(yRange[0] - yRange[1])
-      return Math.pow(height, 0.85) / 25
+      return Math.max(1, Math.pow(height, 0.85) / 25)
     }
 
     return this._defaultNumTicks
@@ -384,7 +538,10 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
 
   private _shouldRenderMinMaxTicksOnly (): boolean {
     const { config } = this
-    return config.minMaxTicksOnly || (config.type === AxisType.X && this._width < config.minMaxTicksOnlyWhenWidthIsLess)
+    if (config.minMaxTicksOnly) return true
+    // The tick fitting owns the narrow-width behavior when enabled
+    if (config.tickTextAdaptiveSets) return false
+    return config.type === AxisType.X && this._width < config.minMaxTicksOnlyWhenWidthIsLess
   }
 
   private _getFullDomainPath (tickSize = 0): string {

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -79,6 +79,13 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .attr('class', s.grid)
   }
 
+  public setConfig (config: AxisConfigInterface<Datum>): void {
+    // `tickTextFontSize` is the only config option the cached font metrics depend on
+    // (CSS-driven font changes are not tracked, as re-resolving the style forces a reflow)
+    if (config?.tickTextFontSize !== this.config.tickTextFontSize) this._tickTextStyleCached = undefined
+    super.setConfig(config)
+  }
+
   /** Renders axis to an invisible grouped to calculate automatic chart margins */
   public preRender (): void {
     const { config } = this

--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -114,6 +114,18 @@ export const tickTextExiting = css`
   label: tick-text-exiting;
 `
 
+export const gridTickHidden = css`
+  label: grid-tick-hidden;
+  opacity: 0;
+  transition: var(${variables.axisTickLabelHideTransition});
+`
+
+export const tickTextHidden = css`
+  label: tick-text-hidden;
+  opacity: 0;
+  transition: var(${variables.axisTickLabelHideTransition});
+`
+
 export const label = css`
   label: label;
   fill: var(${variables.axisLabelColor});

--- a/packages/ts/src/components/axis/tick-fit.ts
+++ b/packages/ts/src/components/axis/tick-fit.ts
@@ -1,0 +1,116 @@
+// Types
+import { Rect } from '@/types/misc'
+import { ContinuousScale } from '@/types/scale'
+
+// Utils
+import { isEqual } from '@/utils/data'
+import { rectIntersect } from '@/utils/misc'
+import { resolveRectsOverlap } from '@/utils/text-overlap'
+
+// Local Types
+import { FittedTickValues, TickValues } from './types'
+
+/** Tick value identity across renders; `+value` so equal `Date`s match */
+export const tickKey = (value: number | Date): string => String(+value)
+
+/** Merges two tick sets, deduplicated and sorted */
+export const mergeTickValues = (a: TickValues, b: TickValues): TickValues => {
+  const keys = new Set(a.map(tickKey))
+  const extra = b.filter(value => !keys.has(tickKey(value)))
+  if (!extra.length) return a
+
+  return [...a, ...extra].sort((x, y) => +x - +y)
+}
+
+/** Returns the tick values to render as marks, restricting the step to 1 or 5 × 10^k.
+ * Every coarser "nice" step is then a multiple of the mark step, so the label sets picked by
+ * {@link findFittingTickValues} land on existing marks and label changes don't add or remove
+ * ticks — visibility toggles animate in CSS with no tick lifecycle management.
+ * Time scales are returned as is: their tick intervals don't form a nested ladder. */
+export function getNestedTickValues (scale: ContinuousScale, maxNumTicks: number, values: TickValues = scale.ticks(maxNumTicks)): TickValues {
+  if (values.length < 2 || values[0] instanceof Date) return values
+
+  const step = (values[1] as number) - (values[0] as number)
+  const stepPower = Math.floor(Math.log10(step))
+  const stepMantissa = step / Math.pow(10, stepPower)
+  if (Math.round(stepMantissa) !== 2) return values
+
+  // Doubling the requested count makes d3 pick the next finer (1 × 10^k) step
+  return scale.ticks(maxNumTicks * 2)
+}
+
+/** Generates candidate tick sets in decreasing size, from `maxNumTicks` down to a single tick.
+ * Consecutive counts often produce the same "nice" values, so the sets are deduplicated. */
+export function getTickValueCandidates (scale: ContinuousScale, maxNumTicks: number): TickValues[] {
+  const candidates: TickValues[] = []
+  for (let n = maxNumTicks; n >= 1; n -= 1) {
+    const values: TickValues = scale.ticks(n)
+    const previous = candidates[candidates.length - 1]
+    if (!previous || !isEqual(values, previous)) candidates.push(values)
+  }
+  return candidates
+}
+
+/** Generates candidate subsets of a custom tick list in decreasing size — every value,
+ * every 2nd, every 3rd and so on, anchored at the first value so the labeled ticks
+ * stay evenly spaced. Used when explicit `tickValues` are fitted adaptively. */
+export function getTickValueSubsetCandidates (values: TickValues): TickValues[] {
+  const candidates: TickValues[] = []
+  for (let k = 1; k <= values.length; k += 1) {
+    const subset = values.filter((_, i) => i % k === 0)
+    const previous = candidates[candidates.length - 1]
+    if (!previous || subset.length < previous.length) candidates.push(subset)
+  }
+  return candidates
+}
+
+/** Indices of the adjacent rect pairs that collide: `0` for the (0, 1) pair and so on.
+ * The rects are expected to be ordered along one axis, the way tick labels are */
+function getCollidingAdjacentPairs (rects: Rect[], tolerance: number): number[] {
+  const pairs: number[] = []
+  for (let pair = 0; pair < rects.length - 1; pair += 1) {
+    if (rectIntersect(rects[pair], rects[pair + 1], tolerance)) pairs.push(pair)
+  }
+  return pairs
+}
+
+/** Finds the largest tick set whose labels don't overlap, among `candidates` ordered from
+ * the densest to the sparsest (see {@link getTickValueCandidates}). Label rects come from
+ * `getLabelRects`, which is expected to predict them without rendering (see
+ * `Axis._getTickLabelRects`). The search stops at the first fitting candidate.
+ * `tolerance` is forwarded to `resolveRectsOverlap`. */
+export function findFittingTickValues (
+  candidates: TickValues[],
+  getLabelRects: (values: TickValues) => Rect[],
+  tolerance = 0
+): FittedTickValues | undefined {
+  const fits = (rects: Rect[]): boolean =>
+    resolveRectsOverlap(rects, { tolerance }).every(visible => visible)
+
+  for (const fittedTicks of candidates) {
+    const rects = getLabelRects(fittedTicks)
+    if (fits(rects)) return { fittedTicks, labeledTicks: fittedTicks }
+
+    // A candidate whose only colliding labels are the extreme (first / last) ones
+    // is still used: the extreme labels are dropped, while their ticks stay
+    const collidingPairs = getCollidingAdjacentPairs(rects, tolerance)
+    const firstPair = 0
+    const lastPair = rects.length - 2
+    const collidesOnExtremesOnly = collidingPairs.length > 0 &&
+      collidingPairs.every(pair => pair === firstPair || pair === lastPair)
+    if (!collidesOnExtremesOnly) continue
+
+    const labeledTicks = [...fittedTicks]
+    if (collidingPairs.includes(lastPair)) labeledTicks.pop()
+    if (collidingPairs.includes(firstPair)) labeledTicks.shift()
+    // A two-tick candidate loses both labels above — keep the first one, a single label always fits
+    if (!labeledTicks.length) labeledTicks.push(fittedTicks[0])
+
+    // The remaining labels get a wider fair share of the axis after the drop,
+    // so the subset is re-measured before getting accepted
+    if (fits(getLabelRects(labeledTicks))) return { fittedTicks, labeledTicks }
+  }
+
+  const sparsestTicks = candidates[candidates.length - 1]
+  return sparsestTicks && { fittedTicks: sparsestTicks, labeledTicks: sparsestTicks }
+}

--- a/packages/ts/src/components/axis/types.ts
+++ b/packages/ts/src/components/axis/types.ts
@@ -2,3 +2,19 @@ export enum AxisType {
   X = 'x',
   Y = 'y',
 }
+
+export type TickValues = (number | Date)[]
+
+/** Result of the adaptive tick fitting */
+export type TickSets = {
+  /** The largest set whose labels fit, all of its ticks are rendered */
+  fittedTicks: TickValues;
+  /** The values of `fittedTicks` that get labeled */
+  labeledTicks: TickValues;
+  /** The full (unfitted) tick set — its remaining ticks render as unlabeled marks.
+   * Kept step-nested so the fitted sets are its subsets, see `getNestedTickValues` */
+  originalTicks: TickValues;
+}
+
+/** The tick set picked by the fitting search, see `findFittingTickValues` */
+export type FittedTickValues = Pick<TickSets, 'fittedTicks' | 'labeledTicks'>

--- a/packages/ts/src/utils/misc.ts
+++ b/packages/ts/src/utils/misc.ts
@@ -50,6 +50,24 @@ export function getPixelValue (v: string | number): number | null {
   return typeof v === 'number' ? v : toPx(v)
 }
 
+/** Returns the axis-aligned bounding box of `rect` rotated by `angleRad` around the origin */
+export function getRotatedRectAabb (rect: Rect, angleRad: number): Rect {
+  const sin = Math.sin(angleRad)
+  const cos = Math.cos(angleRad)
+  const corners = [
+    [rect.x, rect.y],
+    [rect.x + rect.width, rect.y],
+    [rect.x, rect.y + rect.height],
+    [rect.x + rect.width, rect.y + rect.height],
+  ]
+  const xs = corners.map(([x, y]) => x * cos - y * sin)
+  const ys = corners.map(([x, y]) => x * sin + y * cos)
+
+  const x = Math.min(...xs)
+  const y = Math.min(...ys)
+  return { x, y, width: Math.max(...xs) - x, height: Math.max(...ys) - y }
+}
+
 export function rectIntersect (rect1: Rect, rect2: Rect, tolerancePx = 0): boolean {
   const [left1, top1, right1, bottom1] = [
     rect1.x + tolerancePx,

--- a/packages/ts/src/utils/text-measure.ts
+++ b/packages/ts/src/utils/text-measure.ts
@@ -104,9 +104,9 @@ export function getCachedComputedTextLength (el: SVGTextElement | SVGTSpanElemen
   return length
 }
 
-export function getPreciseStringLengthPx (str: string, fontFamily: string, fontSize: string | number): number {
+export function getPreciseStringLengthPx (str: string, fontFamily: string, fontSize: string | number, fontWeight?: string | number): number {
   const fontSizeStr = typeof fontSize === 'number' ? `${fontSize}px` : fontSize
-  const font = `${fontSizeStr} ${fontFamily}`
+  const font = `${fontWeight ?? ''} ${fontSizeStr} ${fontFamily}`.trimStart()
   const key = getTextCacheKey(str, font)
 
   const cached = textLengthCache.get(key)
@@ -122,6 +122,7 @@ export function getPreciseStringLengthPx (str: string, fontFamily: string, fontS
     text.textContent = str
     text.setAttribute('font-size', fontSizeStr)
     text.setAttribute('font-family', fontFamily)
+    if (fontWeight !== undefined) text.setAttribute('font-weight', `${fontWeight}`)
     svg.appendChild(text)
     document.body.appendChild(svg)
     length = text.getComputedTextLength()

--- a/packages/ts/src/utils/text-overlap.ts
+++ b/packages/ts/src/utils/text-overlap.ts
@@ -101,7 +101,8 @@ export function hideOverlappingLabels<El extends SVGGraphicsElement, D, PEl exte
 ): void {
   const nodes = selection.nodes()
   if (nodes.length < 2) {
-    selection.style('opacity', null)
+    // Hideable labels are hidden by a class style until made visible here
+    selection.style('opacity', 1)
     return
   }
 

--- a/packages/ts/src/utils/text.ts
+++ b/packages/ts/src/utils/text.ts
@@ -291,6 +291,7 @@ function breakTextIntoLines (
   if (!text) return []
   const fontSize = textBlock.fontSize ?? UNOVIS_TEXT_DEFAULT.fontSize
   const fontFamily = textBlock.fontFamily ?? UNOVIS_TEXT_DEFAULT.fontFamily
+  const fontWeight = textBlock.fontWeight
   const fontWidthToHeightRatio: number | undefined = textBlock.fontWidthToHeightRatio ?? UNOVIS_TEXT_DEFAULT.fontWidthToHeightRatio
   const separators = Array.isArray(separator) ? separator : [separator]
 
@@ -304,7 +305,7 @@ function breakTextIntoLines (
     for (let i = 0; i < words.length; i += 1) {
       const textLengthPx = fastMode
         ? estimateStringPixelLength(line + words[i], fontSize, fontWidthToHeightRatio)
-        : getPreciseStringLengthPx(line + words[i], fontFamily, fontSize)
+        : getPreciseStringLengthPx(line + words[i], fontFamily, fontSize, fontWeight)
 
       if (textLengthPx < width || i === 0) {
         line += words[i]
@@ -319,7 +320,7 @@ function breakTextIntoLines (
         while (line.trim().length > minCharactersOnLine) {
           const subLineLengthPx = fastMode
             ? estimateStringPixelLength(line, fontSize, fontWidthToHeightRatio)
-            : getPreciseStringLengthPx(line, fontFamily, fontSize)
+            : getPreciseStringLengthPx(line, fontFamily, fontSize, fontWeight)
 
           if (subLineLengthPx > width) {
             let breakIndex = (line.trim()).length - minCharactersOnLine // Place at least `minCharactersOnLine` characters onto the next line
@@ -327,7 +328,7 @@ function breakTextIntoLines (
               const subLine = `${line.substring(0, breakIndex)}${UNOVIS_TEXT_HYPHEN_CHARACTER_DEFAULT}` // Use hyphen when force breaking words
               const subLinePx = fastMode
                 ? estimateStringPixelLength(subLine, fontSize, fontWidthToHeightRatio)
-                : getPreciseStringLengthPx(subLine, fontFamily, fontSize)
+                : getPreciseStringLengthPx(subLine, fontFamily, fontSize, fontWeight)
 
               // If the subline is less than the width, or just one character left, break the line
               if (subLinePx <= width || breakIndex === 1) {
@@ -399,7 +400,7 @@ export function getWrappedText (
       const lineWithEllipsis = `${line} …`
       const textLengthPx = fastMode
         ? estimateStringPixelLength(lineWithEllipsis, text.fontSize, text.fontWidthToHeightRatio)
-        : getPreciseStringLengthPx(lineWithEllipsis, text.fontFamily, text.fontSize)
+        : getPreciseStringLengthPx(lineWithEllipsis, text.fontFamily, text.fontSize, text.fontWeight)
 
       maxWidth = Math.max(textLengthPx, maxWidth)
       if (height && (h + dh) > height && (k !== lines.length - 1)) {

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -203,6 +203,20 @@ The specified count is only a hint, the axis can have more or fewer ticks depend
   defaultValue={20}
   property="numTicks"/>
 
+### Tick Spacing `new`
+When `numTicks` is not set, the _Axis_ derives the tick count from the component's size. For the X axis, the `tickSpacing` property controls that density by setting the approximate distance between ticks in pixels (default: `175`). Smaller values pack in more ticks; larger values spread them out.
+
+:::note
+`tickSpacing` only applies to the X axis, and is ignored when `numTicks` is set explicitly.
+:::
+
+<XYWrapperWithInput
+  {...axisProps()}
+  inputType="range"
+  inputProps={{ min: 40, max: 300, step: 5 }}
+  defaultValue={175}
+  property="tickSpacing"/>
+
 ### Display Only Minimum and Maximum Ticks
 Set the `minMaxTicksOnly` property to `true` if you only want to see the two end ticks on the axis.
 
@@ -240,7 +254,7 @@ function tickValues() {
 ```
 <XYWrapper {...axisProps()} tickValues={[0,2,4,6,8]} hiddenProps={{x:d=>d.x}}/>
 
-### Hide Overlapping Ticks `1.5`
+### Hide Overlapping Ticks
 To prevent overlapping tick labels on the axis, you can use the `tickTextHideOverlapping`
 property. When enabled, it hides any tick labels that would otherwise overlap with
 one another based on a simple bounding box collision detection algorithm. This
@@ -253,6 +267,32 @@ so results can vary depending on tick rotation.
 :::
 
 <XYWrapper {...axisProps()} numTicks={15} containerProps={{ xDomain: [0, 10000000] }} hiddenProps={{x:d=>d.x}} tickTextHideOverlapping={true}/>
+
+### Adaptive Tick Sets `new`
+Set `tickTextAdaptiveSets` to `true` to let the _Axis_ pick the number of ticks automatically so that their labels never overlap. The axis measures candidate tick sets off-screen and renders the largest "nice" set that fits, degrading to sparser sets on narrower charts. Ticks left out of the fitted set still render as unlabeled tick marks, so the axis scale stays visually intact.
+
+`numTicks` (or, when it's not set, the width-based default derived from `tickSpacing`) acts as the upper bound on the number of labeled ticks.
+
+Toggle the checkbox below to see how enabling `tickTextAdaptiveSets` resolves the overlap on a dense, wide-range axis:
+
+<XYWrapperWithInput
+  {...axisProps()}
+  inputType="checkbox"
+  defaultValue={true}
+  property="tickTextAdaptiveSets"
+  numTicks={20}
+  containerProps={{ xDomain: [0, 10000000] }}
+  hiddenProps={{ gridLine: false, x: d => d.x }}/>
+
+When explicit `tickValues` are provided, the axis instead fits every-k-th subset of them (every value, then every 2nd, every 3rd, and so on), anchored at the first value so the labeled ticks stay evenly spaced.
+
+:::note
+`tickTextAdaptiveSets` takes over the narrow-width behavior: it disables the width-based `minMaxTicksOnlyWhenWidthIsLess` fallback, and has no effect when `minMaxTicksOnly` is enabled.
+:::
+
+:::tip
+When `tickTextAdaptiveSets` is enabled, you don't need to also set `tickTextHideOverlapping`. The adaptive pass already measures label overlap and only labels the ticks that fit, so no labels overlap in the first place.
+:::
 
 
 ## Displaying Multiple Axes


### PR DESCRIPTION
## What & why

This PR introduces adaptive tick sets, a new axis option, that picks tick labels to display in a coordinated manner, instead of filtering them one by one.

## Checklist

<!-- Tick what applies; delete what doesn't. A new component usually touches all four. -->

- [x] Dev examples
- [x] Wrappers (regenerated via `pnpm generate`)
- [x] Docs
- [x] Lint passes on the files I changed
- [x] Builds locally (`pnpm build`)

## Screenshots / recordings


https://github.com/user-attachments/assets/390763b8-971d-4e13-8f8b-fe5a966aa7a1


https://github.com/user-attachments/assets/4fa28497-e76a-4ea6-a5c2-20db094c89f6


