### PR TITLE
Core | Component: Resolve `config.events` callbacks at dispatch time

### DIFF
--- a/packages/dev/src/examples/misc/component-events/stale-event-handlers/index.tsx
+++ b/packages/dev/src/examples/misc/component-events/stale-event-handlers/index.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { Scatter } from '@unovis/ts'
+import { VisXYContainer, VisAxis, VisScatter } from '@unovis/react'
+
+export const title = 'Component Events: Stale Handlers'
+export const subTitle = 'Handler freshness after a config update'
+
+type Datum = { x: number; y: number }
+
+/** How often the surrounding app re-renders, emulating a dashboard-wide cross-filter.
+ * Any interval below `ComponentCore`'s 500ms event re-bind throttle keeps the throttle window
+ * permanently occupied, which is when a stale handler becomes observable. */
+const RE_RENDER_INTERVAL_MS = 100
+
+/** Kept at module scope so the point test ids stay stable across re-renders. */
+const pointAttributes = {
+  [Scatter.selectors.point]: {
+    visScatterPointE2eTestId: (d: Datum) => `stale-events-point-${d.x}`,
+  },
+}
+
+const rowStyle: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }
+
+export const component = (): React.ReactNode => {
+  const data = useMemo<Datum[]>(() => Array.from({ length: 6 }, (_, i) => ({ x: i, y: 1 })), [])
+
+  const [renderCount, setRenderCount] = useState(0)
+  const [reRenderBurst, setReRenderBurst] = useState(true)
+  const [selected, setSelected] = useState<number | null>(null)
+  const [maxHandlerLag, setMaxHandlerLag] = useState(0)
+  const [log, setLog] = useState<string[]>([])
+
+  // Always holds the values of the most recent render, so that a handler can compare what it
+  // captured against what is actually current at the moment of the click.
+  const currentRef = useRef({ renderCount, selected })
+  useEffect(() => { currentRef.current = { renderCount, selected } })
+
+  useEffect(() => {
+    if (!reRenderBurst) return
+    const timer = setInterval(() => setRenderCount(c => c + 1), RE_RENDER_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [reRenderBurst])
+
+  // Re-created on every render, capturing `renderCount` and `selected` from *this* render.
+  // A fresh closure is handed to Unovis through `config.events` on every config update, so the
+  // handler that actually runs should always be the newest one.
+  const onPointClick = (d: Datum, event: MouseEvent, i: number): void => {
+    const current = currentRef.current
+    const handlerLag = current.renderCount - renderCount
+    setMaxHandlerLag(m => Math.max(m, handlerLag))
+
+    // Read-modify-write against the captured `selected`: when the handler that runs is stale it
+    // compares against a selection that has already changed, so clicking an already selected
+    // point re-selects it instead of clearing the selection.
+    const next = selected === i ? null : i
+    setSelected(next)
+
+    setLog(prev => [
+      `point ${i} — handler built on render #${renderCount}, current render #${current.renderCount} ` +
+      `(lag ${handlerLag}); it saw selected=${String(selected)} while the real value was ` +
+      `${String(current.selected)}, so it set selected=${String(next)}`,
+      ...prev,
+    ].slice(0, 6))
+  }
+
+  const reset = (): void => {
+    setMaxHandlerLag(0)
+    setLog([])
+    setSelected(null)
+  }
+
+  return (
+    <div>
+      <p>
+        Every render passes a brand new <code>click</code> closure through the <code>events</code> config.
+        The closure reports which render built it, so a non-zero lag means Unovis invoked a handler from an
+        earlier config. Click a point a few times while the re-render burst is running.
+      </p>
+
+      <div style={rowStyle}>
+        <label>
+          <input
+            type='checkbox'
+            checked={reRenderBurst}
+            onChange={e => setReRenderBurst(e.target.checked)}
+          />
+          {` Re-render every ${RE_RENDER_INTERVAL_MS}ms (emulates a dashboard-wide cross-filter)`}
+        </label>
+        <button onClick={reset}>Reset</button>
+      </div>
+
+      <div style={rowStyle}>
+        <span>render #<b data-test-id='render-count'>{renderCount}</b></span>
+        <span>selected: <b data-test-id='selected'>{String(selected)}</b></span>
+        <span style={{ color: maxHandlerLag > 0 ? '#e74c3c' : '#2ecc71' }}>
+          worst handler lag: <b data-test-id='max-handler-lag'>{maxHandlerLag}</b>
+          {maxHandlerLag > 0 ? ' renders behind — stale handler' : ' — handler is current'}
+        </span>
+      </div>
+
+      <VisXYContainer<Datum> data={data} height={200} yDomain={[0, 2]}>
+        <VisScatter
+          x={(d: Datum) => d.x}
+          y={(d: Datum) => d.y}
+          size={40}
+          color={(d: Datum) => (d.x === selected ? '#e74c3c' : '#3498db')}
+          attributes={pointAttributes}
+          events={{
+            [Scatter.selectors.point]: {
+              click: onPointClick,
+            },
+          }}
+          duration={0}
+        />
+        <VisAxis type='x' />
+      </VisXYContainer>
+
+      <ol style={{ fontFamily: 'monospace', fontSize: 12 }}>
+        {log.map((entry, i) => <li key={`${log.length}-${i}`}>{entry}</li>)}
+      </ol>
+    </div>
+  )
+}

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -14,10 +14,13 @@ import { Spacing } from '@/types/spacing'
 import { ColorFunction } from '@/types/accessor'
 
 // Local Types
-import { VisEventCallback, VisEventType } from './types'
+import { VisEventType } from './types'
 
 // Config
 import { ComponentDefaultConfig, ComponentConfigInterface } from './config'
+
+/** Shape shared by the component's own default events and the user-defined `config.events`. */
+type ComponentEvents = NonNullable<ComponentConfigInterface['events']>
 
 export class ComponentCore<
   CoreDatum,
@@ -32,11 +35,7 @@ export class ComponentCore<
   public sizing: Sizing | string = Sizing.Fit // Supported by SingleContainer and a subset of components only (Sankey, Heatmap)
   public uid: string
 
-  protected events: {
-    [selector: string]: {
-      [eventType in VisEventType]?: VisEventCallback;
-    };
-  } = {}
+  protected events: ComponentEvents = {}
 
   /** Default configuration */
   protected _defaultConfig: ConfigInterface = ComponentDefaultConfig as ConfigInterface
@@ -53,6 +52,10 @@ export class ComponentCore<
   /** Color scale for the component. This property is set automatically by the container. */
   protected _colorFunction: ColorFunction | undefined = undefined
 
+  /** Re-binds the component's event listeners so that newly rendered elements get them too.
+   * Throttled because the components that render a lot of elements call it on every frame of a
+   * pan / zoom / layout interaction (see Graph, LeafletMap and TopoJSONMap). Delaying a re-bind
+   * does not delay a configuration change: `_bindEvents` resolves the callbacks at dispatch time. */
   _setUpComponentEventsThrottled = throttle(this._setUpComponentEvents, 500)
 
   /** Set the container margin. Called automatically by containers. */
@@ -142,10 +145,10 @@ export class ComponentCore<
 
   private _setUpComponentEvents (): void {
     // Set up default events
-    this._bindEvents(this.events)
+    this._bindEvents(() => this.events)
 
     // Set up user-defined events
-    this._bindEvents(this.config.events, '.user')
+    this._bindEvents(() => this.config.events, '.user')
   }
 
   // Sometimes we don't want to pass the original data and/or index to the event handler.
@@ -155,17 +158,25 @@ export class ComponentCore<
     return { datum, index }
   }
 
-  private _bindEvents (events = this.events, suffix = ''): void {
+  /** Attaches a listener for every selector / event type of the provided events map.
+   * The map is passed as a getter and the callback is resolved when the event fires instead of
+   * being captured here: `setConfig` replaces `this.config` with a newly merged object, so a
+   * captured map would keep invoking the callbacks of an outdated configuration until the next
+   * re-bind — which `render()` throttles by 500ms. */
+  private _bindEvents (getEvents: () => ComponentEvents | undefined, suffix = ''): void {
+    const events = getEvents() ?? {}
     Object.keys(events).forEach(className => {
       Object.keys(events[className]).forEach(eventType => {
         const selection = (this.g as Selection<SVGGElement | HTMLElement, unknown, null, undefined>)
           .selectAll<SVGGElement | HTMLElement, unknown>(`.${className}`)
         selection.on(eventType + suffix, (event: MouseEvent & WheelEvent & PointerEvent & TouchEvent, d) => {
+          const eventFunction = getEvents()?.[className]?.[eventType as VisEventType]
+          if (!eventFunction) return
+
           const els = selection.nodes()
           const i = els.indexOf(event.currentTarget as SVGGElement | HTMLElement)
-          const eventFunction = events[className][eventType as VisEventType]
           const { datum, index } = this._mapEventDatum(d, i)
-          return eventFunction?.(datum, event, index, els)
+          return eventFunction(datum, event, index, els)
         })
       })
     })

--- a/packages/ts/src/core/component/index.ts
+++ b/packages/ts/src/core/component/index.ts
@@ -53,6 +53,10 @@ export class ComponentCore<
   /** Color scale for the component. This property is set automatically by the container. */
   protected _colorFunction: ColorFunction | undefined = undefined
 
+  /** Re-binds the component's event listeners so that newly rendered elements get them too.
+   * Throttled because the components that render a lot of elements call it on every frame of a
+   * pan / zoom / layout interaction (see Graph, LeafletMap and TopoJSONMap). Delaying a re-bind
+   * does not delay a configuration change: `_bindEvents` resolves the callbacks at dispatch time. */
   _setUpComponentEventsThrottled = throttle(this._setUpComponentEvents, 500)
 
   /** Set the container margin. Called automatically by containers. */
@@ -142,10 +146,10 @@ export class ComponentCore<
 
   private _setUpComponentEvents (): void {
     // Set up default events
-    this._bindEvents(this.events)
+    this._bindEvents(() => this.events)
 
     // Set up user-defined events
-    this._bindEvents(this.config.events, '.user')
+    this._bindEvents(() => this.config.events, '.user')
   }
 
   // Sometimes we don't want to pass the original data and/or index to the event handler.
@@ -155,7 +159,13 @@ export class ComponentCore<
     return { datum, index }
   }
 
-  private _bindEvents (events = this.events, suffix = ''): void {
+  /** Attaches a listener for every selector / event type of the provided events map.
+   * The map is passed as a getter and the callback is resolved when the event fires instead of
+   * being captured here: `setConfig` replaces `this.config` with a newly merged object, so a
+   * captured map would keep invoking the callbacks of an outdated configuration until the next
+   * re-bind — which `render()` throttles by 500ms. */
+  private _bindEvents (getEvents: () => ComponentConfigInterface['events'], suffix = ''): void {
+    const events = getEvents() ?? {}
     Object.keys(events).forEach(className => {
       Object.keys(events[className]).forEach(eventType => {
         const selection = (this.g as Selection<SVGGElement | HTMLElement, unknown, null, undefined>)
@@ -165,10 +175,12 @@ export class ComponentCore<
         // instead of re-querying the DOM on every dispatched event
         const els = selection.nodes()
         selection.on(eventType + suffix, (event: MouseEvent & WheelEvent & PointerEvent & TouchEvent, d) => {
+          const eventFunction = getEvents()?.[className]?.[eventType as VisEventType]
+          if (!eventFunction) return
+
           const i = els.indexOf(event.currentTarget as SVGGElement | HTMLElement)
-          const eventFunction = events[className][eventType as VisEventType]
           const { datum, index } = this._mapEventDatum(d, i)
-          return eventFunction?.(datum, event, index, els)
+          return eventFunction(datum, event, index, els)
         })
       })
     })


### PR DESCRIPTION
## Problem

Callbacks passed through `config.events` keep running from an outdated configuration after `setConfig`. A consumer that re-renders in bursts — a dashboard-wide cross-filter, say — and passes closures capturing state gets handlers that read stale state. A read-modify-write handler then makes the wrong decision: clicking an already-selected element compares against a selection that has already changed and re-selects it instead of clearing it.

## Root cause

`_bindEvents` captured the events map at the moment it attached the listener, and resolved the callback out of that captured object:

```ts
private _bindEvents (events = this.events, suffix = '') {   // `events` captured here
  selection.on(eventType + suffix, (event, d) => {
    const eventFunction = events[className][eventType]       // resolved from the captured object
```

`setConfig` does `this.config = merge(this._defaultConfig, config)`, and `merge` deep-clones — so `this.config.events` is a **new object on every update**. The attached closure still points at the previous one.

Re-binding is what refreshes it, and that happens at the end of `render()` through `_setUpComponentEventsThrottled` (500ms). So during a burst of updates the previously bound callbacks stay live until the trailing invocation. The throttle only bounds *how long* the callback is stale — the capture is what makes it stale at all. Where re-binding is delayed further (containers schedule rendering inside `requestAnimationFrame`, which a background tab suspends), the callback never refreshes.

## Fix

`_bindEvents` now takes the events map as a getter and resolves the callback when the event fires rather than when the listener is attached. Callback identity stops mattering, so no re-bind is needed on a config change. Both call sites go through it, so the component's own default events and the user-defined `.user` ones behave identically:

```ts
this._bindEvents(() => this.events)
this._bindEvents(() => this.config.events, '.user')
```

No public API change; the `events` config shape is untouched.

### The throttle stays

`Graph`, `LeafletMap` and `TopoJSONMap` call `_setUpComponentEventsThrottled()` directly on every frame of a pan / zoom / layout interaction. Unthrottled, each frame would re-run `selectAll` plus `.on()` across every rendered element. It still earns its keep for selector and DOM churn — it is now simply orthogonal to callback correctness. I added a comment at the declaration recording why it exists, since that wasn't written down anywhere.

### Also fixed: handler removal

Removing an entry from `config.events` previously left the old listener firing indefinitely — a re-bind only attaches callbacks that are still in the map, and nothing detached the old one. It now resolves to nothing and the listener is a no-op.

### Known residual

A **newly added** `(selector, eventType)` pair still has no listener attached until the next throttled re-bind (≤500ms). This is the same pre-existing exposure that brand-new DOM nodes have always had. Closing it needs an events-shape check that bypasses the throttle, which lands inconsistently: `Tooltip`, `BulletLegend`, `FlowLegend` and `RollingPinLegend` don't call `super.setConfig` — they inline `this.config = merge(...)` themselves — so any logic added there would silently skip those four. Happy to follow up if you'd like it closed.


## Reproducing

Added a dev example: **Component Events → Component Events: Stale Handlers**.

It re-renders every 100ms to keep the 500ms re-bind window occupied, and each click closure reports which render built it. Any non-zero lag means an outdated callback ran. It also drives the read-modify-write selection toggle described above.

Before this change, clicking a point reported a lag of 5 renders — exactly the 500ms window at a 100ms cadence — and the selection stayed stuck instead of toggling off. After, the lag is 0 and the toggle behaves.

## Testing

- `pnpm run build` passes for all six packages (ts, angular, react, svelte, vue, solid), and `pnpm run build:dev`.
- Typechecked clean under both TypeScript 4.9 and 5.8 (the repo pins 4.2, whose bundled parser chokes on the current `@types/node`, so the build alone does not catch a dangling type reference).
- New example verified in a browser before and after: lag `5` → `0`; selection stuck at `2` → toggles `2` ⇄ `null`.
- Internal `this.events` path still fires — dispatching `mouseenter` / `mouseleave` on a Scatter point still sets `_forceShowLabel` and raises the node.
- `cypress/e2e/tooltip.cy.ts` has 7 failures on the built dev app, but they are **identical with and without this change** — pre-existing and unrelated (Cypress `ensureElIsNotCovered` actionability errors). Flagging in case it's news.
