### PR TITLE
Wrappers: Import granular `@unovis/ts` subpaths instead of the root barrel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,7 @@
     "no-useless-constructor": "off",
     "no-multiple-empty-lines": ["error", { "max": 2, "maxBOF": 0}],
     "import/extensions": 0,
-    "import/no-unresolved": [2, {"commonjs": true, "amd": true, "ignore": ["^@theme", "^@docusaurus", "^@site"]}],
+    "import/no-unresolved": [2, {"commonjs": true, "amd": true, "ignore": ["^@theme", "^@docusaurus", "^@site", "^@unovis/ts/"]}],
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
     "import/first": ["error", "absolute-first"],

--- a/packages/angular/autogen/index.ts
+++ b/packages/angular/autogen/index.ts
@@ -19,8 +19,20 @@ const components = getComponentList() as AngularComponentInput[]
 const skipProperties = ['renderIntoProvidedDomNode']
 
 for (const component of components) {
-  const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties, false)
-  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics, component.isStandAlone ? [] : ['ContainerCore'])
+  const { configProperties, configInterfaceMembers, generics, statements, importSourceMap } = getConfigSummary(component, skipProperties, false)
+  // `ContainerCore` isn't referenced by any component config, so it never makes it into
+  // importSourceMap — without an explicit entry it would fall back to the `@unovis/ts` root barrel.
+  const importSources = { ...importSourceMap }
+  importSources.ContainerCore ??= '@unovis/ts/core/container'
+
+  const importStatements = getImportStatements(
+    component.name,
+    statements,
+    configInterfaceMembers,
+    generics,
+    component.isStandAlone ? [] : ['ContainerCore'],
+    importSources
+  )
 
   const componentCode = getComponentCode(
     component.name,

--- a/packages/angular/gallery/tsconfig.app.json
+++ b/packages/angular/gallery/tsconfig.app.json
@@ -4,7 +4,10 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "paths": {
-     "@unovis/ts": ["../../ts/lib/index.js"],
+     "@unovis/ts": ["../../ts/dist/index.js"],
+     // The wrappers import granular subpaths (`@unovis/ts/components/area`), which only exist
+     // under `packages/ts/dist` — the root of the published tarball, but not of the workspace package.
+     "@unovis/ts/*": ["../../ts/dist/*"],
      "@unovis/shared/*": ["../../shared/*"],
      "@unovis/angular": ["../src/public-api.ts"],
     },

--- a/packages/angular/src/components/annotations/annotations.component.ts
+++ b/packages/angular/src/components/annotations/annotations.component.ts
@@ -1,6 +1,10 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import { Annotations, AnnotationsConfigInterface, ContainerCore, VisEventType, VisEventCallback, AnnotationItem } from '@unovis/ts'
+import { Annotations } from '@unovis/ts/components/annotations'
+import { AnnotationsConfigInterface } from '@unovis/ts/components/annotations/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { AnnotationItem } from '@unovis/ts/components/annotations/types'
 import { VisGenericComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/area/area.component.ts
+++ b/packages/angular/src/components/area/area.component.ts
@@ -1,20 +1,13 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Area,
-  AreaConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  FillPatternType,
-  CurveType,
-  StringAccessor,
-  LinePatternType,
-} from '@unovis/ts'
+import { Area } from '@unovis/ts/components/area'
+import { AreaConfigInterface } from '@unovis/ts/components/area/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { FillPatternType, LinePatternType } from '@unovis/ts/styles/patterns'
+import { CurveType } from '@unovis/ts/types/curve'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/axis/axis.component.ts
+++ b/packages/angular/src/components/axis/axis.component.ts
@@ -1,17 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Axis,
-  AxisConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  Position,
-  AxisType,
-  FitMode,
-  TrimMode,
-  TextAlign,
-} from '@unovis/ts'
+import { Axis } from '@unovis/ts/components/axis'
+import { AxisConfigInterface } from '@unovis/ts/components/axis/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { Position } from '@unovis/ts/types/position'
+import { AxisType } from '@unovis/ts/components/axis/types'
+import { FitMode, TrimMode, TextAlign } from '@unovis/ts/types/text'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/boxplot/boxplot.component.ts
+++ b/packages/angular/src/components/boxplot/boxplot.component.ts
@@ -1,17 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Boxplot,
-  BoxplotConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  StringAccessor,
-} from '@unovis/ts'
+import { Boxplot } from '@unovis/ts/components/boxplot'
+import { BoxplotConfigInterface } from '@unovis/ts/components/boxplot/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
 import { VisXYComponent } from '../../core'
 
 @Component({
@@ -79,6 +73,11 @@ export class VisBoxplotComponent<Datum> implements BoxplotConfigInterface<Datum>
 
   /** Box fill color accessor function. Default: `d => d.color` */
   @Input() color?: ColorAccessor<Datum>
+
+  /** Array of data color keys. Use to map data keys to colors.
+   * Expected to the same length as the `y` accessors array.
+   * Default: `undefined` */
+  @Input() colorKeys?: string[]
 
   /** Scale for X dimension, e.g. Scale.scaleLinear(). If you set xScale you'll be responsible for setting it's `domain` and `range` as well.
    * Only continuous scales are supported.
@@ -148,8 +147,8 @@ export class VisBoxplotComponent<Datum> implements BoxplotConfigInterface<Datum>
   }
 
   private getConfig (): BoxplotConfigInterface<Datum> {
-    const { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor } = this
-    const config = { duration, events, attributes, x, id, color, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor }
+    const { duration, events, attributes, x, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor } = this
+    const config = { duration, events, attributes, x, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, median, quartiles, whiskers, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor }
     const keys = Object.keys(config) as (keyof BoxplotConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/angular/src/components/brush/brush.component.ts
+++ b/packages/angular/src/components/brush/brush.component.ts
@@ -1,7 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import { Brush, BrushConfigInterface, ContainerCore, VisEventType, VisEventCallback, Arrangement } from '@unovis/ts'
+import { Brush } from '@unovis/ts/components/brush'
+import { BrushConfigInterface } from '@unovis/ts/components/brush/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
 import { D3BrushEvent } from 'd3-brush'
+import { Arrangement } from '@unovis/ts/types/position'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
+++ b/packages/angular/src/components/chord-diagram/chord-diagram.component.ts
@@ -1,22 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  ChordDiagram,
-  ChordDiagramConfigInterface,
-  ContainerCore,
-  ChordInputNode,
-  ChordInputLink,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ChordNodeDatum,
-  ColorAccessor,
-  ChordLinkDatum,
-  GenericAccessor,
-  FillPatternType,
-  StringAccessor,
-  ChordLabelAlignment,
-} from '@unovis/ts'
+import { ChordDiagram } from '@unovis/ts/components/chord-diagram'
+import { ChordDiagramConfigInterface } from '@unovis/ts/components/chord-diagram/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { ChordInputNode, ChordInputLink, ChordNodeDatum, ChordLinkDatum, ChordLabelAlignment } from '@unovis/ts/components/chord-diagram/types'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/crosshair/crosshair.component.ts
+++ b/packages/angular/src/components/crosshair/crosshair.component.ts
@@ -1,18 +1,14 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Crosshair,
-  CrosshairConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  Tooltip,
-  CrosshairSnapMode,
-  CrosshairCircle,
-} from '@unovis/ts'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { CrosshairConfigInterface } from '@unovis/ts/components/crosshair/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { CrosshairSnapMode } from '@unovis/ts/components/crosshair/constants'
+import { CrosshairCircle } from '@unovis/ts/components/crosshair/types'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/donut/donut.component.ts
+++ b/packages/angular/src/components/donut/donut.component.ts
@@ -1,16 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Donut,
-  DonutConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  GenericAccessor,
-  FillPatternType,
-} from '@unovis/ts'
+import { Donut } from '@unovis/ts/components/donut'
+import { DonutConfigInterface } from '@unovis/ts/components/donut/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor } from '@unovis/ts/types/accessor'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/free-brush/free-brush.component.ts
+++ b/packages/angular/src/components/free-brush/free-brush.component.ts
@@ -1,6 +1,10 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import { FreeBrush, FreeBrushConfigInterface, ContainerCore, VisEventType, VisEventCallback, FreeBrushMode, FreeBrushSelection } from '@unovis/ts'
+import { FreeBrush } from '@unovis/ts/components/free-brush'
+import { FreeBrushConfigInterface } from '@unovis/ts/components/free-brush/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { FreeBrushMode, FreeBrushSelection } from '@unovis/ts/components/free-brush/types'
 import { D3BrushEvent } from 'd3-brush'
 import { VisXYComponent } from '../../core'
 

--- a/packages/angular/src/components/graph/graph.component.ts
+++ b/packages/angular/src/components/graph/graph.component.ts
@@ -1,41 +1,34 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
+import { Graph } from '@unovis/ts/components/graph'
+import { GraphConfigInterface } from '@unovis/ts/components/graph/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { GraphInputNode, GraphInputLink, GraphInputData } from '@unovis/ts/types/graph'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { Spacing } from '@unovis/ts/types/spacing'
 import {
-  Graph,
-  GraphConfigInterface,
-  ContainerCore,
-  GraphInputNode,
-  GraphInputLink,
-  VisEventType,
-  VisEventCallback,
-  Spacing,
   GraphFitViewAlignment,
   GraphLayoutType,
-  StringAccessor,
   GraphForceLayoutSettings,
   GraphDagreLayoutSetting,
-  GenericAccessor,
   GraphElkLayoutSettings,
   GraphNode,
-  NumericAccessor,
   GraphLinkStyle,
   GraphLinkArrowStyle,
-  ColorAccessor,
-  BooleanAccessor,
   GraphCircleLabel,
   GraphLink,
   GraphNodeShape,
-  TrimMode,
   GraphNodeSelectionHighlightMode,
   GraphPanelConfig,
-  GraphInputData,
-  GraphDataModel,
-} from '@unovis/ts'
+} from '@unovis/ts/components/graph/types'
+import { StringAccessor, GenericAccessor, NumericAccessor, ColorAccessor, BooleanAccessor } from '@unovis/ts/types/accessor'
 import { ElkShape } from 'elkjs'
+import { TrimMode } from '@unovis/ts/types/text'
 import { Selection } from 'd3-selection'
 import { D3DragEvent } from 'd3-drag'
 import { D3ZoomEvent, ZoomTransform } from 'd3-zoom'
 import { D3BrushEvent } from 'd3-brush'
+import { GraphDataModel } from '@unovis/ts/data-models/graph'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/grouped-bar/grouped-bar.component.ts
+++ b/packages/angular/src/components/grouped-bar/grouped-bar.component.ts
@@ -1,19 +1,13 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  GroupedBar,
-  GroupedBarConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  FillPatternType,
-  StringAccessor,
-  Orientation,
-} from '@unovis/ts'
+import { GroupedBar } from '@unovis/ts/components/grouped-bar'
+import { GroupedBarConfigInterface } from '@unovis/ts/components/grouped-bar/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
+import { Orientation } from '@unovis/ts/types/position'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/heatmap/heatmap.component.ts
+++ b/packages/angular/src/components/heatmap/heatmap.component.ts
@@ -1,16 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Heatmap,
-  HeatmapConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  HeatmapLayoutType,
-  StringAccessor,
-} from '@unovis/ts'
+import { Heatmap } from '@unovis/ts/components/heatmap'
+import { HeatmapConfigInterface } from '@unovis/ts/components/heatmap/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { HeatmapLayoutType } from '@unovis/ts/components/heatmap/types'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/line/line.component.ts
+++ b/packages/angular/src/components/line/line.component.ts
@@ -1,19 +1,13 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Line,
-  LineConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  LinePatternType,
-  CurveType,
-  StringAccessor,
-} from '@unovis/ts'
+import { Line } from '@unovis/ts/components/line'
+import { LineConfigInterface } from '@unovis/ts/components/line/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { LinePatternType } from '@unovis/ts/styles/patterns'
+import { CurveType } from '@unovis/ts/types/curve'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/nested-donut/nested-donut.component.ts
+++ b/packages/angular/src/components/nested-donut/nested-donut.component.ts
@@ -1,20 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  NestedDonut,
-  NestedDonutConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NestedDonutDirection,
-  NumericAccessor,
-  NestedDonutSegment,
-  StringAccessor,
-  GenericAccessor,
-  NestedDonutLayerSettings,
-  ColorAccessor,
-  FillPatternType,
-} from '@unovis/ts'
+import { NestedDonut } from '@unovis/ts/components/nested-donut'
+import { NestedDonutConfigInterface } from '@unovis/ts/components/nested-donut/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NestedDonutDirection, NestedDonutSegment, NestedDonutLayerSettings } from '@unovis/ts/components/nested-donut/types'
+import { NumericAccessor, StringAccessor, GenericAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/plotband/plotband.component.ts
+++ b/packages/angular/src/components/plotband/plotband.component.ts
@@ -1,15 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Plotband,
-  PlotbandConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  AxisType,
-  PlotbandLabelPosition,
-  PlotbandLabelOrientation,
-} from '@unovis/ts'
+import { Plotband } from '@unovis/ts/components/plotband'
+import { PlotbandConfigInterface } from '@unovis/ts/components/plotband/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { AxisType } from '@unovis/ts/components/axis/types'
+import { PlotbandLabelPosition, PlotbandLabelOrientation } from '@unovis/ts/components/plotband/types'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/plotline/plotline.component.ts
+++ b/packages/angular/src/components/plotline/plotline.component.ts
@@ -1,16 +1,11 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Plotline,
-  PlotlineConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  AxisType,
-  PlotlineLineStylePresets,
-  PlotlineLabelPosition,
-  PlotlineLabelOrientation,
-} from '@unovis/ts'
+import { Plotline } from '@unovis/ts/components/plotline'
+import { PlotlineConfigInterface } from '@unovis/ts/components/plotline/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { AxisType } from '@unovis/ts/components/axis/types'
+import { PlotlineLineStylePresets, PlotlineLabelPosition, PlotlineLabelOrientation } from '@unovis/ts/components/plotline/types'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/radial-bar/radial-bar.component.ts
+++ b/packages/angular/src/components/radial-bar/radial-bar.component.ts
@@ -1,6 +1,10 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import { RadialBar, RadialBarConfigInterface, ContainerCore, VisEventType, VisEventCallback, NumericAccessor, ColorAccessor } from '@unovis/ts'
+import { RadialBar } from '@unovis/ts/components/radial-bar'
+import { RadialBarConfigInterface } from '@unovis/ts/components/radial-bar/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/sankey/sankey.component.ts
+++ b/packages/angular/src/components/sankey/sankey.component.ts
@@ -1,32 +1,26 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
+import { Sankey } from '@unovis/ts/components/sankey'
+import { SankeyConfigInterface } from '@unovis/ts/components/sankey/config'
+import { ContainerCore } from '@unovis/ts/core/container'
 import {
-  Sankey,
-  SankeyConfigInterface,
-  ContainerCore,
   SankeyInputNode,
   SankeyInputLink,
-  VisEventType,
-  VisEventCallback,
   SankeyZoomMode,
   SankeyExitTransitionType,
   SankeyEnterTransitionType,
   SankeyNode,
   SankeyLink,
   SankeyNodeAlign,
-  StringAccessor,
-  ColorAccessor,
-  GenericAccessor,
-  FillPatternType,
-  NumericAccessor,
-  Position,
-  VerticalAlign,
-  FitMode,
-  TrimMode,
   SankeySubLabelPlacement,
-  Spacing,
-} from '@unovis/ts'
+} from '@unovis/ts/components/sankey/types'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { StringAccessor, ColorAccessor, GenericAccessor, NumericAccessor } from '@unovis/ts/types/accessor'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
+import { Position } from '@unovis/ts/types/position'
+import { VerticalAlign, FitMode, TrimMode } from '@unovis/ts/types/text'
 import { D3ZoomEvent } from 'd3-zoom'
+import { Spacing } from '@unovis/ts/types/spacing'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/scatter/scatter.component.ts
+++ b/packages/angular/src/components/scatter/scatter.component.ts
@@ -1,20 +1,14 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Scatter,
-  ScatterConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  FillPatternType,
-  SymbolType,
-  StringAccessor,
-  Position,
-} from '@unovis/ts'
+import { Scatter } from '@unovis/ts/components/scatter'
+import { ScatterConfigInterface } from '@unovis/ts/components/scatter/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
+import { SymbolType } from '@unovis/ts/types/symbol'
+import { Position } from '@unovis/ts/types/position'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/stacked-bar/stacked-bar.component.ts
+++ b/packages/angular/src/components/stacked-bar/stacked-bar.component.ts
@@ -1,19 +1,13 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  StackedBar,
-  StackedBarConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  FillPatternType,
-  StringAccessor,
-  Orientation,
-} from '@unovis/ts'
+import { StackedBar } from '@unovis/ts/components/stacked-bar'
+import { StackedBarConfigInterface } from '@unovis/ts/components/stacked-bar/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
+import { Orientation } from '@unovis/ts/types/position'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/timeline/timeline.component.ts
+++ b/packages/angular/src/components/timeline/timeline.component.ts
@@ -1,25 +1,15 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Timeline,
-  TimelineConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  StringAccessor,
-  GenericAccessor,
-  FillPatternType,
-  Arrangement,
-  TimelineRowLabel,
-  TimelineRowIcon,
-  TextAlign,
-  TrimMode,
-  TimelineArrow,
-  TimelineLineRenderState,
-} from '@unovis/ts'
+import { Timeline } from '@unovis/ts/components/timeline'
+import { TimelineConfigInterface } from '@unovis/ts/components/timeline/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, StringAccessor, GenericAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { FillPatternType } from '@unovis/ts/styles/patterns'
+import { Arrangement } from '@unovis/ts/types/position'
+import { TimelineRowLabel, TimelineRowIcon, TimelineArrow, TimelineLineRenderState } from '@unovis/ts/components/timeline/types'
+import { TextAlign, TrimMode } from '@unovis/ts/types/text'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/tooltip/tooltip.component.ts
+++ b/packages/angular/src/components/tooltip/tooltip.component.ts
@@ -1,6 +1,10 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import { Tooltip, TooltipConfigInterface, ContainerCore, ComponentCore, Position } from '@unovis/ts'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { TooltipConfigInterface } from '@unovis/ts/components/tooltip/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { Position } from '@unovis/ts/types/position'
 import { VisGenericComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/topojson-map/topojson-map.component.ts
+++ b/packages/angular/src/components/topojson-map/topojson-map.component.ts
@@ -1,19 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  TopoJSONMap,
-  TopoJSONMapConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  StringAccessor,
-  MapPointLabelPosition,
-  TopoJSONMapClusterDatum,
-  TopoJSONMapPointStyles,
-} from '@unovis/ts'
+import { TopoJSONMap } from '@unovis/ts/components/topojson-map'
+import { TopoJSONMapConfigInterface } from '@unovis/ts/components/topojson-map/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
 import { GeoProjection } from 'd3-geo'
+import { NumericAccessor, ColorAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { MapPointLabelPosition, TopoJSONMapClusterDatum, TopoJSONMapPointStyles } from '@unovis/ts/components/topojson-map/types'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/treemap/treemap.component.ts
+++ b/packages/angular/src/components/treemap/treemap.component.ts
@@ -1,20 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  Treemap,
-  TreemapConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  StringAccessor,
-  TreemapNode,
-  ColorAccessor,
-  TreemapTileFunction,
-  TreemapDatum,
-  FitMode,
-  TrimMode,
-} from '@unovis/ts'
+import { Treemap } from '@unovis/ts/components/treemap'
+import { TreemapConfigInterface } from '@unovis/ts/components/treemap/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, StringAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
+import { TreemapNode, TreemapTileFunction, TreemapDatum } from '@unovis/ts/components/treemap/types'
+import { FitMode, TrimMode } from '@unovis/ts/types/text'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/components/xy-labels/xy-labels.component.ts
+++ b/packages/angular/src/components/xy-labels/xy-labels.component.ts
@@ -1,19 +1,12 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges } from '@angular/core'
-import {
-  XYLabels,
-  XYLabelsConfigInterface,
-  ContainerCore,
-  VisEventType,
-  VisEventCallback,
-  NumericAccessor,
-  ColorAccessor,
-  ContinuousScale,
-  GenericAccessor,
-  XYLabelPositioning,
-  StringAccessor,
-  XYLabel,
-} from '@unovis/ts'
+import { XYLabels } from '@unovis/ts/components/xy-labels'
+import { XYLabelsConfigInterface } from '@unovis/ts/components/xy-labels/config'
+import { ContainerCore } from '@unovis/ts/core/container'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
+import { NumericAccessor, ColorAccessor, GenericAccessor, StringAccessor } from '@unovis/ts/types/accessor'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { XYLabelPositioning, XYLabel } from '@unovis/ts/components/xy-labels/types'
 import { VisXYComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/containers/single-container/single-container.component.ts
+++ b/packages/angular/src/containers/single-container/single-container.component.ts
@@ -1,7 +1,13 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, Input, OnDestroy, SimpleChanges, ContentChild } from '@angular/core'
 
 // Vis
-import { ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Spacing, Annotations, Sizing } from '@unovis/ts'
+import { SingleContainer } from '@unovis/ts/containers/single-container'
+import { SingleContainerConfigInterface } from '@unovis/ts/containers/single-container/config'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Annotations } from '@unovis/ts/components/annotations'
+import { Spacing } from '@unovis/ts/types/spacing'
+import { Sizing } from '@unovis/ts/types/component'
 import { VisCoreComponent } from '../../core'
 import { VisTooltipComponent } from '../../components/tooltip/tooltip.component'
 import { VisAnnotationsComponent } from '../../components/annotations/annotations.component'

--- a/packages/angular/src/containers/xy-container/xy-container.component.ts
+++ b/packages/angular/src/containers/xy-container/xy-container.component.ts
@@ -13,7 +13,15 @@ import {
 } from '@angular/core'
 
 // Vis
-import { Annotations, Axis, ContinuousScale, Crosshair, Direction, Spacing, Tooltip, XYContainer, XYContainerConfigInterface } from '@unovis/ts'
+import { XYContainer } from '@unovis/ts/containers/xy-container'
+import { XYContainerConfigInterface } from '@unovis/ts/containers/xy-container/config'
+import { Annotations } from '@unovis/ts/components/annotations'
+import { Axis } from '@unovis/ts/components/axis'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { ContinuousScale } from '@unovis/ts/types/scale'
+import { Direction } from '@unovis/ts/types/direction'
+import { Spacing } from '@unovis/ts/types/spacing'
 import { VisXYComponent } from '../../core'
 import { VisTooltipComponent } from '../../components/tooltip/tooltip.component'
 import { VisAnnotationsComponent } from '../../components/annotations/annotations.component'

--- a/packages/angular/src/core/core-component.ts
+++ b/packages/angular/src/core/core-component.ts
@@ -1,4 +1,5 @@
-import { ComponentCore, ContainerCore } from '@unovis/ts'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { ContainerCore } from '@unovis/ts/core/container'
 import { VisGenericComponent } from './generic-component'
 
 export class VisCoreComponent extends VisGenericComponent {

--- a/packages/angular/src/core/xy-component.ts
+++ b/packages/angular/src/core/xy-component.ts
@@ -1,4 +1,5 @@
-import { XYComponentCore, XYContainer } from '@unovis/ts'
+import { XYComponentCore } from '@unovis/ts/core/xy-component'
+import { XYContainer } from '@unovis/ts/containers/xy-container'
 import { VisCoreComponent } from './core-component'
 
 export class VisXYComponent extends VisCoreComponent {

--- a/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
+++ b/packages/angular/src/html-components/bullet-legend/bullet-legend.component.ts
@@ -1,14 +1,9 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
-import {
-  BulletLegend,
-  BulletLegendConfigInterface,
-  BulletLegendItemInterface,
-  GenericAccessor,
-  BulletShape,
-  BulletLegendOrientation,
-  ColorFunction,
-} from '@unovis/ts'
+import { BulletLegend } from '@unovis/ts/components/bullet-legend'
+import { BulletLegendConfigInterface } from '@unovis/ts/components/bullet-legend/config'
+import { BulletLegendItemInterface, BulletShape, BulletLegendOrientation } from '@unovis/ts/components/bullet-legend/types'
+import { GenericAccessor, ColorFunction } from '@unovis/ts/types/accessor'
 import { VisGenericComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/html-components/flow-legend/flow-legend.component.ts
+++ b/packages/angular/src/html-components/flow-legend/flow-legend.component.ts
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
-import { FlowLegend, FlowLegendConfigInterface, Spacing } from '@unovis/ts'
+import { FlowLegend } from '@unovis/ts/components/flow-legend'
+import { FlowLegendConfigInterface } from '@unovis/ts/components/flow-legend/config'
+import { Spacing } from '@unovis/ts/types/spacing'
 import { VisGenericComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
+++ b/packages/angular/src/html-components/leaflet-flow-map/leaflet-flow-map.component.ts
@@ -1,25 +1,21 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
+import { LeafletFlowMap } from '@unovis/ts/components/leaflet-flow-map'
+import { LeafletFlowMapConfigInterface } from '@unovis/ts/components/leaflet-flow-map/config'
+import { GenericDataRecord } from '@unovis/ts/types/data'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
 import {
-  LeafletFlowMap,
-  LeafletFlowMapConfigInterface,
-  GenericDataRecord,
-  VisEventType,
-  VisEventCallback,
   Bounds,
-  MapLibreStyleSpecs,
   LeafletMapRenderer,
   MapZoomState,
-  NumericAccessor,
-  StringAccessor,
-  GenericAccessor,
   LeafletMapPointShape,
-  ColorAccessor,
   LeafletMapPointDatum,
   LeafletMapClusterDatum,
   LeafletMapPointStyles,
-  Tooltip,
-} from '@unovis/ts'
+} from '@unovis/ts/components/leaflet-map/types'
+import { MapLibreStyleSpecs } from '@unovis/ts/components/leaflet-map/renderer/map-style'
+import { NumericAccessor, StringAccessor, GenericAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
+import { Tooltip } from '@unovis/ts/components/tooltip'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/html-components/leaflet-map/leaflet-map.component.ts
+++ b/packages/angular/src/html-components/leaflet-map/leaflet-map.component.ts
@@ -1,25 +1,21 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
+import { LeafletMap } from '@unovis/ts/components/leaflet-map'
+import { LeafletMapConfigInterface } from '@unovis/ts/components/leaflet-map/config'
+import { GenericDataRecord } from '@unovis/ts/types/data'
+import { VisEventType, VisEventCallback } from '@unovis/ts/core/component/types'
 import {
-  LeafletMap,
-  LeafletMapConfigInterface,
-  GenericDataRecord,
-  VisEventType,
-  VisEventCallback,
   Bounds,
-  MapLibreStyleSpecs,
   LeafletMapRenderer,
   MapZoomState,
-  NumericAccessor,
-  StringAccessor,
-  GenericAccessor,
   LeafletMapPointShape,
-  ColorAccessor,
   LeafletMapPointDatum,
   LeafletMapClusterDatum,
   LeafletMapPointStyles,
-  Tooltip,
-} from '@unovis/ts'
+} from '@unovis/ts/components/leaflet-map/types'
+import { MapLibreStyleSpecs } from '@unovis/ts/components/leaflet-map/renderer/map-style'
+import { NumericAccessor, StringAccessor, GenericAccessor, ColorAccessor } from '@unovis/ts/types/accessor'
+import { Tooltip } from '@unovis/ts/components/tooltip'
 import { VisCoreComponent } from '../../core'
 
 @Component({

--- a/packages/angular/src/html-components/rolling-pin-legend/rolling-pin-legend.component.ts
+++ b/packages/angular/src/html-components/rolling-pin-legend/rolling-pin-legend.component.ts
@@ -1,6 +1,8 @@
 // !!! This code was automatically generated. You should not change it !!!
 import { Component, AfterViewInit, Input, SimpleChanges, ViewChild, ElementRef } from '@angular/core'
-import { RollingPinLegend, RollingPinLegendConfigInterface, RollingPinLegendItem } from '@unovis/ts'
+import { RollingPinLegend } from '@unovis/ts/components/rolling-pin-legend'
+import { RollingPinLegendConfigInterface } from '@unovis/ts/components/rolling-pin-legend/config'
+import { RollingPinLegendItem } from '@unovis/ts/components/rolling-pin-legend/types'
 import { VisGenericComponent } from '../../core'
 
 @Component({

--- a/packages/react/src/components/radial-bar/index.tsx
+++ b/packages/react/src/components/radial-bar/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
 import React, { ForwardedRef, ReactElement, Ref, useImperativeHandle, useEffect, useRef, useState } from 'react'
-import { RadialBar, RadialBarConfigInterface } from '@unovis/ts'
+import { RadialBar } from '@unovis/ts/components/radial-bar'
+import { RadialBarConfigInterface } from '@unovis/ts/components/radial-bar/config'
 
 // Utils
 import { arePropsEqual } from 'src/utils/react'

--- a/packages/shared/integrations/utils.ts
+++ b/packages/shared/integrations/utils.ts
@@ -1,6 +1,39 @@
 import { readFileSync } from 'fs'
+import { posix } from 'path'
 import ts from 'typescript'
 import { ComponentInput, ConfigProperty, GenericParameter } from './types'
+
+/** Top-level directories of `packages/ts/src`, which are published at the root of `@unovis/ts`. */
+const unovisSourceDirs = ['core', 'types', 'utils', 'components', 'containers', 'styles', 'data-models', 'data']
+
+/**
+ * Rewrites an import specifier found inside `@unovis/ts` sources into the granular public
+ * subpath a framework wrapper can import (`@unovis/ts/components/area/config`).
+ *
+ * Wrappers must not import the `@unovis/ts` root barrel: it re-exports every component, so a
+ * bundler has to resolve and transform the whole library — including the lazily loaded map and
+ * graph layout dependencies — even for an app that only renders a line chart.
+ *
+ * `containingDir` is the source directory of the file that declared the import (`/components/area`)
+ * and is required to resolve relative specifiers. Specifiers that don't belong to `@unovis/ts`
+ * (`d3-shape`, `elkjs`) are returned untouched.
+ */
+export function resolveUnovisImportSource (importSource: string, containingDir?: string): string {
+  // `@/*` is the internal path alias configured in packages/ts/tsconfig.json
+  if (importSource.startsWith('@/')) return `@unovis/ts/${importSource.slice(2)}`
+
+  if (importSource.startsWith('./') || importSource.startsWith('../')) {
+    // Without the declaring file's location a relative specifier can't be resolved,
+    // so fall back to the root barrel rather than emitting a broken path.
+    if (!containingDir) return '@unovis/ts'
+    return `@unovis/ts${posix.normalize(`${containingDir}/${importSource}`)}`
+  }
+
+  const [firstSegment] = importSource.split('/')
+  if (importSource.includes('/') && unovisSourceDirs.includes(firstSegment)) return `@unovis/ts/${importSource}`
+
+  return importSource
+}
 
 export function getTypeName (type: ts.Node | undefined): string {
   switch (type.kind) {
@@ -84,14 +117,6 @@ export function getTypeName (type: ts.Node | undefined): string {
     }
     case (ts.SyntaxKind.ArrayType): return `${getTypeName((type as ts.ArrayTypeNode).elementType)}[]`
     case (ts.SyntaxKind.TupleType): return `[${(type as ts.TupleTypeNode).elements.map(getTypeName).join(', ')}]`
-    case (ts.SyntaxKind.TemplateLiteralType): {
-      const t = type as ts.TemplateLiteralTypeNode
-      const head = t.head?.text ?? ''
-      const spans = t.templateSpans.map((span: ts.TemplateLiteralTypeSpan) =>
-        `\${${getTypeName(span.type)}}${span.literal?.text ?? ''}`
-      ).join('')
-      return `\`${head}${spans}\``
-    }
     default: {
       console.error('Couldn\'t extract type name. Consider updating the parser code. ', type)
       return 'any'
@@ -217,13 +242,8 @@ export function getImportStatements (
       if (importSourceMap?.[typeName]) {
         importSources[typeName] = importSourceMap[typeName]
       } else {
-        let importSource: string = (importDec.moduleSpecifier as ts.StringLiteral).text
-        if (!importSource || importSource.startsWith('./') || importSource.startsWith('core/') ||
-          importSource.startsWith('types/') || importSource.startsWith('utils/') || importSource.startsWith('components/') ||
-          importSource.startsWith('styles/') || importSource.startsWith('data-models/') || importSource.startsWith('data/')
-        ) importSource = '@unovis/ts'
-
-        importSources[typeName] = importSource
+        const importSource: string = (importDec.moduleSpecifier as ts.StringLiteral).text
+        importSources[typeName] = importSource ? resolveUnovisImportSource(importSource) : '@unovis/ts'
       }
     }
   }
@@ -331,17 +351,7 @@ export function getConfigSummary (
     const importDeclarations: any[] = sourceStatements.filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
     for (const importDec of importDeclarations) {
       if (!importDec.importClause?.namedBindings?.elements) continue
-      let importSource: string = importDec.moduleSpecifier.text
-      if (importSource.startsWith('./') || importSource.startsWith('../')) {
-        importSource = `@unovis/ts${path}/${importSource.replace(/^\.\//, '')}`
-      } else if (
-        importSource.startsWith('core/') || importSource.startsWith('types/') ||
-        importSource.startsWith('utils/') || importSource.startsWith('components/') ||
-        importSource.startsWith('styles/') || importSource.startsWith('data-models/') ||
-        importSource.startsWith('data/')
-      ) {
-        importSource = `@unovis/ts/${importSource}`
-      }
+      const importSource = resolveUnovisImportSource(importDec.moduleSpecifier.text, path)
       for (const importEl of importDec.importClause.namedBindings.elements) {
         importSourceMap[importEl.name.escapedText] = importSource
       }

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -166,6 +166,11 @@ export default defineConfig({
       // @unovis/angular's dist/ is only produced by `ng build`; point at source
       // (public-api) so it resolves without a prior build, like solid/svelte.
       '@unovis/angular': `${pkgSrc('angular')}/public-api.ts`,
+      // `@unovis/ts` sources import each other through the `@/*` alias declared in
+      // packages/ts/tsconfig.json. Must stay last: Vite matches a string alias as
+      // `id === find || id.startsWith(find + '/')`, so '@' catches `@/types/curve`
+      // but never `@unovis/*`.
+      '@': pkgSrc('ts'),
     },
   },
   server: {

--- a/packages/solid/autogen/index.ts
+++ b/packages/solid/autogen/index.ts
@@ -25,12 +25,14 @@ const components = getComponentList() as SolidComponentInput[]
 const exports: string[] = []
 
 for (const component of components) {
-  const { generics, statements } = getConfigSummary(component, skipProperties)
+  const { generics, statements, importSourceMap } = getConfigSummary(component, skipProperties)
   const importStatements = getImportStatements(
     component.name,
     statements,
     [],
-    generics
+    generics,
+    [],
+    importSourceMap
   )
   const isStandAlone = component.isStandAlone
   const componentCode = getComponentCode(

--- a/packages/solid/src/components/annotations/index.tsx
+++ b/packages/solid/src/components/annotations/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { AnnotationsConfigInterface } from "@unovis/ts";
-import { Annotations } from "@unovis/ts";
+import { Annotations } from "@unovis/ts/components/annotations";
+import type { AnnotationsConfigInterface } from "@unovis/ts/components/annotations/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/area/index.tsx
+++ b/packages/solid/src/components/area/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { AreaConfigInterface } from "@unovis/ts";
-import { Area } from "@unovis/ts";
+import { Area } from "@unovis/ts/components/area";
+import type { AreaConfigInterface } from "@unovis/ts/components/area/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/axis/index.tsx
+++ b/packages/solid/src/components/axis/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { AxisConfigInterface } from "@unovis/ts";
-import { Axis } from "@unovis/ts";
+import { Axis } from "@unovis/ts/components/axis";
+import type { AxisConfigInterface } from "@unovis/ts/components/axis/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/boxplot/index.tsx
+++ b/packages/solid/src/components/boxplot/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { BoxplotConfigInterface } from "@unovis/ts";
-import { Boxplot } from "@unovis/ts";
+import { Boxplot } from "@unovis/ts/components/boxplot";
+import type { BoxplotConfigInterface } from "@unovis/ts/components/boxplot/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/brush/index.tsx
+++ b/packages/solid/src/components/brush/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { BrushConfigInterface } from "@unovis/ts";
-import { Brush } from "@unovis/ts";
+import { Brush } from "@unovis/ts/components/brush";
+import type { BrushConfigInterface } from "@unovis/ts/components/brush/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/chord-diagram/index.tsx
+++ b/packages/solid/src/components/chord-diagram/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { ChordDiagramConfigInterface, ChordInputNode, ChordInputLink } from "@unovis/ts";
-import { ChordDiagram } from "@unovis/ts";
+import { ChordDiagram } from "@unovis/ts/components/chord-diagram";
+import type { ChordDiagramConfigInterface } from "@unovis/ts/components/chord-diagram/config";
+import type { ChordInputNode, ChordInputLink } from "@unovis/ts/components/chord-diagram/types";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/crosshair/index.tsx
+++ b/packages/solid/src/components/crosshair/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { CrosshairConfigInterface } from "@unovis/ts";
-import { Crosshair } from "@unovis/ts";
+import { Crosshair } from "@unovis/ts/components/crosshair";
+import type { CrosshairConfigInterface } from "@unovis/ts/components/crosshair/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/donut/index.tsx
+++ b/packages/solid/src/components/donut/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { DonutConfigInterface } from "@unovis/ts";
-import { Donut } from "@unovis/ts";
+import { Donut } from "@unovis/ts/components/donut";
+import type { DonutConfigInterface } from "@unovis/ts/components/donut/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/free-brush/index.tsx
+++ b/packages/solid/src/components/free-brush/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { FreeBrushConfigInterface } from "@unovis/ts";
-import { FreeBrush } from "@unovis/ts";
+import { FreeBrush } from "@unovis/ts/components/free-brush";
+import type { FreeBrushConfigInterface } from "@unovis/ts/components/free-brush/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/graph/index.tsx
+++ b/packages/solid/src/components/graph/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { GraphConfigInterface, GraphInputNode, GraphInputLink } from "@unovis/ts";
-import { Graph } from "@unovis/ts";
+import { Graph } from "@unovis/ts/components/graph";
+import type { GraphConfigInterface } from "@unovis/ts/components/graph/config";
+import type { GraphInputNode, GraphInputLink } from "@unovis/ts/types/graph";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/grouped-bar/index.tsx
+++ b/packages/solid/src/components/grouped-bar/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { GroupedBarConfigInterface } from "@unovis/ts";
-import { GroupedBar } from "@unovis/ts";
+import { GroupedBar } from "@unovis/ts/components/grouped-bar";
+import type { GroupedBarConfigInterface } from "@unovis/ts/components/grouped-bar/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/heatmap/index.tsx
+++ b/packages/solid/src/components/heatmap/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { HeatmapConfigInterface } from "@unovis/ts";
-import { Heatmap } from "@unovis/ts";
+import { Heatmap } from "@unovis/ts/components/heatmap";
+import type { HeatmapConfigInterface } from "@unovis/ts/components/heatmap/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/line/index.tsx
+++ b/packages/solid/src/components/line/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { LineConfigInterface } from "@unovis/ts";
-import { Line } from "@unovis/ts";
+import { Line } from "@unovis/ts/components/line";
+import type { LineConfigInterface } from "@unovis/ts/components/line/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/nested-donut/index.tsx
+++ b/packages/solid/src/components/nested-donut/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { NestedDonutConfigInterface } from "@unovis/ts";
-import { NestedDonut } from "@unovis/ts";
+import { NestedDonut } from "@unovis/ts/components/nested-donut";
+import type { NestedDonutConfigInterface } from "@unovis/ts/components/nested-donut/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/plotband/index.tsx
+++ b/packages/solid/src/components/plotband/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { PlotbandConfigInterface } from "@unovis/ts";
-import { Plotband } from "@unovis/ts";
+import { Plotband } from "@unovis/ts/components/plotband";
+import type { PlotbandConfigInterface } from "@unovis/ts/components/plotband/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/plotline/index.tsx
+++ b/packages/solid/src/components/plotline/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { PlotlineConfigInterface } from "@unovis/ts";
-import { Plotline } from "@unovis/ts";
+import { Plotline } from "@unovis/ts/components/plotline";
+import type { PlotlineConfigInterface } from "@unovis/ts/components/plotline/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/radial-bar/index.tsx
+++ b/packages/solid/src/components/radial-bar/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { RadialBarConfigInterface } from "@unovis/ts";
-import { RadialBar } from "@unovis/ts";
+import { RadialBar } from "@unovis/ts/components/radial-bar";
+import type { RadialBarConfigInterface } from "@unovis/ts/components/radial-bar/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/sankey/index.tsx
+++ b/packages/solid/src/components/sankey/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { SankeyConfigInterface, SankeyInputNode, SankeyInputLink } from "@unovis/ts";
-import { Sankey } from "@unovis/ts";
+import { Sankey } from "@unovis/ts/components/sankey";
+import type { SankeyConfigInterface } from "@unovis/ts/components/sankey/config";
+import type { SankeyInputNode, SankeyInputLink } from "@unovis/ts/components/sankey/types";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/scatter/index.tsx
+++ b/packages/solid/src/components/scatter/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { ScatterConfigInterface } from "@unovis/ts";
-import { Scatter } from "@unovis/ts";
+import { Scatter } from "@unovis/ts/components/scatter";
+import type { ScatterConfigInterface } from "@unovis/ts/components/scatter/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/stacked-bar/index.tsx
+++ b/packages/solid/src/components/stacked-bar/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { StackedBarConfigInterface } from "@unovis/ts";
-import { StackedBar } from "@unovis/ts";
+import { StackedBar } from "@unovis/ts/components/stacked-bar";
+import type { StackedBarConfigInterface } from "@unovis/ts/components/stacked-bar/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/timeline/index.tsx
+++ b/packages/solid/src/components/timeline/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { TimelineConfigInterface } from "@unovis/ts";
-import { Timeline } from "@unovis/ts";
+import { Timeline } from "@unovis/ts/components/timeline";
+import type { TimelineConfigInterface } from "@unovis/ts/components/timeline/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/tooltip/index.tsx
+++ b/packages/solid/src/components/tooltip/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { TooltipConfigInterface } from "@unovis/ts";
-import { Tooltip } from "@unovis/ts";
+import { Tooltip } from "@unovis/ts/components/tooltip";
+import type { TooltipConfigInterface } from "@unovis/ts/components/tooltip/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/topojson-map/index.tsx
+++ b/packages/solid/src/components/topojson-map/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { TopoJSONMapConfigInterface } from "@unovis/ts";
-import { TopoJSONMap } from "@unovis/ts";
+import { TopoJSONMap } from "@unovis/ts/components/topojson-map";
+import type { TopoJSONMapConfigInterface } from "@unovis/ts/components/topojson-map/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/treemap/index.tsx
+++ b/packages/solid/src/components/treemap/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { TreemapConfigInterface } from "@unovis/ts";
-import { Treemap } from "@unovis/ts";
+import { Treemap } from "@unovis/ts/components/treemap";
+import type { TreemapConfigInterface } from "@unovis/ts/components/treemap/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/components/xy-labels/index.tsx
+++ b/packages/solid/src/components/xy-labels/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { XYLabelsConfigInterface } from "@unovis/ts";
-import { XYLabels } from "@unovis/ts";
+import { XYLabels } from "@unovis/ts/components/xy-labels";
+import type { XYLabelsConfigInterface } from "@unovis/ts/components/xy-labels/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 import { useVisContainer } from "../../utils/context";

--- a/packages/solid/src/containers/single-container/index.tsx
+++ b/packages/solid/src/containers/single-container/index.tsx
@@ -1,10 +1,8 @@
-import { SingleContainer } from '@unovis/ts'
-import type {
-  Annotations,
-  Tooltip,
-  SingleContainerConfigInterface,
-  ComponentCore,
-} from '@unovis/ts'
+import { SingleContainer } from '@unovis/ts/containers/single-container'
+import type { SingleContainerConfigInterface } from '@unovis/ts/containers/single-container/config'
+import type { Annotations } from '@unovis/ts/components/annotations'
+import type { Tooltip } from '@unovis/ts/components/tooltip'
+import type { ComponentCore } from '@unovis/ts/core/component'
 import type { JSX, ParentProps } from 'solid-js'
 import { createEffect, createSignal, on, onCleanup, splitProps } from 'solid-js'
 import { createStore, produce } from 'solid-js/store'

--- a/packages/solid/src/containers/xy-container/index.tsx
+++ b/packages/solid/src/containers/xy-container/index.tsx
@@ -1,12 +1,10 @@
-import { XYContainer } from '@unovis/ts'
-import type {
-  Annotations,
-  Axis,
-  Crosshair,
-  Tooltip,
-  XYComponentCore,
-  XYContainerConfigInterface,
-} from '@unovis/ts'
+import { XYContainer } from '@unovis/ts/containers/xy-container'
+import type { XYContainerConfigInterface } from '@unovis/ts/containers/xy-container/config'
+import type { Annotations } from '@unovis/ts/components/annotations'
+import type { Axis } from '@unovis/ts/components/axis'
+import type { Crosshair } from '@unovis/ts/components/crosshair'
+import type { Tooltip } from '@unovis/ts/components/tooltip'
+import type { XYComponentCore } from '@unovis/ts/core/xy-component'
 import type { JSX, ParentProps } from 'solid-js'
 import {
   createEffect,

--- a/packages/solid/src/html-components/bullet-legend/index.tsx
+++ b/packages/solid/src/html-components/bullet-legend/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { BulletLegendConfigInterface } from "@unovis/ts";
-import { BulletLegend } from "@unovis/ts";
+import { BulletLegend } from "@unovis/ts/components/bullet-legend";
+import type { BulletLegendConfigInterface } from "@unovis/ts/components/bullet-legend/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 

--- a/packages/solid/src/html-components/flow-legend/index.tsx
+++ b/packages/solid/src/html-components/flow-legend/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { FlowLegendConfigInterface } from "@unovis/ts";
-import { FlowLegend } from "@unovis/ts";
+import { FlowLegend } from "@unovis/ts/components/flow-legend";
+import type { FlowLegendConfigInterface } from "@unovis/ts/components/flow-legend/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 

--- a/packages/solid/src/html-components/leaflet-flow-map/index.tsx
+++ b/packages/solid/src/html-components/leaflet-flow-map/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { LeafletFlowMapConfigInterface, GenericDataRecord } from "@unovis/ts";
-import { LeafletFlowMap } from "@unovis/ts";
+import { LeafletFlowMap } from "@unovis/ts/components/leaflet-flow-map";
+import type { LeafletFlowMapConfigInterface } from "@unovis/ts/components/leaflet-flow-map/config";
+import type { GenericDataRecord } from "@unovis/ts/types/data";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 

--- a/packages/solid/src/html-components/leaflet-map/index.tsx
+++ b/packages/solid/src/html-components/leaflet-map/index.tsx
@@ -1,6 +1,7 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { LeafletMapConfigInterface, GenericDataRecord } from "@unovis/ts";
-import { LeafletMap } from "@unovis/ts";
+import { LeafletMap } from "@unovis/ts/components/leaflet-map";
+import type { LeafletMapConfigInterface } from "@unovis/ts/components/leaflet-map/config";
+import type { GenericDataRecord } from "@unovis/ts/types/data";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 

--- a/packages/solid/src/html-components/rolling-pin-legend/index.tsx
+++ b/packages/solid/src/html-components/rolling-pin-legend/index.tsx
@@ -1,6 +1,6 @@
 // !!! This code was automatically generated. You should not change it !!!
-import type { RollingPinLegendConfigInterface } from "@unovis/ts";
-import { RollingPinLegend } from "@unovis/ts";
+import { RollingPinLegend } from "@unovis/ts/components/rolling-pin-legend";
+import type { RollingPinLegendConfigInterface } from "@unovis/ts/components/rolling-pin-legend/config";
 import { createSignal, onCleanup, createEffect, on, onMount } from 'solid-js'
 import { arePropsEqual } from '../../utils/props'
 

--- a/packages/solid/src/utils/props.ts
+++ b/packages/solid/src/utils/props.ts
@@ -1,4 +1,4 @@
-import { isEqual } from '@unovis/ts'
+import { isEqual } from '@unovis/ts/utils/data'
 
 export const arePropsEqual = <PropTypes>(
   prevProps: PropTypes,

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -34,8 +34,10 @@ export default defineConfig(({command, mode}) => {
         sourcemap: true,
         rollupOptions: {
           // make sure to externalize deps that shouldn't be bundled
-          // into your library
-          external: ['solid-js', 'solid-js/web', 'solid-js/store', '@unovis/ts', 'tslib'],
+          // into your library. The regex also covers granular `@unovis/ts` subpaths
+          // (`@unovis/ts/components/area`), which a plain string wouldn't match —
+          // Rollup would then inline the core library into this bundle.
+          external: ['solid-js', 'solid-js/web', 'solid-js/store', /^@unovis\/ts(\/.*)?$/, 'tslib'],
           output: [outputDefault('cjs', 'cjs'), outputDefault('es', 'js')]
         }
       },
@@ -49,6 +51,10 @@ export default defineConfig(({command, mode}) => {
       resolve: {
         alias: {
           '@unovis/solid': resolve(__dirname, 'src/index.ts'),
+          // The wrappers import granular subpaths (`@unovis/ts/components/area`), which only
+          // exist under `packages/ts/dist` — the root of the published tarball, but not of the
+          // workspace package. `packages/dev` and `packages/shared` alias `@unovis/ts` the same way.
+          '@unovis/ts': resolve(__dirname, '../ts/dist'),
           'tslib': 'tslib'
         }
       },

--- a/packages/svelte/autogen/component.ts
+++ b/packages/svelte/autogen/component.ts
@@ -21,9 +21,22 @@ export function getComponentCode (
     ? `ref, ${renderIntoProvidedDomNode ? '{ ...config, renderIntoProvidedDomNode: true }' : 'config'}${dataType ? ', data' : ''}`
     : 'config'
   const lifecycleMethod = ['onMount(() => {', `component = new ${componentType}(${constructorArgs})`, 'return () => component?.destroy()', '})'].join('\n    ')
+
+  // The component class is the only import used as a value (`new Component(...)`); config
+  // interfaces and accessor types appear in type positions only. `importsNotUsedAsValues` is
+  // set to `error` for this package, so those have to be emitted as `import type`.
+  const renderImport = (s: { source: string; elements: string[] }): string => {
+    const values = s.elements.filter(e => e === componentName)
+    const types = s.elements.filter(e => e !== componentName)
+    return [
+      values.length ? `import { ${values.join(', ')} } from '${s.source}'` : '',
+      types.length ? `import type { ${types.join(', ')} } from '${s.source}'` : '',
+    ].filter(Boolean).join('\n  ')
+  }
+
   return `<script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  ${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n  ')}
+  ${importStatements.map(renderImport).join('\n  ')}
   import { onMount${isStandAlone ? '' : ', getContext'} } from 'svelte'
   ${!isStandAlone ? '\n  import type { Lifecycle } from \'../../types/context\'' : ''}
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/autogen/index.ts
+++ b/packages/svelte/autogen/index.ts
@@ -19,8 +19,8 @@ const components = getComponentList() as SvelteComponentInput[]
 const exports: string[] = []
 
 for (const component of components) {
-  const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties)
-  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics)
+  const { configProperties, configInterfaceMembers, generics, statements, importSourceMap } = getConfigSummary(component, skipProperties)
+  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics, [], importSourceMap)
   const isStandAlone = component.isStandAlone
   const componentCode = getComponentCode(
     component.name,
@@ -53,4 +53,4 @@ for (const component of components) {
   console.log(`  ${pathComponent}`)
 }
 
-writeFileSync('src/components.ts', exports.join('\n'))
+writeFileSync('src/components.ts', `${exports.join('\n')}\n`)

--- a/packages/svelte/gallery.rollup.config.js
+++ b/packages/svelte/gallery.rollup.config.js
@@ -24,6 +24,10 @@ export default {
     alias({
       entries: [
         { find: '@unovis/svelte', replacement: path.resolve(__dirname, 'src/index.ts') },
+        // The wrappers import granular subpaths (`@unovis/ts/components/area`), which only exist
+        // under `packages/ts/dist` — the root of the published tarball, but not of the workspace
+        // package. `packages/dev` and `packages/shared` alias `@unovis/ts` the same way.
+        { find: '@unovis/ts', replacement: path.resolve(__dirname, '../ts/dist') },
       ],
     }),
     commonjs(),

--- a/packages/svelte/src/components/annotations/annotations.svelte
+++ b/packages/svelte/src/components/annotations/annotations.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Annotations, AnnotationsConfigInterface, AnnotationItem } from '@unovis/ts'
+  import { Annotations } from '@unovis/ts/components/annotations'
+  import type { AnnotationsConfigInterface } from '@unovis/ts/components/annotations/config'
+  import type { AnnotationItem } from '@unovis/ts/components/annotations/types'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/area/area.svelte
+++ b/packages/svelte/src/components/area/area.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Area, AreaConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Area } from '@unovis/ts/components/area'
+  import type { AreaConfigInterface } from '@unovis/ts/components/area/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/axis/axis.svelte
+++ b/packages/svelte/src/components/axis/axis.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Axis, AxisConfigInterface } from '@unovis/ts'
+  import { Axis } from '@unovis/ts/components/axis'
+  import type { AxisConfigInterface } from '@unovis/ts/components/axis/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/boxplot/boxplot.svelte
+++ b/packages/svelte/src/components/boxplot/boxplot.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Boxplot, BoxplotConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Boxplot } from '@unovis/ts/components/boxplot'
+  import type { BoxplotConfigInterface } from '@unovis/ts/components/boxplot/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'
@@ -12,12 +14,11 @@
   // eslint-disable-next-line no-undef-init
   export let data: Datum[] = undefined
   export let x: NumericAccessor<Datum>
-  export let y: NumericAccessor<Datum> | NumericAccessor<Datum>[]
 
   // config
   let prevConfig: BoxplotConfigInterface<Datum>
   let config: BoxplotConfigInterface<Datum>
-  $: config = { x, y, ...$$restProps }
+  $: config = { x, ...$$restProps }
 
   // component declaration
   let component: Boxplot<Datum>

--- a/packages/svelte/src/components/brush/brush.svelte
+++ b/packages/svelte/src/components/brush/brush.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Brush, BrushConfigInterface } from '@unovis/ts'
+  import { Brush } from '@unovis/ts/components/brush'
+  import type { BrushConfigInterface } from '@unovis/ts/components/brush/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/chord-diagram/chord-diagram.svelte
+++ b/packages/svelte/src/components/chord-diagram/chord-diagram.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { ChordDiagram, ChordDiagramConfigInterface, ChordInputNode, ChordInputLink } from '@unovis/ts'
+  import { ChordDiagram } from '@unovis/ts/components/chord-diagram'
+  import type { ChordDiagramConfigInterface } from '@unovis/ts/components/chord-diagram/config'
+  import type { ChordInputNode, ChordInputLink } from '@unovis/ts/components/chord-diagram/types'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/crosshair/crosshair.svelte
+++ b/packages/svelte/src/components/crosshair/crosshair.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Crosshair, CrosshairConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Crosshair } from '@unovis/ts/components/crosshair'
+  import type { CrosshairConfigInterface } from '@unovis/ts/components/crosshair/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/donut/donut.svelte
+++ b/packages/svelte/src/components/donut/donut.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Donut, DonutConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Donut } from '@unovis/ts/components/donut'
+  import type { DonutConfigInterface } from '@unovis/ts/components/donut/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/free-brush/free-brush.svelte
+++ b/packages/svelte/src/components/free-brush/free-brush.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { FreeBrush, FreeBrushConfigInterface } from '@unovis/ts'
+  import { FreeBrush } from '@unovis/ts/components/free-brush'
+  import type { FreeBrushConfigInterface } from '@unovis/ts/components/free-brush/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/graph/graph.svelte
+++ b/packages/svelte/src/components/graph/graph.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Graph, GraphConfigInterface, GraphInputNode, GraphInputLink } from '@unovis/ts'
+  import { Graph } from '@unovis/ts/components/graph'
+  import type { GraphConfigInterface } from '@unovis/ts/components/graph/config'
+  import type { GraphInputNode, GraphInputLink } from '@unovis/ts/types/graph'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/grouped-bar/grouped-bar.svelte
+++ b/packages/svelte/src/components/grouped-bar/grouped-bar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { GroupedBar, GroupedBarConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { GroupedBar } from '@unovis/ts/components/grouped-bar'
+  import type { GroupedBarConfigInterface } from '@unovis/ts/components/grouped-bar/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/heatmap/heatmap.svelte
+++ b/packages/svelte/src/components/heatmap/heatmap.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Heatmap, HeatmapConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Heatmap } from '@unovis/ts/components/heatmap'
+  import type { HeatmapConfigInterface } from '@unovis/ts/components/heatmap/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/line/line.svelte
+++ b/packages/svelte/src/components/line/line.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Line, LineConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Line } from '@unovis/ts/components/line'
+  import type { LineConfigInterface } from '@unovis/ts/components/line/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/nested-donut/nested-donut.svelte
+++ b/packages/svelte/src/components/nested-donut/nested-donut.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { NestedDonut, NestedDonutConfigInterface, StringAccessor } from '@unovis/ts'
+  import { NestedDonut } from '@unovis/ts/components/nested-donut'
+  import type { NestedDonutConfigInterface } from '@unovis/ts/components/nested-donut/config'
+  import type { StringAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/plotband/plotband.svelte
+++ b/packages/svelte/src/components/plotband/plotband.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Plotband, PlotbandConfigInterface } from '@unovis/ts'
+  import { Plotband } from '@unovis/ts/components/plotband'
+  import type { PlotbandConfigInterface } from '@unovis/ts/components/plotband/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/plotline/plotline.svelte
+++ b/packages/svelte/src/components/plotline/plotline.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Plotline, PlotlineConfigInterface } from '@unovis/ts'
+  import { Plotline } from '@unovis/ts/components/plotline'
+  import type { PlotlineConfigInterface } from '@unovis/ts/components/plotline/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/radial-bar/radial-bar.svelte
+++ b/packages/svelte/src/components/radial-bar/radial-bar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { RadialBar, RadialBarConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { RadialBar } from '@unovis/ts/components/radial-bar'
+  import type { RadialBarConfigInterface } from '@unovis/ts/components/radial-bar/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/sankey/sankey.svelte
+++ b/packages/svelte/src/components/sankey/sankey.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Sankey, SankeyConfigInterface, SankeyInputNode, SankeyInputLink } from '@unovis/ts'
+  import { Sankey } from '@unovis/ts/components/sankey'
+  import type { SankeyConfigInterface } from '@unovis/ts/components/sankey/config'
+  import type { SankeyInputNode, SankeyInputLink } from '@unovis/ts/components/sankey/types'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/scatter/scatter.svelte
+++ b/packages/svelte/src/components/scatter/scatter.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Scatter, ScatterConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Scatter } from '@unovis/ts/components/scatter'
+  import type { ScatterConfigInterface } from '@unovis/ts/components/scatter/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/stacked-bar/stacked-bar.svelte
+++ b/packages/svelte/src/components/stacked-bar/stacked-bar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { StackedBar, StackedBarConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { StackedBar } from '@unovis/ts/components/stacked-bar'
+  import type { StackedBarConfigInterface } from '@unovis/ts/components/stacked-bar/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/timeline/timeline.svelte
+++ b/packages/svelte/src/components/timeline/timeline.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Timeline, TimelineConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { Timeline } from '@unovis/ts/components/timeline'
+  import type { TimelineConfigInterface } from '@unovis/ts/components/timeline/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/tooltip/tooltip.svelte
+++ b/packages/svelte/src/components/tooltip/tooltip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Tooltip, TooltipConfigInterface } from '@unovis/ts'
+  import { Tooltip } from '@unovis/ts/components/tooltip'
+  import type { TooltipConfigInterface } from '@unovis/ts/components/tooltip/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/topojson-map/topojson-map.svelte
+++ b/packages/svelte/src/components/topojson-map/topojson-map.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { TopoJSONMap, TopoJSONMapConfigInterface } from '@unovis/ts'
+  import { TopoJSONMap } from '@unovis/ts/components/topojson-map'
+  import type { TopoJSONMapConfigInterface } from '@unovis/ts/components/topojson-map/config'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/treemap/treemap.svelte
+++ b/packages/svelte/src/components/treemap/treemap.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { Treemap, TreemapConfigInterface, StringAccessor } from '@unovis/ts'
+  import { Treemap } from '@unovis/ts/components/treemap'
+  import type { TreemapConfigInterface } from '@unovis/ts/components/treemap/config'
+  import type { StringAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/components/xy-labels/xy-labels.svelte
+++ b/packages/svelte/src/components/xy-labels/xy-labels.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { XYLabels, XYLabelsConfigInterface, NumericAccessor } from '@unovis/ts'
+  import { XYLabels } from '@unovis/ts/components/xy-labels'
+  import type { XYLabelsConfigInterface } from '@unovis/ts/components/xy-labels/config'
+  import type { NumericAccessor } from '@unovis/ts/types/accessor'
   import { onMount, getContext } from 'svelte'
 
   import type { Lifecycle } from '../../types/context'

--- a/packages/svelte/src/containers/single-container/single-container.svelte
+++ b/packages/svelte/src/containers/single-container/single-container.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { ComponentCore, SingleContainer, SingleContainerConfigInterface, Tooltip, Annotations } from '@unovis/ts'
+  import { SingleContainer } from '@unovis/ts/containers/single-container'
+  import type { SingleContainerConfigInterface } from '@unovis/ts/containers/single-container/config'
+  import type { ComponentCore } from '@unovis/ts/core/component'
+  import type { Tooltip } from '@unovis/ts/components/tooltip'
+  import type { Annotations } from '@unovis/ts/components/annotations'
   import { arePropsEqual } from '../../utils/props'
   import { onDestroy, setContext } from 'svelte'
 

--- a/packages/svelte/src/containers/xy-container/xy-container.svelte
+++ b/packages/svelte/src/containers/xy-container/xy-container.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { XYContainer, XYComponentCore, XYContainerConfigInterface, Tooltip, Crosshair, Axis, Annotations } from '@unovis/ts'
+  import { XYContainer } from '@unovis/ts/containers/xy-container'
+  import type { XYContainerConfigInterface } from '@unovis/ts/containers/xy-container/config'
+  import type { XYComponentCore } from '@unovis/ts/core/xy-component'
+  import type { Tooltip } from '@unovis/ts/components/tooltip'
+  import type { Crosshair } from '@unovis/ts/components/crosshair'
+  import type { Axis } from '@unovis/ts/components/axis'
+  import type { Annotations } from '@unovis/ts/components/annotations'
   import { onMount, setContext } from 'svelte'
 
   type Datum = $$Generic
@@ -40,7 +46,7 @@
   $: chart?.setData(data, true)
 
   let animationFrame = 0
-  const updateContainer = async () => {
+  const updateContainer = () => {
     // due to the order of events when a component is removed update container can be called
     // while a component is being destroyed. This can lead to an error because we trigger an update
     // with a destroyed component.
@@ -73,8 +79,12 @@
   }
 
   $: {
+    // Bare references declare the reactive dependencies of this block; they are a Svelte
+    // idiom rather than dead expressions.
+    /* eslint-disable no-unused-expressions */
     config
     $$restProps
+    /* eslint-enable no-unused-expressions */
     updateContainer()
   }
 

--- a/packages/svelte/src/html-components/bullet-legend/bullet-legend.svelte
+++ b/packages/svelte/src/html-components/bullet-legend/bullet-legend.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { BulletLegend, BulletLegendConfigInterface, BulletLegendItemInterface } from '@unovis/ts'
+  import { BulletLegend } from '@unovis/ts/components/bullet-legend'
+  import type { BulletLegendConfigInterface } from '@unovis/ts/components/bullet-legend/config'
+  import type { BulletLegendItemInterface } from '@unovis/ts/components/bullet-legend/types'
   import { onMount } from 'svelte'
 
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/src/html-components/flow-legend/flow-legend.svelte
+++ b/packages/svelte/src/html-components/flow-legend/flow-legend.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { FlowLegend, FlowLegendConfigInterface } from '@unovis/ts'
+  import { FlowLegend } from '@unovis/ts/components/flow-legend'
+  import type { FlowLegendConfigInterface } from '@unovis/ts/components/flow-legend/config'
   import { onMount } from 'svelte'
 
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/src/html-components/leaflet-flow-map/leaflet-flow-map.svelte
+++ b/packages/svelte/src/html-components/leaflet-flow-map/leaflet-flow-map.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { LeafletFlowMap, LeafletFlowMapConfigInterface, GenericDataRecord, MapLibreStyleSpecs } from '@unovis/ts'
+  import { LeafletFlowMap } from '@unovis/ts/components/leaflet-flow-map'
+  import type { LeafletFlowMapConfigInterface } from '@unovis/ts/components/leaflet-flow-map/config'
+  import type { GenericDataRecord } from '@unovis/ts/types/data'
+  import type { MapLibreStyleSpecs } from '@unovis/ts/components/leaflet-map/renderer/map-style'
   import { onMount } from 'svelte'
 
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/src/html-components/leaflet-map/leaflet-map.svelte
+++ b/packages/svelte/src/html-components/leaflet-map/leaflet-map.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { LeafletMap, LeafletMapConfigInterface, GenericDataRecord, MapLibreStyleSpecs } from '@unovis/ts'
+  import { LeafletMap } from '@unovis/ts/components/leaflet-map'
+  import type { LeafletMapConfigInterface } from '@unovis/ts/components/leaflet-map/config'
+  import type { GenericDataRecord } from '@unovis/ts/types/data'
+  import type { MapLibreStyleSpecs } from '@unovis/ts/components/leaflet-map/renderer/map-style'
   import { onMount } from 'svelte'
 
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/src/html-components/rolling-pin-legend/rolling-pin-legend.svelte
+++ b/packages/svelte/src/html-components/rolling-pin-legend/rolling-pin-legend.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   // !!! This code was automatically generated. You should not change it !!!
-  import { RollingPinLegend, RollingPinLegendConfigInterface, RollingPinLegendItem } from '@unovis/ts'
+  import { RollingPinLegend } from '@unovis/ts/components/rolling-pin-legend'
+  import type { RollingPinLegendConfigInterface } from '@unovis/ts/components/rolling-pin-legend/config'
+  import type { RollingPinLegendItem } from '@unovis/ts/components/rolling-pin-legend/types'
   import { onMount } from 'svelte'
 
   import { arePropsEqual } from '../../utils/props'

--- a/packages/svelte/src/types/context.ts
+++ b/packages/svelte/src/types/context.ts
@@ -1,4 +1,5 @@
-import type { ComponentCore, Tooltip } from '@unovis/ts'
+import type { ComponentCore } from '@unovis/ts/core/component'
+import type { Tooltip } from '@unovis/ts/components/tooltip'
 import type { Action } from 'svelte/action'
 
 export type Lifecycle = Action<HTMLElement, ComponentCore<unknown> | Tooltip>

--- a/packages/svelte/src/utils/props.ts
+++ b/packages/svelte/src/utils/props.ts
@@ -1,4 +1,4 @@
-import { isEqual } from '@unovis/ts'
+import { isEqual } from '@unovis/ts/utils/data'
 
 export function arePropsEqual<PropTypes> (prevProps: PropTypes, nextProps: PropTypes): boolean {
   return isEqual(prevProps, nextProps)

--- a/packages/vue/autogen/component.ts
+++ b/packages/vue/autogen/component.ts
@@ -27,7 +27,8 @@ export function getComponentCode (
 
   return `<script setup lang="ts" ${genericsExtend}>
 // !!! This code was automatically generated. You should not change it !!!
-${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n  ')}${componentName === 'Timeline' ? '\nimport { XYComponentConfigInterface, StringAccessor } from "@unovis/ts"' : ''}
+
+${importStatements.map(s => `import { ${s.elements.join(', ')} } from '${s.source}'`).join('\n  ')}${componentName === 'Timeline' ? '\nimport { XYComponentConfigInterface } from \'@unovis/ts/core/xy-component/config\'\nimport { StringAccessor } from \'@unovis/ts/types/accessor\'' : ''}
 import { onMounted, onUnmounted, computed, ref, watch, nextTick${isStandAlone ? '' : ', inject'} } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 ${isStandAlone ? '' : `import { ${elementSuffix}AccessorKey } from '../../utils/context'\n`}

--- a/packages/vue/autogen/index.ts
+++ b/packages/vue/autogen/index.ts
@@ -19,8 +19,8 @@ const components = getComponentList() as VueComponentInput[]
 const exports: string[] = []
 
 for (const component of components) {
-  const { configProperties, configInterfaceMembers, generics, statements } = getConfigSummary(component, skipProperties)
-  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics)
+  const { configProperties, configInterfaceMembers, generics, statements, importSourceMap } = getConfigSummary(component, skipProperties)
+  const importStatements = getImportStatements(component.name, statements, configInterfaceMembers, generics, [], importSourceMap)
   const isStandAlone = component.isStandAlone
   const componentCode = getComponentCode(
     component.name,

--- a/packages/vue/src/components/annotations/index.vue
+++ b/packages/vue/src/components/annotations/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // !!! This code was automatically generated. You should not change it !!!
-import type { AnnotationsConfigInterface } from '@unovis/ts'
-import { Annotations } from '@unovis/ts'
+
+import type { AnnotationsConfigInterface } from '@unovis/ts/components/annotations/config'
+import { Annotations } from '@unovis/ts/components/annotations'
 import { inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { annotationsAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/area/index.vue
+++ b/packages/vue/src/components/area/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { AreaConfigInterface } from '@unovis/ts'
-import { Area } from '@unovis/ts'
+
+import type { AreaConfigInterface } from '@unovis/ts/components/area/config'
+import { Area } from '@unovis/ts/components/area'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/axis/index.vue
+++ b/packages/vue/src/components/axis/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { AxisConfigInterface } from '@unovis/ts'
-import { Axis } from '@unovis/ts'
+
+import type { AxisConfigInterface } from '@unovis/ts/components/axis/config'
+import { Axis } from '@unovis/ts/components/axis'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { axisAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/boxplot/index.vue
+++ b/packages/vue/src/components/boxplot/index.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { BoxplotConfigInterface } from '@unovis/ts'
-import { Boxplot } from '@unovis/ts'
+
+import type { BoxplotConfigInterface } from '@unovis/ts/components/boxplot/config'
+import { Boxplot } from '@unovis/ts/components/boxplot'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 
+// data and required props
 // !!! temporary solution to ignore complex type. related issue: https://github.com/vuejs/core/issues/8412
 const props = defineProps</** @vue-ignore */ BoxplotConfigInterface<Datum> & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)

--- a/packages/vue/src/components/brush/index.vue
+++ b/packages/vue/src/components/brush/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { BrushConfigInterface } from '@unovis/ts'
-import { Brush } from '@unovis/ts'
+
+import type { BrushConfigInterface } from '@unovis/ts/components/brush/config'
+import { Brush } from '@unovis/ts/components/brush'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/chord-diagram/index.vue
+++ b/packages/vue/src/components/chord-diagram/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts" generic="N extends ChordInputNode, L extends ChordInputLink">
 // !!! This code was automatically generated. You should not change it !!!
-import type { ChordDiagramConfigInterface, ChordInputLink, ChordInputNode } from '@unovis/ts'
-import { ChordDiagram } from '@unovis/ts'
+
+import type { ChordDiagramConfigInterface } from '@unovis/ts/components/chord-diagram/config'
+import type { ChordInputLink, ChordInputNode } from '@unovis/ts/components/chord-diagram/types'
+import { ChordDiagram } from '@unovis/ts/components/chord-diagram'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/crosshair/index.vue
+++ b/packages/vue/src/components/crosshair/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { CrosshairConfigInterface } from '@unovis/ts'
-import { Crosshair } from '@unovis/ts'
+
+import type { CrosshairConfigInterface } from '@unovis/ts/components/crosshair/config'
+import { Crosshair } from '@unovis/ts/components/crosshair'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { crosshairAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/donut/index.vue
+++ b/packages/vue/src/components/donut/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { DonutConfigInterface } from '@unovis/ts'
-import { Donut } from '@unovis/ts'
+
+import type { DonutConfigInterface } from '@unovis/ts/components/donut/config'
+import { Donut } from '@unovis/ts/components/donut'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/free-brush/index.vue
+++ b/packages/vue/src/components/free-brush/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { FreeBrushConfigInterface } from '@unovis/ts'
-import { FreeBrush } from '@unovis/ts'
+
+import type { FreeBrushConfigInterface } from '@unovis/ts/components/free-brush/config'
+import { FreeBrush } from '@unovis/ts/components/free-brush'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/graph/index.vue
+++ b/packages/vue/src/components/graph/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts" generic="N extends GraphInputNode, L extends GraphInputLink">
 // !!! This code was automatically generated. You should not change it !!!
-import type { GraphConfigInterface, GraphInputLink, GraphInputNode } from '@unovis/ts'
-import { Graph } from '@unovis/ts'
+
+import type { GraphConfigInterface } from '@unovis/ts/components/graph/config'
+import type { GraphInputLink, GraphInputNode } from '@unovis/ts/types/graph'
+import { Graph } from '@unovis/ts/components/graph'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/grouped-bar/index.vue
+++ b/packages/vue/src/components/grouped-bar/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { GroupedBarConfigInterface } from '@unovis/ts'
-import { GroupedBar } from '@unovis/ts'
+
+import type { GroupedBarConfigInterface } from '@unovis/ts/components/grouped-bar/config'
+import { GroupedBar } from '@unovis/ts/components/grouped-bar'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/heatmap/index.vue
+++ b/packages/vue/src/components/heatmap/index.vue
@@ -1,23 +1,24 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import { Heatmap, HeatmapConfigInterface, NumericAccessor } from '@unovis/ts'
-import { onMounted, onUnmounted, computed, ref, watch, nextTick, inject } from 'vue'
-import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+import type { HeatmapConfigInterface } from '@unovis/ts/components/heatmap/config'
+import { Heatmap } from '@unovis/ts/components/heatmap'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
+import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+const props = defineProps<Props & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props 
+// data and required props
 type Props = HeatmapConfigInterface<Datum>
-const props = defineProps<Props & { data?: Datum[] }>()
-
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)
 
 // component declaration
 const component = ref<Heatmap<Datum>>()
-
 
 onMounted(() => {
   nextTick(() => {
@@ -44,7 +45,7 @@ watch(data, () => {
 })
 
 defineExpose({
-  component
+  component,
 })
 </script>
 
@@ -55,5 +56,3 @@ export const VisHeatmapSelectors = Heatmap.selectors
 <template>
   <div data-vis-component />
 </template>
-
-

--- a/packages/vue/src/components/line/index.vue
+++ b/packages/vue/src/components/line/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { LineConfigInterface } from '@unovis/ts'
-import { Line } from '@unovis/ts'
+
+import type { LineConfigInterface } from '@unovis/ts/components/line/config'
+import { Line } from '@unovis/ts/components/line'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/nested-donut/index.vue
+++ b/packages/vue/src/components/nested-donut/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { NestedDonutConfigInterface } from '@unovis/ts'
-import { NestedDonut } from '@unovis/ts'
+
+import type { NestedDonutConfigInterface } from '@unovis/ts/components/nested-donut/config'
+import { NestedDonut } from '@unovis/ts/components/nested-donut'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/plotband/index.vue
+++ b/packages/vue/src/components/plotband/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { PlotbandConfigInterface } from '@unovis/ts'
-import { Plotband } from '@unovis/ts'
+
+import type { PlotbandConfigInterface } from '@unovis/ts/components/plotband/config'
+import { Plotband } from '@unovis/ts/components/plotband'
 import { inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/plotline/index.vue
+++ b/packages/vue/src/components/plotline/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { PlotlineConfigInterface } from '@unovis/ts'
-import { Plotline } from '@unovis/ts'
+
+import type { PlotlineConfigInterface } from '@unovis/ts/components/plotline/config'
+import { Plotline } from '@unovis/ts/components/plotline'
 import { inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/radial-bar/index.vue
+++ b/packages/vue/src/components/radial-bar/index.vue
@@ -1,23 +1,24 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import { RadialBar, RadialBarConfigInterface, NumericAccessor } from '@unovis/ts'
-import { onMounted, onUnmounted, computed, ref, watch, nextTick, inject } from 'vue'
-import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+import type { RadialBarConfigInterface } from '@unovis/ts/components/radial-bar/config'
+import { RadialBar } from '@unovis/ts/components/radial-bar'
+import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
+import { arePropsEqual, useForwardProps } from '../../utils/props'
+
+const props = defineProps<Props & { data?: Datum[] }>()
 
 const accessor = inject(componentAccessorKey)
 
-// data and required props 
+// data and required props
 type Props = RadialBarConfigInterface<Datum>
-const props = defineProps<Props & { data?: Datum[] }>()
-
 const data = computed(() => accessor.data.value ?? props.data)
 // config
 const config = useForwardProps(props)
 
 // component declaration
 const component = ref<RadialBar<Datum>>()
-
 
 onMounted(() => {
   nextTick(() => {
@@ -44,7 +45,7 @@ watch(data, () => {
 })
 
 defineExpose({
-  component
+  component,
 })
 </script>
 
@@ -55,5 +56,3 @@ export const VisRadialBarSelectors = RadialBar.selectors
 <template>
   <div data-vis-component />
 </template>
-
-

--- a/packages/vue/src/components/sankey/index.vue
+++ b/packages/vue/src/components/sankey/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts" generic="N extends SankeyInputNode, L extends SankeyInputLink">
 // !!! This code was automatically generated. You should not change it !!!
-import type { SankeyConfigInterface, SankeyInputLink, SankeyInputNode } from '@unovis/ts'
-import { Sankey } from '@unovis/ts'
+
+import type { SankeyConfigInterface } from '@unovis/ts/components/sankey/config'
+import type { SankeyInputLink, SankeyInputNode } from '@unovis/ts/components/sankey/types'
+import { Sankey } from '@unovis/ts/components/sankey'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/scatter/index.vue
+++ b/packages/vue/src/components/scatter/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { ScatterConfigInterface } from '@unovis/ts'
-import { Scatter } from '@unovis/ts'
+
+import type { ScatterConfigInterface } from '@unovis/ts/components/scatter/config'
+import { Scatter } from '@unovis/ts/components/scatter'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/stacked-bar/index.vue
+++ b/packages/vue/src/components/stacked-bar/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { StackedBarConfigInterface } from '@unovis/ts'
-import { StackedBar } from '@unovis/ts'
+
+import type { StackedBarConfigInterface } from '@unovis/ts/components/stacked-bar/config'
+import { StackedBar } from '@unovis/ts/components/stacked-bar'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/timeline/index.vue
+++ b/packages/vue/src/components/timeline/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { TimelineConfigInterface } from '@unovis/ts'
-import { Timeline } from '@unovis/ts'
+
+import type { TimelineConfigInterface } from '@unovis/ts/components/timeline/config'
+import { Timeline } from '@unovis/ts/components/timeline'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/tooltip/index.vue
+++ b/packages/vue/src/components/tooltip/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // !!! This code was automatically generated. You should not change it !!!
-import type { TooltipConfigInterface } from '@unovis/ts'
-import { Tooltip } from '@unovis/ts'
+
+import type { TooltipConfigInterface } from '@unovis/ts/components/tooltip/config'
+import { Tooltip } from '@unovis/ts/components/tooltip'
 import { inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { tooltipAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/topojson-map/index.vue
+++ b/packages/vue/src/components/topojson-map/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="AreaDatum, PointDatum, LinkDatum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { TopoJSONMapConfigInterface } from '@unovis/ts'
-import { TopoJSONMap } from '@unovis/ts'
+
+import type { TopoJSONMapConfigInterface } from '@unovis/ts/components/topojson-map/config'
+import { TopoJSONMap } from '@unovis/ts/components/topojson-map'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/treemap/index.vue
+++ b/packages/vue/src/components/treemap/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { TreemapConfigInterface } from '@unovis/ts'
-import { Treemap } from '@unovis/ts'
+
+import type { TreemapConfigInterface } from '@unovis/ts/components/treemap/config'
+import { Treemap } from '@unovis/ts/components/treemap'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/components/xy-labels/index.vue
+++ b/packages/vue/src/components/xy-labels/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" generic="Datum">
 // !!! This code was automatically generated. You should not change it !!!
-import type { XYLabelsConfigInterface } from '@unovis/ts'
-import { XYLabels } from '@unovis/ts'
+
+import type { XYLabelsConfigInterface } from '@unovis/ts/components/xy-labels/config'
+import { XYLabels } from '@unovis/ts/components/xy-labels'
 import { computed, inject, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { componentAccessorKey } from '../../utils/context'
 import { arePropsEqual, useForwardProps } from '../../utils/props'

--- a/packages/vue/src/containers/single-container/index.vue
+++ b/packages/vue/src/containers/single-container/index.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts" generic="T">
-import { SingleContainer, ComponentCore, SingleContainerConfigInterface, Tooltip, Annotations } from '@unovis/ts'
+import { SingleContainer } from '@unovis/ts/containers/single-container'
+import { SingleContainerConfigInterface } from '@unovis/ts/containers/single-container/config'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Annotations } from '@unovis/ts/components/annotations'
 import { onUnmounted, ref, provide, watch, toRefs, watchEffect, reactive, toRaw } from 'vue'
 import { annotationsAccessorKey, componentAccessorKey, tooltipAccessorKey,  } from "../../utils/context"
 import { useForwardProps } from "../../utils/props"

--- a/packages/vue/src/containers/xy-container/index.vue
+++ b/packages/vue/src/containers/xy-container/index.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts" generic="T">
-import { XYContainer, XYComponentCore, XYContainerConfigInterface, Tooltip, Crosshair, Axis, Annotations } from '@unovis/ts'
+import { XYContainer } from '@unovis/ts/containers/xy-container'
+import { XYContainerConfigInterface } from '@unovis/ts/containers/xy-container/config'
+import { XYComponentCore } from '@unovis/ts/core/xy-component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { Axis } from '@unovis/ts/components/axis'
+import { Annotations } from '@unovis/ts/components/annotations'
 import { onUnmounted, ref, provide, watch, toRefs, reactive, watchEffect, toRaw } from 'vue'
 import { componentAccessorKey, tooltipAccessorKey, axisAccessorKey, crosshairAccessorKey, annotationsAccessorKey } from "../../utils/context"
 import { useForwardProps } from "../../utils/props"

--- a/packages/vue/src/html-components/bullet-legend/index.vue
+++ b/packages/vue/src/html-components/bullet-legend/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // !!! This code was automatically generated. You should not change it !!!
-import type { BulletLegendConfigInterface } from '@unovis/ts'
-import { BulletLegend } from '@unovis/ts'
+
+import type { BulletLegendConfigInterface } from '@unovis/ts/components/bullet-legend/config'
+import { BulletLegend } from '@unovis/ts/components/bullet-legend'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 

--- a/packages/vue/src/html-components/flow-legend/index.vue
+++ b/packages/vue/src/html-components/flow-legend/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // !!! This code was automatically generated. You should not change it !!!
-import type { FlowLegendConfigInterface } from '@unovis/ts'
-import { FlowLegend } from '@unovis/ts'
+
+import type { FlowLegendConfigInterface } from '@unovis/ts/components/flow-legend/config'
+import { FlowLegend } from '@unovis/ts/components/flow-legend'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 

--- a/packages/vue/src/html-components/leaflet-flow-map/index.vue
+++ b/packages/vue/src/html-components/leaflet-flow-map/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts" generic="PointDatum extends GenericDataRecord, FlowDatum extends GenericDataRecord">
 // !!! This code was automatically generated. You should not change it !!!
-import type { GenericDataRecord, LeafletFlowMapConfigInterface } from '@unovis/ts'
-import { LeafletFlowMap } from '@unovis/ts'
+
+import type { LeafletFlowMapConfigInterface } from '@unovis/ts/components/leaflet-flow-map/config'
+import type { GenericDataRecord } from '@unovis/ts/types/data'
+import { LeafletFlowMap } from '@unovis/ts/components/leaflet-flow-map'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 

--- a/packages/vue/src/html-components/leaflet-map/index.vue
+++ b/packages/vue/src/html-components/leaflet-map/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts" generic="Datum extends GenericDataRecord">
 // !!! This code was automatically generated. You should not change it !!!
-import type { GenericDataRecord, LeafletMapConfigInterface } from '@unovis/ts'
-import { LeafletMap } from '@unovis/ts'
+
+import type { LeafletMapConfigInterface } from '@unovis/ts/components/leaflet-map/config'
+import type { GenericDataRecord } from '@unovis/ts/types/data'
+import { LeafletMap } from '@unovis/ts/components/leaflet-map'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 

--- a/packages/vue/src/html-components/rolling-pin-legend/index.vue
+++ b/packages/vue/src/html-components/rolling-pin-legend/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // !!! This code was automatically generated. You should not change it !!!
-import type { RollingPinLegendConfigInterface } from '@unovis/ts'
-import { RollingPinLegend } from '@unovis/ts'
+
+import type { RollingPinLegendConfigInterface } from '@unovis/ts/components/rolling-pin-legend/config'
+import { RollingPinLegend } from '@unovis/ts/components/rolling-pin-legend'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { arePropsEqual, useForwardProps } from '../../utils/props'
 

--- a/packages/vue/src/utils/context.ts
+++ b/packages/vue/src/utils/context.ts
@@ -1,4 +1,9 @@
-import { XYComponentCore, ComponentCore, Tooltip, Crosshair, Axis, Annotations } from '@unovis/ts'
+import { XYComponentCore } from '@unovis/ts/core/xy-component'
+import { ComponentCore } from '@unovis/ts/core/component'
+import { Tooltip } from '@unovis/ts/components/tooltip'
+import { Crosshair } from '@unovis/ts/components/crosshair'
+import { Axis } from '@unovis/ts/components/axis'
+import { Annotations } from '@unovis/ts/components/annotations'
 import { InjectionKey, Ref } from 'vue'
 
 export const componentAccessorKey = Symbol('componentAccessorKey') as InjectionKey<{

--- a/packages/vue/src/utils/props.ts
+++ b/packages/vue/src/utils/props.ts
@@ -1,4 +1,4 @@
-import { isEqual } from '@unovis/ts'
+import { isEqual } from '@unovis/ts/utils/data'
 import { camelize, computed, getCurrentInstance, useAttrs } from 'vue'
 
 export function arePropsEqual<PropTypes> (prevProps: PropTypes, nextProps: PropTypes): boolean {

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -41,7 +41,10 @@ export default defineConfig(({ command, mode }): UserConfig => {
           entry: resolve(__dirname, 'src/index.ts'),
         },
         rollupOptions: {
-          external: ['vue', '@unovis/ts'],
+          // The regex also covers granular subpaths (`@unovis/ts/components/area`), which the
+          // wrappers import instead of the root barrel. A plain string would only match the
+          // bare specifier and Rollup would inline the core library into this bundle.
+          external: ['vue', /^@unovis\/ts(\/.*)?$/],
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore overloaded issue
           output: [outputDefault('cjs', 'cjs'), outputDefault('es', 'js')],
@@ -60,6 +63,11 @@ export default defineConfig(({ command, mode }): UserConfig => {
       resolve: {
         alias: {
           '@unovis/vue': resolve(__dirname, 'src/index.ts'),
+          // The wrappers import granular subpaths (`@unovis/ts/components/area`). Those only
+          // exist under `packages/ts/dist`, which is the root of the published tarball but not
+          // of the workspace package, so they need an explicit alias here. `packages/dev` and
+          // `packages/shared` alias `@unovis/ts` the same way.
+          '@unovis/ts': resolve(__dirname, '../ts/dist'),
         },
       },
     }


### PR DESCRIPTION
## Problem

Importing anything from the `@unovis/ts` root barrel forces a consumer's bundler to resolve and transform the entire library — ~1500 modules, including the lazily loaded `elkjs` / `three` / `leaflet` / `maplibre-gl` dependencies — even for an app that only renders a line chart. Resolution happens *before* tree-shaking, so the final bundle stays small while the **build** can exhaust memory. That's the failure reported in #740: a Nuxt build on Cloudflare Pages dying at a 256 MB heap.

`@unovis/react` already avoided this by importing `@unovis/ts/components/area` instead of the barrel. The other four wrappers did not — so every Vue / Svelte / Solid / Angular app pulled the whole core no matter how its own code imported things. In the reported case the chain was nuxt-charts → `@unovis/vue` → `@unovis/ts`, which meant no import style available to the user could have avoided it.

## Root cause

Two layers, and the second is why this wasn't a one-line fix:

1. `getConfigSummary()` in `packages/shared/integrations/utils.ts` already returned an `importSourceMap` of granular paths, and `getImportStatements()` already accepted it. React passed it; the other four generators simply never forwarded it.

2. That map had been quietly broken by the `@/*` path-alias migration (9d4eef5d, d231f7fe). It only rewrote *bare* internal specifiers (`types/`, `core/`, …), so `@/types/accessor` fell straight through and was emitted verbatim into generated wrappers. This is also the reason `pnpm generate` for Angular had been producing code that doesn't compile.

## What changed

| Commit | |
|---|---|
| `Core \| Dev` | `resolveUnovisImportSource()` — maps `@/x` → `@unovis/ts/x`, normalizes relative specifiers against the declaring file's directory, leaves third-party specifiers alone |
| `Vue \| Svelte \| Solid \| Angular` | all four generators forward `importSourceMap` |
| `Vue \| Solid \| Svelte \| Angular` | build + demo resolution (see below) |
| `Vue \| Svelte \| Solid \| Angular` | hand-written containers / prop helpers / context types |
| `Misc` | regenerated wrapper components (121 files) |
| `Dev \| Gallery` | missing `@` alias in the playground |

Two things the split exposed and fixed:

- **Vue and Solid externalized the exact string `@unovis/ts`.** Rollup matches that literally, so subpath imports would *not* have been externalized and the entire core library would have been inlined into each wrapper bundle. Now a regex covering subpaths.
- **Svelte sets `importsNotUsedAsValues: error`.** Splitting one barrel import into per-source statements made the type-only ones fatal, so its template now emits `import type` for everything except the component class.

## Measurements

Vite, single line chart, counting modules resolved and transformed:

| import | modules | heavy deps |
|---|---|---|
| `@unovis/ts` (barrel) | 1521 | elkjs, three, leaflet, maplibre-gl, dagre, graphlibrary, topojson |
| `@unovis/ts/components/line` | 355 | none |
| `@unovis/vue` (wrapper barrel) | 1545 | elkjs, three, leaflet, maplibre-gl, … |
| **`@unovis/vue/components/line`** | **358** | **none** |

The 1521 figure reproduces the ~1492 measured in #740. The last row is the point: **before this change that path did not exist** — a granular wrapper import still dragged in the whole core.

## What this does not fix

Importing from a wrapper's own root barrel (`import { VisLine } from '@unovis/vue'`) still walks every wrapper component and therefore still pulls everything — that barrel is unchanged here. So this is the enabling fix, not a complete one for barrel consumers like nuxt-charts. Making the wrapper barrels cheap is a separate change.

## Verification

- All five packages build and typecheck clean (`vue-tsc`, `svelte-check` 0 errors, Angular AOT, React, Solid).
- Zero root-barrel imports and zero `@/` leakage remain in any wrapper `src/`.
- Regenerating React produced exactly one diff — fixing a stale barrel import in `radial-bar` — confirming the codegen change causes no drift.
- The `:9600` multi-framework playground renders all six panels (react/vue/solid/svelte/angular/vanilla). On `elk-layered-graph` every framework produces identical DOM and the lazy `elkjs` chunk still loads, confirming dynamic imports survive.

## Notes for review

- **`packages/shared/vite.config.ts` is a pre-existing fix, not part of this work.** The playground was already broken — 131 `Failed to resolve import "@/…"` errors killing all six panels — because that alias block still lists pre-migration bare prefixes and never gained an `@` entry. Happy to split it out; it's here because it's how the rest was verified.
- Granular subpaths only exist under `packages/ts/dist`, which is the root of the published tarball but *not* of the workspace package. Anything resolving `@unovis/ts/...` without an alias therefore fails, which is why the demo configs alias it (as `packages/dev` and `packages/shared` already did). The proper follow-up is an `exports` map on `@unovis/ts` — worth noting that exports patterns have **no directory-index fallback**, so `./*` → `./dist/*.js` would break `@unovis/ts/components/area`.
- `import/no-unresolved` cannot follow these subpaths for the same reason; it's added to the rule's existing ignore list next to the docusaurus aliases. The imports are still validated by tsc / vue-tsc / svelte-check. This already affected React's committed granular imports.
- Angular's UMD bundle now emits ~32 "no name provided for external module" warnings instead of one. Only the browser-globals branch is affected — `require`/AMD are correct — and `@unovis/ts` ships ESM-only, so that branch was already unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
