### PR TITLE
Component | Controls: Fix dark theme buttons border color variable reference

### DIFF
--- a/packages/dev/src/examples/auxiliary/controls/vis-controls-dark-theme/index.tsx
+++ b/packages/dev/src/examples/auxiliary/controls/vis-controls-dark-theme/index.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useRef } from 'react'
+import { VisControls } from '@unovis/ts'
+
+export const title = 'Controls'
+export const subTitle = 'Theme border color'
+
+export const component = (): React.ReactNode => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return undefined
+    const controls = new VisControls(containerRef.current, {
+      items: [
+        { icon: '+' },
+        { icon: '&minus;', borderLeft: true },
+        { icon: '&#x21bb;', borderLeft: true },
+      ],
+    })
+    return () => { controls.element.remove() }
+  }, [])
+
+  return (
+    <div style={{ padding: 40 }}>
+      <p>Border respects the active theme</p>
+      <div ref={containerRef} />
+    </div>
+  )
+}

--- a/packages/ts/src/components/vis-controls/style.ts
+++ b/packages/ts/src/components/vis-controls/style.ts
@@ -19,7 +19,7 @@ export const variables = injectGlobal`
   }
 
   ${darkThemeCssSelectors} ${`.${root}`} {
-    --vis-controls-buttons-border-color: var(--vis-dark-controls.buttons-border-color);
+    --vis-controls-buttons-border-color: var(--vis-dark-controls-buttons-border-color);
     --vis-controls-buttons-background-color: var(--vis-dark-controls-buttons-background-color);
     --vis-controls-button-color: var(--vis-dark-controls-button-color);
   }


### PR DESCRIPTION
## What & why

The dot is not valid in a CSS identifier, and the line gets dropped, so we get the light theme border color.

JSDom (how I initially saw it) shows "Could not parse CSS stylesheet".

Updated variable and double checked it is the correct name.

## Checklist

- [x] Dev examples
- [x] Lint passes on the files I changed
- [x] Builds locally (`pnpm build`)
- [x] All commands pass (`pnpm cmds-report`)

## Screenshots / recordings

| Before | After |
| --- | --- |
| <img width="526" height="365" alt="Screenshot 2026-08-05 115816" src="https://github.com/user-attachments/assets/02e7cdd0-9dac-413a-a0da-76a00908cd0d" /> | <img width="526" height="365" alt="Screenshot 2026-08-05 115848" src="https://github.com/user-attachments/assets/40c83925-3cad-4054-91d5-874c6e7034ad" /> |