### PR TITLE
Clear vite-plugin-dts type errors and fail the build on missing entry declarations

### DIFF
--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -47,8 +47,8 @@
     "dist/styles/index.js"
   ],
   "scripts": {
-    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild; echo $sha > .srcsha; fi; npm run build:package-json",
-    "forcebuild": "rimraf dist; vite build; rm -rf dist/.cache; cp LICENSE README.md ./dist; npm run build:package-json",
+    "build": "sha=$(tar cf - ./src | shasum); if [[ $(echo $sha) == $(< .srcsha) ]] && [[ -d \"./dist\" ]]; then echo \"Lib Build Exists\"; else npm run forcebuild || exit 1; echo $sha > .srcsha; fi; npm run build:package-json",
+    "forcebuild": "rimraf dist && vite build && rm -rf dist/.cache && cp LICENSE README.md ./dist && npm run build:package-json",
     "publish:dist": "cd ./dist; npm publish",
     "build:package-json": "node -e \"const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); delete p.typesVersions; require('fs').writeFileSync('./dist/package.json', JSON.stringify(p, null, 2))\"",
     "license:check": "pnpm license-report --config=../../lic-report-config.json > licences.md"

--- a/packages/ts/src/components/annotations/index.ts
+++ b/packages/ts/src/components/annotations/index.ts
@@ -25,7 +25,7 @@ export class Annotations extends ComponentCore<unknown[], AnnotationsConfigInter
   protected _defaultConfig = AnnotationsDefaultConfig as AnnotationsConfigInterface
   public config: AnnotationsConfigInterface = this._defaultConfig
 
-  g: Selection<SVGGElement, unknown, null, undefined>
+  declare g: Selection<SVGGElement, unknown, null, undefined>
 
   events = {}
 

--- a/packages/ts/src/components/axis/index.ts
+++ b/packages/ts/src/components/axis/index.ts
@@ -317,7 +317,7 @@ export class Axis<Datum> extends XYComponentCore<Datum, AxisConfigInterface<Datu
       .classed(s.tickLabelHideable, Boolean(config.tickTextHideOverlapping))
       // Ticks outside the fitted set render as unlabeled tick marks
       .classed(s.tickTextHidden, tickValue => labeledTickKeys ? !labeledTickKeys.has(tickKey(tickValue)) : false)
-      .style('fill', config.tickTextColor) as Selection<SVGTextElement, number, SVGGElement, unknown> | Selection<SVGTextElement, Date, SVGGElement, unknown>
+      .style('fill', config.tickTextColor) as Selection<SVGTextElement, number | Date, SVGGElement, unknown>
 
     // Stale inline opacity (set by the overlap pass) would override the hiding class
     if (labeledTickKeys) {

--- a/packages/ts/src/components/brush/index.ts
+++ b/packages/ts/src/components/brush/index.ts
@@ -160,7 +160,7 @@ export class Brush<Datum> extends XYComponentCore<Datum, BrushConfigInterface<Da
   _onBrush (event: D3BrushEvent<Datum>): void {
     const { config } = this
     const xScale = this.xScale
-    const xRange = [0, this._width]
+    const xRange: [number, number] = [0, this._width]
     const s = (event?.selection || xRange) as [number, number]
     const userDriven = !!event?.sourceEvent
     // Handle edge cases:

--- a/packages/ts/src/components/bullet-legend/index.ts
+++ b/packages/ts/src/components/bullet-legend/index.ts
@@ -27,7 +27,7 @@ export class BulletLegend {
   prevConfig: BulletLegendConfigInterface
   protected _container: HTMLElement
 
-  private _colorAccessor = (d: BulletLegendItemInterface): string|string[] => d.color
+  private _colorAccessor = (d: BulletLegendItemInterface): string => d.color as string
 
   constructor (element: HTMLElement, config?: BulletLegendConfigInterface) {
     this._container = element

--- a/packages/ts/src/components/bullet-legend/modules/shape.ts
+++ b/packages/ts/src/components/bullet-legend/modules/shape.ts
@@ -67,7 +67,7 @@ export function updateBullets (
     const width = getBulletsTotalWidth(bulletWidth, numBullets, spacing)
     const height = shape === BulletShape.Line ? BULLET_SIZE / 2.5 : BULLET_SIZE
 
-    const selection = select(els[i]).select('svg')
+    const selection = select(els[i]).select<SVGSVGElement>('svg')
       .attr('viewBox', `0 0 ${width} ${height}`)
 
     // Remove existing paths

--- a/packages/ts/src/components/chord-diagram/index.ts
+++ b/packages/ts/src/components/chord-diagram/index.ts
@@ -15,9 +15,19 @@ import { getCSSVariableValueInPixels } from '@/utils/misc'
 
 // Types
 import { Spacing } from '@/types/spacing'
+import { GraphNodeCore } from '@/types/graph'
 
 // Local Types
-import { ChordInputNode, ChordInputLink, ChordDiagramData, ChordNode, ChordRibbon, ChordLabelAlignment, ChordLeafNode } from './types'
+import {
+  ChordInputNode,
+  ChordInputLink,
+  ChordDiagramData,
+  ChordHierarchyNode,
+  ChordNode,
+  ChordRibbon,
+  ChordLabelAlignment,
+  ChordLeafNode,
+} from './types'
 
 // Config
 import { ChordDiagramDefaultConfig, ChordDiagramConfigInterface } from './config'
@@ -67,7 +77,7 @@ export class ChordDiagram<
   }
 
   private _nodes: ChordNode<N>[] = []
-  private _links: ChordRibbon<N>[] = []
+  private _links: ChordRibbon<N, L>[] = []
   private _rootNode: ChordNode<N>
 
   private get _forceHighlight (): boolean {
@@ -140,7 +150,7 @@ export class ChordDiagram<
     links = links.filter(d => d._state.value)
     const root = getHierarchyNodes(nodes, d => d._state?.value, nodeLevels)
 
-    const partitionData = partition().size([this.config.angleRange[1], 1])(root) as ChordNode<N>
+    const partitionData = partition<ChordHierarchyNode<GraphNodeCore<N, L>>>().size([this.config.angleRange[1], 1])(root) as unknown as ChordNode<N>
     partitionData.each((n, i) => {
       positionChildren(n, padAngle)
       n.uid = `${this.uid.substr(0, 4)}-${i}`
@@ -152,7 +162,7 @@ export class ChordDiagram<
     const partitionDataWithRoot = partitionData.descendants()
     this._rootNode = partitionDataWithRoot.find(d => d.depth === 0)
     this._nodes = partitionDataWithRoot.filter(d => d.depth !== 0) // Filter out the root node
-    this._links = getRibbons<N>(partitionData, links, padAngle)
+    this._links = getRibbons<N, L>(partitionData, links, padAngle)
   }
 
   _render (customDuration?: number): void {
@@ -190,7 +200,7 @@ export class ChordDiagram<
 
     // Links
     const linksSelection = this.linkGroup
-      .selectAll<SVGPathElement, ChordRibbon<N>>(`.${s.link}`)
+      .selectAll<SVGPathElement, ChordRibbon<N, L>>(`.${s.link}`)
       .data(this._links, d => String(d.data._id))
 
     const linksEnter = linksSelection.enter().append('path')
@@ -215,12 +225,12 @@ export class ChordDiagram<
 
     const nodesEnter = nodesSelection.enter().append('path')
       .attr('class', s.node)
-      .call(createNode, config)
+      .call(createNode)
 
     const nodesMerged = nodesSelection
       .merge(nodesEnter)
       .classed(s.highlightedNode, d => config.highlightedNodeId === d.data._id)
-    nodesMerged.call(updateNode, config, this.arcGen, duration, this.bleed)
+    nodesMerged.call(updateNode, config, this.arcGen, duration)
 
     nodesSelection.exit()
       .call(removeNode, duration)
@@ -244,7 +254,7 @@ export class ChordDiagram<
   }
 
   private _onNodeMouseOver (d: ChordNode<N>): void {
-    let ribbons: ChordRibbon<N>[]
+    let ribbons: ChordRibbon<N, L>[]
     if (d.children) {
       const leaves = d.leaves() as ChordLeafNode<N>[]
       ribbons = this._links.filter(l =>
@@ -264,7 +274,7 @@ export class ChordDiagram<
     this._highlightOnHover()
   }
 
-  private _onLinkMouseOver (d: ChordRibbon<N>): void {
+  private _onLinkMouseOver (d: ChordRibbon<N, L>): void {
     this._highlightOnHover([d])
   }
 
@@ -272,7 +282,7 @@ export class ChordDiagram<
     this._highlightOnHover()
   }
 
-  private _highlightOnHover (links?: ChordRibbon<N>[]): void {
+  private _highlightOnHover (links?: ChordRibbon<N, L>[]): void {
     if (this._forceHighlight) return
     if (links) {
       links.forEach(l => {
@@ -289,7 +299,7 @@ export class ChordDiagram<
 
     this.nodeGroup.selectAll<SVGPathElement, ChordNode<N>>(`.${s.node}`)
       .classed(s.highlightedNode, d => d._state.hovered)
-    this.linkGroup.selectAll<SVGPathElement, ChordRibbon<N>>(`.${s.link}`)
+    this.linkGroup.selectAll<SVGPathElement, ChordRibbon<N, L>>(`.${s.link}`)
       .classed(s.highlightedLink, d => d._state.hovered)
 
     this.g.classed(s.transparent, !!links)

--- a/packages/ts/src/components/chord-diagram/modules/layout.ts
+++ b/packages/ts/src/components/chord-diagram/modules/layout.ts
@@ -9,7 +9,7 @@ import { getNumber, groupBy } from '@/utils/data'
 import { NumericAccessor } from '@/types/accessor'
 
 // Local Types
-import { ChordNode, ChordRibbon, ChordLinkDatum, ChordHierarchyNode, ChordLeafNode } from '../types'
+import { ChordInputLink, ChordInputNode, ChordNode, ChordRibbon, ChordLinkDatum, ChordHierarchyNode, ChordLeafNode } from '../types'
 
 function transformData <T> (node: HierarchyNode<T>): void {
   const { height, depth } = node
@@ -26,7 +26,7 @@ export function getHierarchyNodes<N> (
   levels: string[] = []
 ): HierarchyNode<ChordHierarchyNode<N>> {
   const nodeLevels = levels.map(level => (d: N) => d[level as keyof N]) as unknown as [(d: N) => string]
-  const nestedData = levels.length ? group<N, string>(data, ...nodeLevels) : { key: 'root', children: data }
+  const nestedData = levels.length ? group(data, ...nodeLevels) : { key: 'root', children: data }
 
   const root = hierarchy(nestedData)
     .sum(d => getNumber(d as unknown as N, value))
@@ -63,7 +63,7 @@ export function positionChildren<N> (node: ChordNode<N>, padding: number, scalin
   })
 }
 
-export function getRibbons<N> (data: ChordNode<N>, links: ChordLinkDatum<N>[], padding: number): ChordRibbon<N>[] {
+export function getRibbons<N extends ChordInputNode, L extends ChordInputLink> (data: ChordNode<N>, links: ChordLinkDatum<N, L>[], padding: number): ChordRibbon<N, L>[] {
   type LinksArrayType = typeof links
   const groupedBySource: Record<string, LinksArrayType> = groupBy(links, d => d.source._id)
   const groupedByTarget: Record<string, LinksArrayType> = groupBy(links, d => d.target._id)
@@ -77,8 +77,8 @@ export function getRibbons<N> (data: ChordNode<N>, links: ChordLinkDatum<N>[], p
     partitionHeight: number,
     nodes: ChordNode<N>[] = []
   ): ChordNode<N>[] => {
-    nodes[source.height] = source
-    nodes[partitionHeight * 2 - target.height] = target
+    nodes[source.height] = source as unknown as ChordNode<N>
+    nodes[partitionHeight * 2 - target.height] = target as unknown as ChordNode<N>
     if (source.parent && target.parent) getNodesInRibbon(source.parent, target.parent, partitionHeight, nodes)
     return nodes
   }

--- a/packages/ts/src/components/chord-diagram/modules/link.ts
+++ b/packages/ts/src/components/chord-diagram/modules/link.ts
@@ -54,8 +54,8 @@ function linkGen (points: ChordRibbonPoint[], radiusScale: ScalePower<number, nu
   return convertLineToArc(path, radius)
 }
 
-export function createLink<N extends ChordInputNode> (
-  selection: Selection<SVGPathElement, ChordRibbon<N>, SVGGElement, unknown>,
+export function createLink<N extends ChordInputNode, L extends ChordInputLink> (
+  selection: Selection<SVGPathElement, ChordRibbon<N, L>, SVGGElement, unknown>,
   radiusScale: ScalePower<number, number>
 ): void {
   selection

--- a/packages/ts/src/components/chord-diagram/modules/node.ts
+++ b/packages/ts/src/components/chord-diagram/modules/node.ts
@@ -40,7 +40,7 @@ export function createNode<N extends ChordInputNode, L extends ChordInputLink> (
 export function updateNode<N extends ChordInputNode, L extends ChordInputLink> (
   selection: Selection<SVGPathElement, ChordNode<N>, SVGGElement, unknown>,
   config: ChordDiagramConfigInterface<N, L>,
-  arcGen: Arc<unknown, AnimState>,
+  arcGen: Arc<any, ChordNode<N>>,
   duration: number
 ): void {
   const nodeColor = (d: ChordNode<N>): string => getColor(d.data, config.nodeColor, d.height)
@@ -63,7 +63,7 @@ export function updateNode<N extends ChordInputNode, L extends ChordInputLink> (
 
       return (t: number): string => {
         arcNode._animState = datum(t)
-        return arcGen(arcNode._animState)
+        return arcGen(arcNode._animState as unknown as ChordNode<N>)
       }
     })
   } else {

--- a/packages/ts/src/components/graph/index.ts
+++ b/packages/ts/src/components/graph/index.ts
@@ -88,7 +88,7 @@ export class Graph<
   }
 
   static nodeSelectors = nodeSelectors
-  g: Selection<SVGGElement, unknown, null, undefined>
+  declare g: Selection<SVGGElement, unknown, null, undefined>
   protected _defaultConfig = GraphDefaultConfig as unknown as GraphConfigInterface<N, L>
   public config: GraphConfigInterface<N, L> = this._defaultConfig
   datamodel: GraphDataModel<N, L, GraphNode<N, L>, GraphLink<N, L>> = new GraphDataModel()
@@ -376,7 +376,7 @@ export class Graph<
 
     const linkGroupsEnter = linkGroups.enter().append('g')
       .attr('class', linkSelectors.gLink)
-      .call(createLinks, config, duration)
+      .call(createLinks)
 
     const linkGroupsMerged = linkGroups.merge(linkGroupsEnter)
     linkGroupsMerged.call(updateLinks, config, duration, this._scale, this._getLinkArrowDefId, this._linkPathLengthMap)
@@ -413,7 +413,7 @@ export class Graph<
 
     const panelGroupEnter = panelGroup.enter().append('g')
       .attr('class', panelSelectors.gPanel)
-      .call(createPanels, selection)
+      .call(createPanels)
     const panelGroupMerged = panelGroup.merge(panelGroupEnter)
 
     this._updatePanels(panelGroupMerged, duration)
@@ -771,8 +771,7 @@ export class Graph<
       .call(
         (nodes.length > config.zoomThrottledUpdateNodeThreshold ? zoomLinksThrottled : zoomLinks) as typeof zoomLinks,
         config,
-        this._scale,
-        this._getLinkArrowDefId
+        this._scale
       )
   }
 

--- a/packages/ts/src/components/graph/modules/panel/index.ts
+++ b/packages/ts/src/components/graph/modules/panel/index.ts
@@ -57,9 +57,9 @@ export function createPanels<N extends GraphNode, L extends GraphLink> (
   sideIcon.append('text').attr('class', panelSelectors.sideIconSymbol)
 }
 
-export function updatePanels<N extends GraphNode, L extends GraphLink> (
+export function updatePanels<N extends GraphInputNode, L extends GraphInputLink> (
   selection: Selection<SVGGElement, GraphPanel, SVGGElement, unknown>,
-  config: GraphConfigInterface<GraphInputNode, GraphInputLink>,
+  config: GraphConfigInterface<N, L>,
   duration: number
 ): void {
   smartTransition(selection, duration)
@@ -86,7 +86,7 @@ export function updatePanels<N extends GraphNode, L extends GraphLink> (
   const sideIcon = selection.select<SVGGElement>(`.${panelSelectors.sideIconGroup}`)
 
   sideIcon.select<SVGGElement>(`.${panelSelectors.sideIconShape}`)
-    .call(updateShape, (d: GraphPanel) => d.sideIconShape, (d: GraphPanel) => d.sideIconShapeSize ?? DEFAULT_SIDE_LABEL_SIZE)
+    .call(updateShape, (d: GraphPanel) => d.sideIconShape, (d: GraphPanel) => d.sideIconShapeSize ?? DEFAULT_SIDE_LABEL_SIZE, 0)
     .style('stroke', d => d.sideIconShapeStroke)
     .style('cursor', d => d.sideIconCursor ?? null)
     .style('opacity', d => d.sideIconShape ? 1 : 0)
@@ -125,9 +125,9 @@ export function updatePanels<N extends GraphNode, L extends GraphLink> (
     })
 }
 
-export function removePanels<N extends GraphNode, L extends GraphLink> (
+export function removePanels<N extends GraphInputNode, L extends GraphInputLink> (
   selection: Selection<SVGGElement, GraphPanel, SVGGElement, unknown>,
-  config: GraphConfigInterface<GraphInputNode, GraphInputLink>,
+  config: GraphConfigInterface<N, L>,
   duration: number
 ): void {
   smartTransition(selection, duration / 2)

--- a/packages/ts/src/components/heatmap/utils.ts
+++ b/packages/ts/src/components/heatmap/utils.ts
@@ -43,7 +43,7 @@ export function resolveHeatmapCellSize (
 /** Resolves the grid dimensions from the total number of cells, the fill layout, and any explicit dimensions. */
 export function getHeatmapGridSize (
   total: number,
-  layout: HeatmapLayoutType,
+  layout: HeatmapLayoutType | `${HeatmapLayoutType}`,
   numRows?: number,
   numColumns?: number
 ): { rows: number; columns: number } {

--- a/packages/ts/src/components/leaflet-map/index.ts
+++ b/packages/ts/src/components/leaflet-map/index.ts
@@ -63,9 +63,9 @@ export class LeafletMap<Datum extends GenericDataRecord> extends ComponentCore<D
   protected _defaultConfig = LeafletMapDefaultConfig as LeafletMapConfigInterface<Datum>
   public config: LeafletMapConfigInterface<Datum> = this._defaultConfig
 
-  g: Selection<HTMLElement, unknown, null, undefined>
+  declare g: Selection<HTMLElement, unknown, null, undefined>
   type = ComponentType.HTML
-  element: HTMLElement
+  declare element: HTMLElement
   datamodel: MapDataModel<Datum> = new MapDataModel()
   protected _container: HTMLElement
   protected _containerSelection: Selection<HTMLElement, unknown, null, undefined>
@@ -527,7 +527,7 @@ export class LeafletMap<Datum extends GenericDataRecord> extends ComponentCore<D
       .call(createNodes)
 
     const pointsMerged = points.merge(pointsEnter)
-    pointsEnter.call(updateNodes, config, this._map.leaflet)
+    pointsEnter.call(updateNodes, config, this._map.leaflet, false)
     points.call(updateNodes, config, this._map.leaflet, mapMoveZoomUpdateOnly)
     pointsMerged.call(collideLabels, this._map.leaflet)
 

--- a/packages/ts/src/components/leaflet-map/modules/utils.ts
+++ b/packages/ts/src/components/leaflet-map/modules/utils.ts
@@ -229,7 +229,7 @@ export function shouldClusterExpand<D extends GenericDataRecord> (
 
   const clusterExpansionZoomLevel = cluster.clusterIndex.getClusterExpansionZoom(cluster.properties.cluster_id as number)
   return zoomLevel >= maxLevel ||
-        (zoomLevel >= midLevel && (cluster.properties.point_count < 20 || clusterExpansionZoomLevel >= maxClusterZoomLevel))
+        (zoomLevel >= midLevel && ((cluster.properties as LeafletMapClusterDatum<D>).point_count < 20 || clusterExpansionZoomLevel >= maxClusterZoomLevel))
 }
 
 export function findPointAndClusterByPointId<D extends GenericDataRecord> (

--- a/packages/ts/src/components/nested-donut/index.ts
+++ b/packages/ts/src/components/nested-donut/index.ts
@@ -2,7 +2,7 @@ import { Selection } from 'd3-selection'
 import { arc, pie } from 'd3-shape'
 import { hierarchy, HierarchyNode, partition } from 'd3-hierarchy'
 import { scaleLinear, ScaleLinear } from 'd3-scale'
-import { group } from 'd3-array'
+import { group, InternMap } from 'd3-array'
 
 // Core
 import { ComponentCore } from '@/core/component'
@@ -20,7 +20,7 @@ import { cssvar } from '@/utils/style'
 import { wrapSVGText } from '@/utils/text'
 
 // Local Types
-import { NestedDonutDirection, NestedDonutSegment, NestedDonutLayer, NestedDonutSegmentLabelAlignment } from './types'
+import { NestedDonutArcAnimState, NestedDonutDirection, NestedDonutSegment, NestedDonutLayer, NestedDonutSegmentLabelAlignment } from './types'
 
 // Config
 import { NestedDonutDefaultConfig, NestedDonutConfigInterface } from './config'
@@ -47,7 +47,7 @@ NestedDonutConfigInterface<Datum>
   centralLabel: Selection<SVGTextElement, unknown, SVGGElement, unknown>
   centralSubLabel: Selection<SVGTextElement, unknown, SVGGElement, unknown>
 
-  arcGen = arc<Partial<NestedDonutSegment<Datum>>>()
+  arcGen = arc<NestedDonutArcAnimState>()
   colorScale: ScaleLinear<string, string> = scaleLinear()
 
   events = { }
@@ -181,7 +181,7 @@ NestedDonutConfigInterface<Datum>
       ? hierarchy(nestedData).sum(index => typeof index === 'number' && getNumber(data[index], config.value, index))
       : hierarchy(nestedData).count()
 
-    const partitionData = partition().size([config.angleRange[1], 1])(rootNode) as NestedDonutSegment<Datum>
+    const partitionData = partition<InternMap<string, number[]>>().size([config.angleRange[1], 1])(rootNode) as unknown as NestedDonutSegment<Datum>
 
     partitionData
       .each(node => {

--- a/packages/ts/src/components/nested-donut/modules/arc.ts
+++ b/packages/ts/src/components/nested-donut/modules/arc.ts
@@ -9,14 +9,13 @@ import { getPattern, getFillPatternValue, UNOVIS_PATTERN_INDEX_ATTR } from '@/ut
 import { smartTransition } from '@/utils/d3'
 
 // Local Types
-import { NestedDonutSegment } from '../types'
+import { NestedDonutArcAnimState, NestedDonutSegment } from '../types'
 
 // Config
 import { NestedDonutConfigInterface } from '../config'
 
-type AnimState = { x0: number; x1: number; y0: number; y1: number }
 export interface ArcNode extends SVGElement {
-  _animState?: AnimState;
+  _animState?: NestedDonutArcAnimState;
 }
 
 export function createArc<Datum> (
@@ -44,7 +43,7 @@ export function createArc<Datum> (
 export function updateArc<Datum> (
   selection: Selection<SVGPathElement, NestedDonutSegment<Datum>, SVGGElement, unknown>,
   config: NestedDonutConfigInterface<Datum>,
-  arcGen: Arc<any, AnimState>,
+  arcGen: Arc<any, NestedDonutArcAnimState>,
   duration: number
 ): void {
   selection

--- a/packages/ts/src/components/nested-donut/modules/label.ts
+++ b/packages/ts/src/components/nested-donut/modules/label.ts
@@ -14,7 +14,7 @@ import { wrapSVGText } from '@/utils/text'
 import { NestedDonutConfigInterface } from '../config'
 
 // Local Types
-import { NestedDonutSegment, NestedDonutSegmentLabelAlignment } from '../types'
+import { NestedDonutArcAnimState, NestedDonutSegment, NestedDonutSegmentLabelAlignment } from '../types'
 
 // Styles
 import { variables } from '../style'
@@ -39,7 +39,7 @@ function getLabelFillColor<Datum> (
 
 function getLabelTransform<Datum> (
   d: NestedDonutSegment<Datum>,
-  arcGen: Arc<unknown, NestedDonutSegment<Datum>>
+  arcGen: Arc<unknown, NestedDonutArcAnimState>
 ): string {
   const translate = `translate(${arcGen.centroid(d)})`
   const degree = 180 / Math.PI * (arcGen.startAngle()(d) + arcGen.endAngle()(d)) / 2 - 90
@@ -71,7 +71,7 @@ function getLabelBounds<Datum> (
 
 export function createLabel<Datum> (
   selection: Selection<SVGTextElement, NestedDonutSegment<Datum>, SVGGElement, unknown>,
-  arcGen: Arc<unknown, NestedDonutSegment<Datum>>
+  arcGen: Arc<unknown, NestedDonutArcAnimState>
 ): void {
   selection
     .attr('transform', d => getLabelTransform(d, arcGen))
@@ -83,7 +83,7 @@ export function createLabel<Datum> (
 export function updateLabel<Datum> (
   selection: Selection<SVGTextElement, NestedDonutSegment<Datum>, SVGGElement, unknown>,
   config: NestedDonutConfigInterface<Datum>,
-  arcGen: Arc<unknown, NestedDonutSegment<Datum>>,
+  arcGen: Arc<unknown, NestedDonutArcAnimState>,
   duration: number
 ): void {
   selection

--- a/packages/ts/src/components/nested-donut/types.ts
+++ b/packages/ts/src/components/nested-donut/types.ts
@@ -16,6 +16,8 @@ export type NestedDonutSegment<Datum> = HierarchyRectangularNode<NestedDonutSegm
   };
 }
 
+export type NestedDonutArcAnimState = { x0: number; x1: number; y0: number; y1: number }
+
 export enum NestedDonutDirection {
   Inwards = 'inwards',
   Outwards = 'outwards',

--- a/packages/ts/src/components/plotband/index.ts
+++ b/packages/ts/src/components/plotband/index.ts
@@ -94,9 +94,9 @@ export class Plotband<Datum> extends XYComponentCore<Datum, PlotbandConfigInterf
         .style('font-size', config.labelSize ? `${config.labelSize}px` : undefined)
 
       smartTransition(this.label, config.duration)
-        .text(config.labelText)
         .attr('x', labelProps.x)
         .attr('y', labelProps.y)
+        .text(config.labelText)
     }
 
     smartTransition(this.plotband.exit())

--- a/packages/ts/src/components/sankey/index.ts
+++ b/packages/ts/src/components/sankey/index.ts
@@ -53,7 +53,7 @@ export class Sankey<
   protected _defaultConfig = SankeyDefaultConfig as SankeyConfigInterface<N, L>
   public config: SankeyConfigInterface<N, L> = this._defaultConfig
   datamodel: GraphDataModel<N, L, SankeyNode<N, L>, SankeyLink<N, L>> = new GraphDataModel()
-  public g: Selection<SVGGElement, unknown, null, undefined>
+  public declare g: Selection<SVGGElement, unknown, null, undefined>
   // eslint-disable-next-line @typescript-eslint/naming-convention
   private _gNode: SVGGElement & { __zoom: ZoomTransform }
   private _prevWidth: number | undefined = undefined
@@ -237,7 +237,7 @@ export class Sankey<
       (nodes.length === 1 && !config.showSingleNode) ||
       (nodes.length > 1 && links.length === 0)
     ) {
-      this._linksGroup.selectAll<SVGGElement, SankeyLink<N, L>>(`.${s.link}`).call(removeLinks, duration)
+      this._linksGroup.selectAll<SVGGElement, SankeyLink<N, L>>(`.${s.link}`).call(removeLinks)
       this._nodesGroup.selectAll<SVGGElement, SankeyNode<N, L>>(`.${s.nodeGroup}`).call(removeNodes, config, duration)
     }
 

--- a/packages/ts/src/components/timeline/index.ts
+++ b/packages/ts/src/components/timeline/index.ts
@@ -1,5 +1,4 @@
 import { select, Selection } from 'd3-selection'
-import { Transition } from 'd3-transition'
 import { max, min, minIndex } from 'd3-array'
 import { scaleOrdinal, ScaleOrdinal } from 'd3-scale'
 import { drag, D3DragEvent } from 'd3-drag'
@@ -9,7 +8,7 @@ import { XYComponentCore } from '@/core/xy-component'
 
 // Utils
 import { isNumber, arrayOfIndices, getMin, getMax, getString, getNumber, getValue, groupBy, isPlainObject, isFunction } from '@/utils/data'
-import { smartTransition } from '@/utils/d3'
+import { smartTransition, Selection$Transition } from '@/utils/d3'
 import { getColor } from '@/utils/color'
 import { getPattern, getFillPatternValue, UNOVIS_PATTERN_INDEX_ATTR } from '@/utils/pattern'
 import { textAlignToAnchor, trimSVGText } from '@/utils/text'
@@ -368,7 +367,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
       .attr(UNOVIS_PATTERN_INDEX_ATTR, (d, i) => yOrdinalScale(this._getRecordKey(d, i)))
       .style('fill', (d, i) => getColor(d, config.color, yOrdinalScale(this._getRecordKey(d, i)), undefined, colorOptions))
       .style('mask', (d, i) => getFillPatternValue(getPattern(d, config.pattern, yOrdinalScale(this._getRecordKey(d, i)))))
-      .call(this._renderLines.bind(this), rowHeight)
+      .call(this._renderLines.bind(this))
 
     linesEnter.append('use').attr('class', s.lineStartIcon)
     linesEnter.append('use').attr('class', s.lineEndIcon)
@@ -384,7 +383,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
       .style('fill', (d, i) => getColor(d, config.color, yOrdinalScale(this._getRecordKey(d, i)), undefined, colorOptions))
       .style('mask', (d, i) => getFillPatternValue(getPattern(d, config.pattern, yOrdinalScale(this._getRecordKey(d, i)))))
       .style('cursor', (d, i) => getString(d, config.lineCursor ?? config.cursor, i))
-      .call(this._renderLines.bind(this), rowHeight)
+      .call(this._renderLines.bind(this))
 
     linesMerged.selectAll<SVGUseElement, Datum & TimelineLineRenderState>(`.${s.lineStartIcon}`)
       .data(d => [d])
@@ -623,7 +622,7 @@ export class Timeline<Datum> extends XYComponentCore<Datum, TimelineConfigInterf
 
 
   private _renderLines (
-    selection: Selection<SVGRectElement, Datum & TimelineLineRenderState, SVGGElement, unknown> | Transition<SVGRectElement, Datum & TimelineLineRenderState, SVGGElement, unknown>
+    selection: Selection$Transition<SVGRectElement, Datum & TimelineLineRenderState, SVGGElement, unknown>
   ): void {
     const { config } = this
 

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -284,7 +284,7 @@ export class Tooltip {
       const node = this.div.select(':first-child').node()
       if (node !== html) this.div.html('').append(() => html)
     } else if (html !== null && html !== undefined && html !== '') {
-      this.div.html(html)
+      this.div.html(html as string)
     }
 
     this.div

--- a/packages/ts/src/components/topojson-map/index.ts
+++ b/packages/ts/src/components/topojson-map/index.ts
@@ -31,6 +31,7 @@ import {
   MapProjection,
   TopoJSONMapPointShape,
   FlowParticle,
+  FlowUpdateContext,
   TopoJSONMapPoint,
   TopoJSONMapClusterDatum,
   TopoJSONMapPointDatum,
@@ -38,6 +39,7 @@ import {
   ExpandedClusterPoint,
   CollapsedClusterFeature,
   PointOrClusterProperties,
+  AreaLabelDatum,
 } from './types'
 
 // Config
@@ -62,7 +64,7 @@ import {
 import { updateDonut } from './modules/donut'
 import { renderBackground } from './modules/background'
 import { updateSelectionRing } from './modules/selectionRing'
-import { initFlowFeatures, updateFlowParticles, FlowInitContext, FlowUpdateContext } from './modules/flow'
+import { initFlowFeatures, updateFlowParticles, FlowInitContext } from './modules/flow'
 
 // Styles
 import * as s from './style'
@@ -85,7 +87,7 @@ export class TopoJSONMap<
   public config: TopoJSONMapConfigInterface<AreaDatum, PointDatum, LinkDatum> = this._defaultConfig
 
   datamodel: MapGraphDataModel<AreaDatum, PointDatum, LinkDatum> = new MapGraphDataModel()
-  g: Selection<SVGGElement, unknown, null, undefined>
+  declare g: Selection<SVGGElement, unknown, null, undefined>
   private _firstRender = true
   private _isResizing = false
   private _initialScale: number = undefined
@@ -114,18 +116,15 @@ export class TopoJSONMap<
 
   private _featureCollection: GeoJSON.FeatureCollection
   private _zoomBehavior: ZoomBehavior<SVGGElement, unknown> = zoom()
-  private _backgroundRect = this.g.append('rect').attr('class', s.background)
-  private _featuresGroup = this.g.append('g').attr('class', s.features)
-  private _areaLabelsGroup = this.g.append('g').attr('class', s.areaLabel)
-  private _linksGroup = this.g.append('g').attr('class', s.links)
-  private _clusterBackgroundGroup = this.g.append('g').attr('class', s.clusterBackground)
-  private _flowParticlesGroup = this.g.append('g').attr('class', s.flowParticles)
-  // Points after links + flow groups so map nodes paint above link arcs and flow particles
-  private _pointsGroup = this.g.append('g').attr('class', s.points)
-  private _pointSelectionRing = this._pointsGroup.append('g').attr('class', s.pointSelectionRing)
-    .call(sel => sel.append('path').attr('class', s.pointSelection))
-
-  private _sourcePointsGroup = this.g.append('g').attr('class', s.sourcePoints)
+  private _backgroundRect: Selection<SVGRectElement, unknown, null, undefined>
+  private _featuresGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _areaLabelsGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _linksGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _clusterBackgroundGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _flowParticlesGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _pointsGroup: Selection<SVGGElement, unknown, null, undefined>
+  private _pointSelectionRing: Selection<SVGGElement, unknown, null, undefined>
+  private _sourcePointsGroup: Selection<SVGGElement, unknown, null, undefined>
   private _selectedPoint: TopoJSONMapPoint<PointDatum> | null = null
   private _flowParticles: FlowParticle[] = []
   private _sourcePoints: { x: number; y: number; radius: number; color: string; flowData: LinkDatum }[] = []
@@ -138,6 +137,18 @@ export class TopoJSONMap<
 
   constructor (config?: TopoJSONMapConfigInterface<AreaDatum, PointDatum, LinkDatum>, data?: MapData<AreaDatum, PointDatum, LinkDatum>) {
     super()
+    this._backgroundRect = this.g.append('rect').attr('class', s.background)
+    this._featuresGroup = this.g.append('g').attr('class', s.features)
+    this._areaLabelsGroup = this.g.append('g').attr('class', s.areaLabel)
+    this._linksGroup = this.g.append('g').attr('class', s.links)
+    this._clusterBackgroundGroup = this.g.append('g').attr('class', s.clusterBackground)
+    this._flowParticlesGroup = this.g.append('g').attr('class', s.flowParticles)
+    // Points after links + flow groups so map nodes paint above link arcs and flow particles
+    this._pointsGroup = this.g.append('g').attr('class', s.points)
+    this._pointSelectionRing = this._pointsGroup.append('g').attr('class', s.pointSelectionRing)
+      .call(sel => sel.append('path').attr('class', s.pointSelection))
+    this._sourcePointsGroup = this.g.append('g').attr('class', s.sourcePoints)
+
     this._zoomBehavior
       .on('zoom', this._onZoom.bind(this))
       .on('end', this._onZoomEnd.bind(this))
@@ -1138,7 +1149,7 @@ export class TopoJSONMap<
     this._collisionDetectionAnimFrameId = window.requestAnimationFrame(() => {
       const duration = this.config.duration
       // Run collision detection for area labels
-      const areaLabels = this._areaLabelsGroup.selectAll<SVGTextElement, unknown>(`.${s.areaLabel}`)
+      const areaLabels = this._areaLabelsGroup.selectAll<SVGTextElement, AreaLabelDatum>(`.${s.areaLabel}`)
       collideAreaLabels(areaLabels, duration)
 
       // Run collision detection for point bottom labels

--- a/packages/ts/src/components/topojson-map/utils.ts
+++ b/packages/ts/src/components/topojson-map/utils.ts
@@ -272,9 +272,9 @@ export function toGeoJSONPoint<D> (
   }
 }
 
-export function calculateClusterIndex<D> (
+export function calculateClusterIndex<A, D, L> (
   data: D[],
-  config: TopoJSONMapConfigInterface<unknown, D, unknown>,
+  config: TopoJSONMapConfigInterface<A, D, L>,
   maxClusterZoomLevel = 24
 ): Supercluster<D> {
   const { colorMap, pointShape, latitude, longitude, clusteringDistance } = config
@@ -333,11 +333,11 @@ export function getPointRadius<D> (
     : radius
 }
 
-export function geoJsonPointToScreenPoint<D> (
+export function geoJsonPointToScreenPoint<A, D, L> (
   geoPoint: ClusterFeature<TopoJSONMapClusterDatum<D>> | PointFeature<TopoJSONMapPointDatum<D>>,
   i: number,
   projection: (coordinates: [number, number]) => [number, number],
-  config: TopoJSONMapConfigInterface<unknown, D, unknown>,
+  config: TopoJSONMapConfigInterface<A, D, L>,
   zoomLevel: number
 ): TopoJSONMapPoint<D> {
   const isCluster = (geoPoint.properties as TopoJSONMapClusterDatum<D>).cluster

--- a/packages/ts/src/components/treemap/index.ts
+++ b/packages/ts/src/components/treemap/index.ts
@@ -15,7 +15,6 @@ import { getColor, brighter, getHexValue, isColorDark } from '@/utils/color'
 import { getString, getNumber, isNumber, isFunction } from '@/utils/data'
 import { smartTransition } from '@/utils/d3'
 import { trimSVGText, wrapSVGText } from '@/utils/text'
-import { getCachedFontSizePx } from '@/utils/text-measure'
 import { cssvar } from '@/utils/style'
 
 // Types

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -44,7 +44,7 @@ export type XYConfigInterface<Datum> = XYComponentConfigInterface<Datum>
 
 export class XYContainer<Datum> extends ContainerCore {
   protected _defaultConfig = XYContainerDefaultConfig as XYContainerConfigInterface<Datum>
-  protected _svgDefs: Selection<SVGDefsElement, unknown, null, undefined>
+  protected declare _svgDefs: Selection<SVGDefsElement, unknown, null, undefined>
   public datamodel: CoreDataModel<Datum[]> = new CoreDataModel()
   public config: XYContainerConfigInterface<Datum> = this._defaultConfig
   private _clipPath: Selection<SVGClipPathElement, unknown, null, undefined>

--- a/packages/ts/src/core/xy-component/index.ts
+++ b/packages/ts/src/core/xy-component/index.ts
@@ -18,10 +18,10 @@ export class XYComponentCore<
   Datum,
   ConfigInterface extends Partial<XYComponentConfigInterface<Datum>> = Partial<XYComponentConfigInterface<Datum>>,
 > extends ComponentCore<Datum[], ConfigInterface> {
-  public element: SVGGraphicsElement
-  public g: Selection<SVGGElement, unknown, null, undefined>
-  public config: ConfigInterface
-  public prevConfig: ConfigInterface
+  public declare element: SVGGraphicsElement
+  public declare g: Selection<SVGGElement, unknown, null, undefined>
+  public declare config: ConfigInterface
+  public declare prevConfig: ConfigInterface
   public datamodel: SeriesDataModel<Datum> = new SeriesDataModel()
 
   /** Clippable components can be affected by a clipping path (set up in the container) */

--- a/packages/ts/src/utils/color.ts
+++ b/packages/ts/src/utils/color.ts
@@ -34,7 +34,7 @@ export function getColor<T> (
   // If accessor is a function, call it and return the result
   let value: string | null | undefined
   if (isFunction(accessorOrValue)) {
-    value = accessorOrValue(d, index, key) as (string | null | undefined)
+    value = accessorOrValue(d, index, key as string) as (string | null | undefined)
   } else {
     value = accessorOrValue as string | null | undefined
   }

--- a/packages/ts/vite.config.ts
+++ b/packages/ts/vite.config.ts
@@ -31,7 +31,17 @@ const output: OutputOptions = {
 
 export default defineConfig({
   plugins: [
-    dts({ tsconfigPath: './tsconfig.json', exclude: ['vite.config.ts'] }),
+    dts({
+      tsconfigPath: './tsconfig.json',
+      exclude: ['vite.config.ts'],
+      afterBuild: (emittedFiles) => {
+        // vite-plugin-dts skips entries whose type-check reports diagnostics without failing
+        // the build, which would publish a dist untyped at the package root — fail loudly instead
+        const emitted = [...emittedFiles.keys()].map(f => f.replace(/\\/g, '/'))
+        const missing = ['index.d.ts', 'maps.d.ts'].filter(entry => !emitted.some(f => f.endsWith(`/dist/${entry}`)))
+        if (missing.length) throw new Error(`Declaration entries were not emitted: ${missing.join(', ')}. Check the type errors above.`)
+      },
+    }),
   ],
   resolve: {
     alias: { '@': resolve(__dirname, './src') },


### PR DESCRIPTION
Closes #890

Since the vite migration, `vite-plugin-dts` type-checks the package on every build — something the old rollup setup deliberately skipped (`check: false`, with a TODO acknowledging it). The accumulated diagnostics (~30 across 20 files) can block the plugin from emitting the root entry declarations `dist/index.d.ts` / `dist/maps.d.ts`, and the build exited 0 regardless. This PR clears every diagnostic and makes the build fail loudly if the entries ever go missing again.

- [x] Type fixes across `packages/ts` (compile-time only — no emitted-JS behavior change)
- [x] Build guardrail: `afterBuild` entry check in `vite.config.ts` + fail-fast `&&` chaining in the build scripts

## Why each kind of change is safe

**1. `declare` modifiers on narrowed base-class fields** (`g`, `element`, `config`, `prevConfig`, `_svgDefs` in annotations, graph, leaflet-map, sankey, topojson-map, xy-component, xy-container)
`declare` is erased from the emitted JS entirely — the field only existed to narrow the base class's type, and the base constructor still performs the actual assignment. This is also the *correct* form under `useDefineForClassFields` semantics, where a bare re-declaration would clobber the base's value with `undefined` (the hazard TS2612/TS2729 warn about).

**2. Removed extra `.call()` arguments** (graph `createLinks`/`createPanels`/`zoomLinks`, chord `createNode`/`updateNode`, sankey `removeLinks`, timeline `_renderLines`)
d3's `selection.call(fn, ...args)` forwards the extra args to `fn` — but none of these callees declare parameters for them, and none reads `arguments` or rest params. JavaScript silently discards surplus arguments, so the values were dead on arrival; removing them is a runtime no-op. TS2554 was flagging the call sites, not the functions.

**3. Generic propagation instead of fixed concrete types** (chord `ChordRibbon<N, L>`/`getRibbons`, graph `updatePanels`/`removePanels`, topojson `calculateClusterIndex`/`geoJsonPointToScreenPoint`)
Types only — zero runtime code. The signatures now accept the caller's own generics instead of variance-broken concrete ones, so they *widen* what compiles; every existing valid call still type-checks (all call sites are internal and rely on inference — verified by grep across the monorepo).

**4. Precise d3 generics and boundary casts** (`partition<T>()`, `arc<T>()` anim-state types, `Selection$Transition` for timeline, tuple-typed brush range, `select<SVGSVGElement>`, plus a few one-line `as` casts in axis/tooltip/color/leaflet utils)
Type annotations and casts are erased at compile time. Each cast narrows to what the value already is at runtime (e.g. tooltip's `html` is provably a string after its guards; the legacy `key === true` path in `getColor` never reaches an accessor with a non-string).

**5. TopoJSON map: group creation moved from field initializers into the constructor**
The only real code motion. Field initializers already ran after `super()` (so `this.g` existed) and before the constructor body; they now run at the top of the constructor body in the *same relative order*, so the DOM `append` sequence — which controls paint layering — is unchanged. This matches the existing pattern in graph, chord-diagram, and sankey.

**6. Reordered chained setters** (plotband `.text()` after `.attr()`)
Independent setters on the same element; order between them has no observable effect. The reorder just keeps the chain on a type where `.attr` remains available.

## Guardrail

`vite-plugin-dts` logs diagnostics but doesn't fail the build, and `forcebuild` chained commands with `;` — so a build that skipped the entries still exited 0 (the "nothing flags it" part of #890). Now:
- an `afterBuild` hook throws if `dist/index.d.ts` or `dist/maps.d.ts` wasn't emitted (verified it fires by requiring a bogus entry — build exits 1);
- `forcebuild` chains with `&&` and `build` no longer writes `.srcsha` on failure (so a failed build can't be cached as good).

## Verification

- `npm run forcebuild`: **0 diagnostics**, 252 `.d.ts` files emitted including both entries, exit 0
- `pnpm build:react` and `pnpm build:dev` (CI's checks) pass against the rebuilt core
- ESLint clean on all changed files (remaining warnings confirmed pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)