### PR TITLE
Component | Axis: Config for label trim separator character

### DIFF
--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -96,6 +96,9 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
   @Input() labelTextTrimType?: TrimMode | `${TrimMode}`
 
+  /** Label text wrapping separator. String or array of strings. Default: `undefined` */
+  @Input() labelTextSeparator?: string | string[]
+
   /** Font color of the axis label as CSS string. Default: `null` */
   @Input() labelColor?: string | null
 
@@ -201,8 +204,8 @@ export class VisAxisComponent<Datum> implements AxisConfigInterface<Datum>, Afte
   }
 
   private getConfig (): AxisConfigInterface<Datum> {
-    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize } = this
-    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize }
+    const { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize } = this
+    const config = { duration, events, attributes, position, type, fullSize, label, labelFontSize, labelMargin, labelTextFitMode, labelTextTrimType, labelTextSeparator, labelColor, gridLine, tickLine, domainLine, minMaxTicksOnly, minMaxTicksOnlyShowGridLines, minMaxTicksOnlyWhenWidthIsLess, tickFormat, tickValues, numTicks, tickSpacing, tickTextFitMode, tickTextWidth, tickTextSeparator, tickTextForceWordBreak, tickTextTrimType, tickTextFontSize, tickTextAlign, tickTextColor, tickTextAngle, tickTextAdaptiveSets, tickTextHideOverlapping, tickPadding, tickSize }
     const keys = Object.keys(config) as (keyof AxisConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/ts/src/components/axis/config.ts
+++ b/packages/ts/src/components/axis/config.ts
@@ -23,6 +23,8 @@ export interface AxisConfigInterface<Datum> extends Partial<XYComponentConfigInt
   labelTextFitMode?: FitMode | `${FitMode}`;
   /** Label text trim mode: `TrimMode.Start`, `TrimMode.Middle` or `TrimMode.End`. Default: `TrimMode.Middle` */
   labelTextTrimType?: TrimMode | `${TrimMode}`;
+  /** Label text wrapping separator. String or array of strings. Default: `undefined` */
+  labelTextSeparator?: string | string[];
   /** Font color of the axis label as CSS string. Default: `null` */
   labelColor?: string | null;
   /** Sets whether to draw the grid lines or not. Default: `true` */
@@ -95,6 +97,7 @@ export const AxisDefaultConfig: AxisConfigInterface<unknown> = {
   labelFontSize: null,
   labelTextFitMode: FitMode.Wrap,
   labelTextTrimType: TrimMode.Middle,
+  labelTextSeparator: undefined,
   gridLine: true,
   tickLine: true,
   domainLine: true,

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -560,7 +560,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
   }
 
   private _renderAxisLabel (selection = this.axisGroup): void {
-    const { type, label, labelMargin, labelFontSize, labelTextFitMode } = this.config
+    const { type, label, labelMargin, labelFontSize, labelTextFitMode, labelTextSeparator } = this.config
 
     // Remove the old label first to calculate the axis size properly
     selection.selectAll(`.${s.label}`).remove()
@@ -593,7 +593,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       const currentTextWidth = getCachedComputedTextLength(textElement.node())
 
       if (currentTextWidth > maxWidth) {
-        wrapSVGText(textElement, maxWidth)
+        wrapSVGText(textElement, maxWidth, labelTextSeparator)
         isWrapped = true
       }
     }

--- a/packages/website/docs/auxiliary/Axis.mdx
+++ b/packages/website/docs/auxiliary/Axis.mdx
@@ -69,6 +69,23 @@ Change the label color with the `labelColor` property.
 The spacing between the label and the axis itself can be set with the `labelMargin` property:
 <XYWrapperWithInput {...axisProps()} label="Label" inputType="range" inputProps={{ min: 0, max: 50, step: 1}} defaultValue={5} property="labelMargin"/>
 
+### Label Text Separator
+When a label is too long to fit, _Axis_ wraps it onto multiple lines (this happens when `labelTextFitMode` is
+set to `FitMode.Wrap`, which is the default). You can control where the text is allowed to break by providing the
+`labelTextSeparator` property with a `string` or `string[]` of separators. By default the label breaks on spaces, hyphens, periods and commas.
+
+In the example below the label contains none of the default separators, so it can't wrap and overflows the axis.
+Provide `"/"` as the separator to let it break on the slashes instead.
+<XYWrapperWithInput
+  {...axisProps()}
+  type="y"
+  configKey="yAxis"
+  height={150}
+  label="Population/Density/Per/Square/Kilometer"
+  inputType="text"
+  defaultValue="/"
+  property="labelTextSeparator"/>
+
 ## Grid Line
 You can enable or disable the visibility of the _Axis_ grid line with the `gridLine` property.
 <XYWrapperWithInput


### PR DESCRIPTION
<!--
  Thanks for contributing to Unovis!
  • Commit messages follow our format: `Type | Scope: Sentence-case subject`
    → https://unovis.dev/contributing/pull-requests#commit-messages
  • First-time contributors: the F5 CLA bot will ask you to sign the CLA.
  • Using an AI coding agent (Claude Code, Codex, Cursor)? See AGENTS.md at the repo root.
-->

## What & why

Adding a new config property: `labelTextSeparator`. 
@lee00678, we've been using it for quite a while already, I just forgot to push it to the upstream.

## Checklist

<!-- Tick what applies; delete what doesn't. A new component usually touches all four. -->

- [x] Dev examples
- [x] Wrappers (regenerated via `pnpm generate`)
- [x] Docs
- [x] Lint passes on the files I changed
- [x] Builds locally (`pnpm build`)
- [x] All commands pass (`pnpm cmds-report`)

## Screenshots / recordings


https://github.com/user-attachments/assets/c5da40d9-0697-41b5-a753-5edb94fb5e22

