### PR TITLE
Core: Support CSP nonce via global

### DIFF
--- a/ai/skills/add-component/SKILL.md
+++ b/ai/skills/add-component/SKILL.md
@@ -26,7 +26,9 @@ Create `packages/ts/src/components/<kebab-name>/` (kebab-case dir + files):
   and a `_render(customDuration?)` (or `render`) with clear **enter / update / exit** D3 selections.
 - **`style.ts`** — emotion `css` selectors + a `cssVarDefaults` map. CSS variables are named
   `--vis-<component>-<selector>-<property>`; every color var needs a `--vis-dark-...` counterpart.
-  Export `variables = getCssVarNames(cssVarDefaults)` and call `injectGlobalCssVariables(...)`.
+  Import `css` / `injectGlobal` from `@/styles/emotion` (not `@emotion/css` directly) so styles
+  respect the `globalThis.UNOVIS_NONCE` CSP nonce. Export `variables = getCssVarNames(cssVarDefaults)`
+  and call `injectGlobalCssVariables(...)`.
 - **`types.ts`** — component-specific types (optional).
 - **`modules/`** — extract long render logic into `call`-able helpers (optional).
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "cd packages/dev && pnpm dev",
     "dev:gallery": "pnpm --filter @unovis/shared dev",
+    "dev:gallery:csp": "pnpm --filter @unovis/shared dev:csp",
     "website": "cd packages/website && pnpm start",
     "build": "pnpm build:ts && pnpm build:react && pnpm build:angular && pnpm build:svelte && pnpm build:vue && pnpm build:solid && pnpm build:website",
     "build:ts": "cd packages/ts && pnpm build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,6 +33,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "dev:csp": "UNOVIS_CSP=1 vite",
     "license:check": "pnpm license-report --config=../../lic-report-config.json > licences.md"
   },
   "peerDependencies": {

--- a/packages/shared/vite.config.ts
+++ b/packages/shared/vite.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, transformWithEsbuild } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { resolve, dirname } from 'node:path'
 import { readFile } from 'node:fs/promises'
@@ -26,6 +28,115 @@ const isAngularFile = (id: string): boolean => {
 export default defineConfig({
   root: 'gallery-dev-server',
   plugins: [
+    // Opt-in Content-Security-Policy for verifying the @unovis/ts Emotion nonce
+    // fix end-to-end. Enable with `UNOVIS_CSP=1 pnpm dev:gallery`. Sets a real
+    // response header (browser-enforced, not just a meta tag) and injects a
+    // pre-bundle script that seeds `window.UNOVIS_NONCE` so Emotion's cache
+    // reads it before any `injectGlobal` runs.
+    ...(process.env.UNOVIS_CSP
+      ? [{
+        name: 'unovis-csp-nonce-test',
+        configureServer (server: ViteDevServer) {
+          const nonce = process.env.UNOVIS_CSP_NONCE || 'unovis-dev-nonce'
+          server.middlewares.use((_req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => {
+            res.setHeader(
+              'Content-Security-Policy',
+              [
+                "default-src 'self'",
+                // <script> blocks & module URLs — nonce-gated
+                `script-src-elem 'self' 'nonce-${nonce}'`,
+                // Inline event handlers (onclick="…") — always blocked
+                "script-src-attr 'none'",
+                // Vite dev needs eval; both -elem and -attr inherit from here
+                `script-src 'self' 'nonce-${nonce}' 'unsafe-eval'`,
+                // <style> blocks & external stylesheets — nonce-gated for
+                // inline, plus `https:` so 3rd-party CSS (Google Fonts,
+                // Bootstrap Icons CDN, etc.) still loads.
+                `style-src-elem 'self' 'nonce-${nonce}' https:`,
+                // Inline style="…" attributes — nonces don't cover these (CSP3
+                // limitation), and d3 / leaflet / Vite's error overlay all set
+                // them at runtime. Kept permissive; not what we're verifying.
+                "style-src-attr 'unsafe-inline'",
+                `style-src 'self' 'nonce-${nonce}'`,
+                "img-src 'self' data: blob:",
+                // Unovis loads Font Awesome from cdnjs for graph icons (see
+                // packages/ts/src/core/container/index.ts). Consumers who
+                // self-host fonts can tighten this to `'self' data:`.
+                "font-src 'self' data: https:",
+                "connect-src 'self' ws: wss: http: https:",
+                // ELK.js (elk-layered-graph example) spawns its layout engine
+                // in a Worker created from a `Blob` URL — falls back to
+                // script-src otherwise, which doesn't allow blob:.
+                "worker-src 'self' blob:",
+              ].join('; ')
+            )
+            next()
+          })
+        },
+        // Runs after other plugins (React Refresh preamble, Vite HMR client)
+        // so their injected inline <script>/<style> tags also receive the nonce.
+        transformIndexHtml: {
+          order: 'post' as const,
+          handler (html: string) {
+            const nonce = process.env.UNOVIS_CSP_NONCE || 'unovis-dev-nonce'
+            const addNonce = (tag: 'script' | 'style', input: string): string =>
+              input.replace(
+                new RegExp(`<${tag}(?![^>]*\\snonce=)([^>]*)>`, 'gi'),
+                `<${tag} nonce="${nonce}"$1>`
+              )
+            const withNonces = addNonce('style', addNonce('script', html))
+            // Runtime shim: stamp the nonce onto every <style>/<link> created
+            // via `document.createElement` AND onto any such node inserted via
+            // appendChild/insertBefore (covers Solid's cloneNode template
+            // pattern, Vite HMR CSS updates, Vue's `styleInject`, Angular's
+            // SharedStylesHost, etc.). A MutationObserver would fire too late
+            // — the CSP check runs synchronously during insertion.
+            const bootstrap = `
+              window.UNOVIS_NONCE = ${JSON.stringify(nonce)};
+              (function () {
+                var n = window.UNOVIS_NONCE;
+                if (!n) return;
+                function stamp (node) {
+                  if (!node) return;
+                  if (node.nodeType === 1) {
+                    var tag = node.tagName;
+                    if ((tag === 'STYLE' || tag === 'LINK') && !node.getAttribute('nonce')) {
+                      node.setAttribute('nonce', n);
+                    }
+                  }
+                  if (node.querySelectorAll) {
+                    var list = node.querySelectorAll('style, link');
+                    for (var i = 0; i < list.length; i++) {
+                      if (!list[i].getAttribute('nonce')) list[i].setAttribute('nonce', n);
+                    }
+                  }
+                }
+                var origCreate = document.createElement.bind(document);
+                document.createElement = function (tag, opts) {
+                  var el = origCreate(tag, opts);
+                  var t = String(tag).toLowerCase();
+                  if (t === 'style' || t === 'link') el.setAttribute('nonce', n);
+                  return el;
+                };
+                var origAppend = Node.prototype.appendChild;
+                Node.prototype.appendChild = function (child) { stamp(child); return origAppend.call(this, child); };
+                var origInsert = Node.prototype.insertBefore;
+                Node.prototype.insertBefore = function (child, ref) { stamp(child); return origInsert.call(this, child, ref); };
+              })();
+            `.replace(/\s+/g, ' ').trim()
+            return {
+              html: withNonces,
+              tags: [{
+                tag: 'script',
+                attrs: { nonce },
+                children: bootstrap,
+                injectTo: 'head-prepend' as const,
+              }],
+            }
+          },
+        },
+      } satisfies Plugin]
+      : []),
     // @unovis/ts has ONE `import leafletCSS from './leaflet.css'` (in
     // packages/ts/src/components/leaflet-map/style.ts) that expects the CSS as
     // a string default export — webpack provides this via css-loader; Vite no

--- a/packages/ts/global.d.ts
+++ b/packages/ts/global.d.ts
@@ -18,5 +18,6 @@ declare global {
       marginTop: number;
       marginBottom: number;
     }
+    var UNOVIS_NONCE: string | undefined
   }
 }

--- a/packages/ts/src/components/annotations/style.ts
+++ b/packages/ts/src/components/annotations/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 
 // Utils
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'

--- a/packages/ts/src/components/area/style.ts
+++ b/packages/ts/src/components/area/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 

--- a/packages/ts/src/components/axis/style.ts
+++ b/packages/ts/src/components/axis/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/boxplot/style.ts
+++ b/packages/ts/src/components/boxplot/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/brush/style.ts
+++ b/packages/ts/src/components/brush/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/bullet-legend/style.ts
+++ b/packages/ts/src/components/bullet-legend/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/chord-diagram/style.ts
+++ b/packages/ts/src/components/chord-diagram/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/crosshair/style.ts
+++ b/packages/ts/src/components/crosshair/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/donut/style.ts
+++ b/packages/ts/src/components/donut/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/flow-legend/style.ts
+++ b/packages/ts/src/components/flow-legend/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { UNOVIS_ICON_FONT_FAMILY_DEFAULT } from '@/styles/index'
 import { darkThemeCssSelectors } from '@/utils/theme'
 import { FlowLegendItem } from './types'

--- a/packages/ts/src/components/free-brush/style.ts
+++ b/packages/ts/src/components/free-brush/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/graph/modules/link/style.ts
+++ b/packages/ts/src/components/graph/modules/link/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const links = css`

--- a/packages/ts/src/components/graph/modules/node/style.ts
+++ b/packages/ts/src/components/graph/modules/node/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const nodes = css`

--- a/packages/ts/src/components/graph/modules/panel/style.ts
+++ b/packages/ts/src/components/graph/modules/panel/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const panels = css`

--- a/packages/ts/src/components/graph/style.ts
+++ b/packages/ts/src/components/graph/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { UNOVIS_ICON_FONT_FAMILY_DEFAULT } from '@/styles/index'
 
 // Nodes

--- a/packages/ts/src/components/grouped-bar/style.ts
+++ b/packages/ts/src/components/grouped-bar/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/heatmap/style.ts
+++ b/packages/ts/src/components/heatmap/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/leaflet-map/renderer/mapboxgl-layer.ts
+++ b/packages/ts/src/components/leaflet-map/renderer/mapboxgl-layer.ts
@@ -2,7 +2,7 @@ import type L from 'leaflet'
 import type Maplibre from 'maplibre-gl'
 import type { Map } from 'maplibre-gl'
 
-import { injectGlobal } from '@emotion/css'
+import { injectGlobal } from '@/styles/emotion'
 
 // Utils
 import { isObject } from '@/utils/data'

--- a/packages/ts/src/components/leaflet-map/style.ts
+++ b/packages/ts/src/components/leaflet-map/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 
 // Utils
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'

--- a/packages/ts/src/components/line/style.ts
+++ b/packages/ts/src/components/line/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 
 export const globalStyles = injectGlobal`
   :root {

--- a/packages/ts/src/components/nested-donut/style.ts
+++ b/packages/ts/src/components/nested-donut/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 
 // Utils
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'

--- a/packages/ts/src/components/plotband/style.ts
+++ b/packages/ts/src/components/plotband/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 

--- a/packages/ts/src/components/plotline/style.ts
+++ b/packages/ts/src/components/plotline/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const globalStyles = injectGlobal`

--- a/packages/ts/src/components/radial-bar/style.ts
+++ b/packages/ts/src/components/radial-bar/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/rolling-pin-legend/style.ts
+++ b/packages/ts/src/components/rolling-pin-legend/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const root = css`

--- a/packages/ts/src/components/sankey/style.ts
+++ b/packages/ts/src/components/sankey/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 import { UNOVIS_ICON_FONT_FAMILY_DEFAULT } from '@/styles/index'
 

--- a/packages/ts/src/components/scatter/style.ts
+++ b/packages/ts/src/components/scatter/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 
 export const globalStyles = injectGlobal`
   :root {

--- a/packages/ts/src/components/stacked-bar/style.ts
+++ b/packages/ts/src/components/stacked-bar/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/timeline/style.ts
+++ b/packages/ts/src/components/timeline/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import type { UnovisCssVariablesDefinition } from '@/types/style'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 

--- a/packages/ts/src/components/tooltip/style.ts
+++ b/packages/ts/src/components/tooltip/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { darkThemeCssSelectors } from '@/utils/theme'
 
 export const root = css`

--- a/packages/ts/src/components/topojson-map/style.ts
+++ b/packages/ts/src/components/topojson-map/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'
 
 export const cssVarDefaults = {

--- a/packages/ts/src/components/treemap/style.ts
+++ b/packages/ts/src/components/treemap/style.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 
 // Utils
 import { getCssVarNames, injectGlobalCssVariables } from '@/utils/style'

--- a/packages/ts/src/components/vis-controls/style.ts
+++ b/packages/ts/src/components/vis-controls/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 import { UNOVIS_ICON_FONT_FAMILY_DEFAULT } from '@/styles/index'
 import { darkThemeCssSelectors } from '@/utils/theme'
 

--- a/packages/ts/src/components/xy-labels/style.ts
+++ b/packages/ts/src/components/xy-labels/style.ts
@@ -1,4 +1,4 @@
-import { css, injectGlobal } from '@emotion/css'
+import { css, injectGlobal } from '@/styles/emotion'
 
 export const globalStyles = injectGlobal`
   :root {

--- a/packages/ts/src/containers/xy-container/index.ts
+++ b/packages/ts/src/containers/xy-container/index.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 import { extent, merge as mergeArrays } from 'd3-array'
 import { Selection } from 'd3-selection'
 

--- a/packages/ts/src/styles/emotion.spec.ts
+++ b/packages/ts/src/styles/emotion.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const NONCE = 'test-nonce-abc123'
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const globals = globalThis as { UNOVIS_NONCE?: string }
+
+describe('emotion nonce (jsdom)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    globals.UNOVIS_NONCE = NONCE
+  })
+
+  afterEach(() => {
+    globals.UNOVIS_NONCE = undefined
+    document.head.querySelectorAll('style[data-emotion^="unovis"]').forEach(n => n.remove())
+  })
+
+  it('applies globalThis.UNOVIS_NONCE to injected style tags', async () => {
+    const { injectGlobal } = await import('./emotion')
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    injectGlobal`.__unovis_nonce_test__ { color: red; }`
+
+    const tags = document.head.querySelectorAll<HTMLStyleElement>('style[data-emotion^="unovis"]')
+    expect(tags.length).toBeGreaterThan(0)
+    for (const tag of tags) {
+      expect(tag.getAttribute('nonce')).toBe(NONCE)
+    }
+  })
+
+  it('omits the nonce attribute when UNOVIS_NONCE is unset', async () => {
+    globals.UNOVIS_NONCE = undefined
+    vi.resetModules()
+
+    const { injectGlobal } = await import('./emotion')
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    injectGlobal`.__unovis_nonce_absent__ { color: blue; }`
+
+    const tags = document.head.querySelectorAll<HTMLStyleElement>('style[data-emotion^="unovis"]')
+    expect(tags.length).toBeGreaterThan(0)
+    for (const tag of tags) {
+      expect(tag.hasAttribute('nonce')).toBe(false)
+    }
+  })
+})

--- a/packages/ts/src/styles/emotion.spec.ts
+++ b/packages/ts/src/styles/emotion.spec.ts
@@ -12,7 +12,7 @@ describe('emotion nonce (jsdom)', () => {
 
   afterEach(() => {
     globals.UNOVIS_NONCE = undefined
-    document.head.querySelectorAll('style[data-emotion^="unovis"]').forEach(n => n.remove())
+    document.head.querySelectorAll('style[data-emotion]').forEach(n => n.remove())
   })
 
   it('applies globalThis.UNOVIS_NONCE to injected style tags', async () => {
@@ -27,7 +27,7 @@ describe('emotion nonce (jsdom)', () => {
     }
   })
 
-  it('omits the nonce attribute when UNOVIS_NONCE is unset', async () => {
+  it('falls back to the default css- prefix and omits the nonce attribute when UNOVIS_NONCE is unset', async () => {
     globals.UNOVIS_NONCE = undefined
     vi.resetModules()
 
@@ -35,7 +35,7 @@ describe('emotion nonce (jsdom)', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     injectGlobal`.__unovis_nonce_absent__ { color: blue; }`
 
-    const tags = document.head.querySelectorAll<HTMLStyleElement>('style[data-emotion^="unovis"]')
+    const tags = document.head.querySelectorAll<HTMLStyleElement>('style[data-emotion^="css"]')
     expect(tags.length).toBeGreaterThan(0)
     for (const tag of tags) {
       expect(tag.hasAttribute('nonce')).toBe(false)

--- a/packages/ts/src/styles/emotion.ts
+++ b/packages/ts/src/styles/emotion.ts
@@ -1,15 +1,17 @@
+import * as defaultEmotion from '@emotion/css'
 import createEmotion from '@emotion/css/create-instance'
-import type { Options } from '@emotion/css/create-instance'
 
 export type { CSSInterpolation, CSSObject } from '@emotion/css/create-instance'
 
-const EMOTION_KEY = 'unovis'
-
-const options: Options = {
-  key: EMOTION_KEY,
-  nonce: globalThis?.UNOVIS_NONCE,
-}
-
-const emotion = createEmotion(options)
+// Only spin up a dedicated (differently-keyed) Emotion cache when a CSP nonce
+// is actually configured. Without it, behave exactly like the default
+// `@emotion/css` singleton (same `css-` class prefix) so non-CSP consumers see
+// zero change. A distinct `key` is required once a nonce is used because two
+// Emotion caches sharing a page must not both use the default `css` key
+// (https://emotion.sh/docs/@emotion/cache#key).
+const nonce = globalThis?.UNOVIS_NONCE
+const emotion = nonce
+  ? createEmotion({ key: 'unovis', nonce })
+  : defaultEmotion
 
 export const { css, cx, injectGlobal, keyframes, cache, sheet } = emotion

--- a/packages/ts/src/styles/emotion.ts
+++ b/packages/ts/src/styles/emotion.ts
@@ -1,0 +1,15 @@
+import createEmotion from '@emotion/css/create-instance'
+import type { Options } from '@emotion/css/create-instance'
+
+export type { CSSInterpolation, CSSObject } from '@emotion/css/create-instance'
+
+const EMOTION_KEY = 'unovis'
+
+const options: Options = {
+  key: EMOTION_KEY,
+  nonce: globalThis?.UNOVIS_NONCE,
+}
+
+const emotion = createEmotion(options)
+
+export const { css, cx, injectGlobal, keyframes, cache, sheet } = emotion

--- a/packages/ts/src/styles/index.ts
+++ b/packages/ts/src/styles/index.ts
@@ -1,4 +1,4 @@
-import { injectGlobal } from '@emotion/css'
+import { injectGlobal } from '@/styles/emotion'
 import { getCSSVariableValue } from '@/utils/misc'
 import { darkThemeCssSelectors } from '@/utils/theme'
 import { UNOVIS_PATTERN_INDEX_ATTR } from '@/utils/pattern'

--- a/packages/ts/src/styles/sizes.ts
+++ b/packages/ts/src/styles/sizes.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css'
+import { css } from '@/styles/emotion'
 
 export const styleLargeSize = css`
   label: large-size;

--- a/packages/ts/src/utils/style.ts
+++ b/packages/ts/src/utils/style.ts
@@ -1,4 +1,4 @@
-import { injectGlobal } from '@emotion/css'
+import { injectGlobal } from '@/styles/emotion'
 
 import { kebabCaseToCamel } from '@/utils/text'
 import type { KebabToCamelCase, RemovePrefix } from '@/utils/type'

--- a/packages/website/contributing/guides/adding-a-component.mdx
+++ b/packages/website/contributing/guides/adding-a-component.mdx
@@ -129,7 +129,7 @@ Any CSS variables will also be initialized in this file.
 The general template for a `style.ts` file looks like:
 
 ```ts title=style.ts
-import { css } from '@emotion/css'
+import { css } from '@unovis/ts/styles/emotion'
 import { getCssVarNames, injectGlobalCssVariables } from 'utils/style'
 
 export const root = css`

--- a/packages/website/docs/guides/csp.mdx
+++ b/packages/website/docs/guides/csp.mdx
@@ -23,6 +23,19 @@ strict `style-src` directive those tags are rejected unless they carry either
 nonce. _Unovis_ hands its Emotion cache the nonce you provide, so every one of
 its `<style>` tags satisfies `style-src 'self' 'nonce-<value>'`.
 
+Passing a `nonce` requires _Unovis_ to create its own Emotion cache instance
+rather than relying on the default `@emotion/css` singleton, and Emotion
+requires every cache sharing a page to use a distinct
+[`key`](https://emotion.sh/docs/@emotion/cache#key) — reusing the default
+`css` key risks two caches "fighting" over the same style elements. Because of
+this, when `UNOVIS_NONCE` is set, _Unovis_'s generated class names carry a
+`unovis-` prefix (e.g. `unovis-1a2b3c`) instead of the usual `css-` prefix.
+Consumers who don't set `UNOVIS_NONCE` are unaffected — _Unovis_ keeps using
+the default `@emotion/css` singleton and its `css-` prefix. Either way, this
+only affects the auto-generated, content-hashed class names Emotion assigns
+internally — the supported styling API (the `--vis-*` CSS custom properties
+documented in [Theming](./theming.mdx)) is unaffected.
+
 ## Quick start — set `UNOVIS_NONCE`
 
 Set `window.UNOVIS_NONCE` to the value your server issued for the current

--- a/packages/website/docs/guides/csp.mdx
+++ b/packages/website/docs/guides/csp.mdx
@@ -1,0 +1,362 @@
+---
+description: Use Unovis under a strict Content-Security-Policy
+---
+
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+import CodeBlock from '@theme/CodeBlock'
+
+# Content Security Policy (CSP)
+
+_Unovis_ supports strict CSP setups that require a per-request `nonce` on every
+injected `<style>` and `<script>` element. Integration is opt-in and consists of
+one line — assigning `window.UNOVIS_NONCE` **before** the library is imported.
+Consumers who don't use CSP need to do nothing; the library remains fully
+backward-compatible.
+
+## Why a nonce?
+
+Every _Unovis_ component ships its styles via [Emotion](https://emotion.sh),
+which injects `<style>` elements into `document.head` at runtime. Under a
+strict `style-src` directive those tags are rejected unless they carry either
+`'unsafe-inline'` (defeats the point of CSP), a matching hash, or the request's
+nonce. _Unovis_ hands its Emotion cache the nonce you provide, so every one of
+its `<style>` tags satisfies `style-src 'self' 'nonce-<value>'`.
+
+## Quick start — set `UNOVIS_NONCE`
+
+Set `window.UNOVIS_NONCE` to the value your server issued for the current
+request, **before** any `@unovis/*` module is evaluated. The safest place is an
+inline `<script>` at the very top of `<head>` — same nonce as the CSP header:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <script nonce="<SERVER_NONCE>">window.UNOVIS_NONCE = "<SERVER_NONCE>"</script>
+    <!-- your framework bundle imports @unovis/* below this line -->
+    <script nonce="<SERVER_NONCE>" type="module" src="/app.js"></script>
+  </head>
+  <body>...</body>
+</html>
+```
+
+That's it. Every `<style>` Emotion injects for _Unovis_ will now carry
+`nonce="<SERVER_NONCE>"` and be accepted by the browser.
+
+:::info Timing matters
+The nonce is captured once, when the `@unovis/ts` Emotion module first
+evaluates. Setting `window.UNOVIS_NONCE` **after** the library has loaded has no
+effect on the styles it has already injected.
+:::
+
+## Recommended CSP header
+
+A minimum-friction, nonce-based policy that works with every _Unovis_ chart
+looks like this:
+
+```
+Content-Security-Policy:
+  default-src 'self';
+  script-src-elem 'self' 'nonce-<SERVER_NONCE>';
+  script-src-attr 'none';
+  style-src-elem 'self' 'nonce-<SERVER_NONCE>';
+  style-src-attr 'unsafe-inline';
+  img-src 'self' data: blob:;
+  font-src 'self' data: https:;
+  connect-src 'self' https:;
+  worker-src 'self' blob:;
+```
+
+Notes on each directive:
+
+- **`script-src-elem 'nonce-…'`** — enforces the nonce on `<script>` blocks and
+  external `src` scripts.
+- **`script-src-attr 'none'`** — blocks inline event-handler attributes like
+  `onclick="…"`; _Unovis_ never emits any.
+- **`style-src-elem 'nonce-…'`** — enforces the nonce on `<style>` blocks and
+  `<link rel="stylesheet">` elements. This is the one that protects _Unovis_'s
+  Emotion output.
+- **`style-src-attr 'unsafe-inline'`** — **required**. Nonces cannot cover
+  inline `style="…"` attributes ([CSP3 limitation](https://www.w3.org/TR/CSP3/#directive-style-src-attr)),
+  and `d3-selection`, Leaflet, and other DOM libraries _Unovis_ depends on set
+  them on every update. There is no way around this short of a per-page hash
+  allowlist that changes with every data update.
+- **`img-src 'self' data: blob:`** — allows tile images, generated SVG
+  thumbnails, and inline data URIs.
+- **`font-src 'self' data: https:`** — only required if you use graph node
+  icons; _Unovis_ loads Font Awesome from `cdnjs.cloudflare.com` for the
+  built-in icon set. Self-host the font to tighten this to `'self' data:`.
+- **`worker-src 'self' blob:`** — only required if you render the
+  [ELK-layered graph](../components/Graph), which spawns a Web Worker
+  from a `Blob` URL.
+
+## Framework integration
+
+Below are copy-paste snippets for wiring the nonce into each supported
+framework. The pattern is always the same:
+
+1. Have your server emit a nonce per request and echo it into both the
+   `Content-Security-Policy` header and every `<script nonce>` / `<style nonce>`
+   tag it renders.
+2. Set `window.UNOVIS_NONCE` in an inline nonced `<script>` before your app
+   bundle loads.
+
+<Tabs groupId="framework">
+
+<TabItem value="react" label="React">
+
+**Vite / plain HTML entry** — edit `index.html`:
+
+```html
+<script nonce="<%= nonce %>">window.UNOVIS_NONCE = "<%= nonce %>"</script>
+<script nonce="<%= nonce %>" type="module" src="/src/main.tsx"></script>
+```
+
+**Next.js App Router** — set the nonce in `middleware.ts`, then read it in the
+root layout:
+
+```ts
+// middleware.ts
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware (req: NextRequest): NextResponse {
+  const nonce = crypto.randomUUID().replace(/-/g, '')
+  const csp = [
+    "default-src 'self'",
+    `script-src-elem 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    `style-src-elem 'self' 'nonce-${nonce}'`,
+    "style-src-attr 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data: https:",
+  ].join('; ')
+  const res = NextResponse.next({ request: { headers: new Headers({ ...req.headers, 'x-nonce': nonce }) } })
+  res.headers.set('content-security-policy', csp)
+  return res
+}
+```
+
+```tsx
+// app/layout.tsx
+import { headers } from 'next/headers'
+import Script from 'next/script'
+
+export default function RootLayout ({ children }: { children: React.ReactNode }) {
+  const nonce = headers().get('x-nonce') ?? ''
+  return (
+    <html>
+      <head>
+        <Script id="unovis-nonce" nonce={nonce} strategy="beforeInteractive">
+          {`window.UNOVIS_NONCE = ${JSON.stringify(nonce)}`}
+        </Script>
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+</TabItem>
+
+<TabItem value="angular" label="Angular">
+
+Angular has its own `SharedStylesHost` for component styles. Provide **both**
+Angular's built-in [`CSP_NONCE`](https://angular.dev/api/core/CSP_NONCE) token
+_and_ `window.UNOVIS_NONCE`:
+
+```ts
+// main.ts
+import { bootstrapApplication, CSP_NONCE } from '@angular/core'
+import { AppComponent } from './app/app.component'
+
+// The nonce is emitted by your server; e.g. read it from a <meta> tag or a
+// window-level variable set inline in index.html.
+const nonce = document.querySelector<HTMLMetaElement>('meta[name="csp-nonce"]')?.content ?? ''
+;(window as any).UNOVIS_NONCE = nonce
+
+bootstrapApplication(AppComponent, {
+  providers: [{ provide: CSP_NONCE, useValue: nonce }],
+})
+```
+
+```html
+<!-- index.html -->
+<meta name="csp-nonce" content="<%= nonce %>" />
+<script nonce="<%= nonce %>">window.UNOVIS_NONCE = document.querySelector('meta[name="csp-nonce"]').content</script>
+```
+
+</TabItem>
+
+<TabItem value="svelte" label="Svelte / SvelteKit">
+
+**SvelteKit** — set the CSP header and inject the seed via `handle` in
+`hooks.server.ts`:
+
+```ts
+// hooks.server.ts
+import type { Handle } from '@sveltejs/kit'
+import { randomBytes } from 'node:crypto'
+
+export const handle: Handle = async ({ event, resolve }) => {
+  const nonce = randomBytes(16).toString('base64url')
+
+  return resolve(event, {
+    transformPageChunk: ({ html }) =>
+      html
+        .replace('%unovis.nonce%', nonce)
+        .replace(
+          '<head>',
+          `<head><script nonce="${nonce}">window.UNOVIS_NONCE = ${JSON.stringify(nonce)}</script>`
+        ),
+  })
+}
+```
+
+```html
+<!-- src/app.html — SvelteKit inserts nonces on framework scripts via csp config -->
+<!doctype html>
+<html>
+  <head>
+    <meta name="csp-nonce" content="%unovis.nonce%" />
+    %sveltekit.head%
+  </head>
+  <body>
+    <div>%sveltekit.body%</div>
+  </body>
+</html>
+```
+
+Set the CSP directives via SvelteKit's [`csp` config](https://kit.svelte.dev/docs/configuration#csp)
+in `svelte.config.js`.
+
+</TabItem>
+
+<TabItem value="vue" label="Vue">
+
+**Vite + `vue-router`** — same pattern as React. Set `window.UNOVIS_NONCE` in
+`index.html`:
+
+```html
+<script nonce="<%= nonce %>">window.UNOVIS_NONCE = "<%= nonce %>"</script>
+<script nonce="<%= nonce %>" type="module" src="/src/main.ts"></script>
+```
+
+**Nuxt 3** — use a server middleware to set the header, then a plugin to seed:
+
+```ts
+// server/middleware/csp.ts
+export default defineEventHandler(event => {
+  const nonce = crypto.randomUUID().replace(/-/g, '')
+  event.context.nonce = nonce
+  setResponseHeader(event, 'Content-Security-Policy',
+    `default-src 'self'; script-src-elem 'self' 'nonce-${nonce}'; style-src-elem 'self' 'nonce-${nonce}'; style-src-attr 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data: https:`
+  )
+})
+```
+
+```ts
+// plugins/unovis-nonce.server.ts
+export default defineNuxtPlugin(nuxt => {
+  const nonce = useRequestEvent()?.context.nonce
+  useHead({
+    script: [{ innerHTML: `window.UNOVIS_NONCE = ${JSON.stringify(nonce)}`, tagPriority: 'critical', nonce }],
+  })
+})
+```
+
+</TabItem>
+
+<TabItem value="solid" label="Solid">
+
+**SolidStart** — set the CSP header via a request handler and seed the nonce
+in `entry-server.tsx`:
+
+```tsx
+// src/entry-server.tsx
+import { createHandler, StartServer } from '@solidjs/start/server'
+import { randomBytes } from 'node:crypto'
+
+export default createHandler(() => {
+  const nonce = randomBytes(16).toString('base64url')
+  return (
+    <StartServer
+      document={({ assets, children, scripts }) => (
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <script nonce={nonce}>{`window.UNOVIS_NONCE = ${JSON.stringify(nonce)}`}</script>
+            {assets}
+          </head>
+          <body>
+            <div id="app">{children}</div>
+            {scripts}
+          </body>
+        </html>
+      )}
+    />
+  )
+})
+```
+
+</TabItem>
+
+<TabItem value="ts" label="Vanilla TypeScript">
+
+Any static HTML page works — just make sure the seed script runs before the
+bundle that imports `@unovis/ts`:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <script nonce="<%= nonce %>">window.UNOVIS_NONCE = "<%= nonce %>"</script>
+    <script nonce="<%= nonce %>" type="module" src="/app.js"></script>
+  </head>
+  <body><div id="chart"></div></body>
+</html>
+```
+
+```ts
+// app.ts
+import { Line, XYContainer } from '@unovis/ts'
+
+const container = new XYContainer(document.getElementById('chart')!, {
+  components: [new Line({ x: d => d.x, y: d => d.y })],
+  data: [/* … */],
+})
+```
+
+</TabItem>
+
+</Tabs>
+
+## Known limitations
+
+- **Inline `style="…"` attributes** — CSP3 nonces do not apply to element
+  `style` attributes. Because `d3-selection` sets them on every update
+  (`selection.style('fill', '#fff')`), a strict `style-src-attr` breaks every
+  chart. Use `style-src-attr 'unsafe-inline'` (or a per-page hash allowlist if
+  you must — impractical for data-driven charts).
+- **External stylesheets** — `<link rel="stylesheet">` from third-party origins
+  (e.g. Google Fonts, Bootstrap Icons CDN) cannot carry your server's nonce.
+  Either self-host, add the origin to `style-src-elem`, or allow `https:`.
+- **Web Workers from `Blob` URLs** — the ELK-layered graph uses one. Add
+  `worker-src 'self' blob:` if you render that component.
+- **Runtime style injection by other libraries** — the nonce is only applied to
+  _Unovis_'s own Emotion output. If you use Angular, MUI, Vuetify, Chakra, etc.
+  in the same app, follow each library's own nonce-integration guide.
+
+## Verifying locally
+
+The multi-framework gallery playground doubles as a CSP verification harness.
+From the repo root:
+
+```bash
+UNOVIS_CSP_NONCE=devnonce123 pnpm dev:gallery:csp
+```
+
+Then open [http://localhost:9600](http://localhost:9600) and inspect the
+_Network_ tab — the response `Content-Security-Policy` header will show the
+strict policy, and every example (React, Vue, Solid, Svelte, TypeScript,
+Angular) should render with an empty DevTools console.

--- a/packages/website/licences.md
+++ b/packages/website/licences.md
@@ -3,6 +3,7 @@
 | @docsearch/core                           | perpetual      | MIT          | 4.6.0             | Algolia, Inc. https://www.algolia.com                    |
 | @docsearch/react                          | perpetual      | MIT          | 4.6.0             | Algolia, Inc. https://www.algolia.com                    |
 | @docusaurus/core                          | perpetual      | MIT          | 3.9.2             | n/a                                                      |
+| @docusaurus/plugin-client-redirects       | perpetual      | MIT          | 3.9.2             | n/a                                                      |
 | @docusaurus/plugin-debug                  | perpetual      | MIT          | 3.9.2             | n/a                                                      |
 | @docusaurus/plugin-sitemap                | perpetual      | MIT          | 3.9.2             | n/a                                                      |
 | @docusaurus/preset-classic                | perpetual      | MIT          | 3.9.2             | n/a                                                      |

--- a/scripts/commands-report.js
+++ b/scripts/commands-report.js
@@ -75,7 +75,7 @@ const ROOT_SKIP_STARTS = ['build'] // 'build' and 'build:*'
 
 // Workspace: publish & gallery variants are out. Long-running servers,
 // interactive / destructive tooling, and generator pass-throughs too.
-const WS_SKIP_CONTAINS = ['publish', 'gallery']
+const WS_SKIP_CONTAINS = ['publish', 'gallery', 'csp']
 const WS_SKIP_EXACT = new Set([
   'dev',
   'serve',


### PR DESCRIPTION
<!--
  Thanks for contributing to Unovis!
  • Commit messages follow our format: `Type | Scope: Sentence-case subject`
    → https://unovis.dev/contributing/pull-requests#commit-messages
  • First-time contributors: the F5 CLA bot will ask you to sign the CLA.
  • Using an AI coding agent (Claude Code, Codex, Cursor)? See AGENTS.md at the repo root.
-->

## What & why
This MR introduces opt-in Content Security Policy (CSP) nonce support for Unovis. Because every Unovis component injects <style> elements into document.head via Emotion, those tags are rejected by a strict style-src CSP directive unless they carry a nonce. The change consists of three logical commits:

Core — A new @/styles/emotion wrapper module (packages/ts/src/styles/emotion.ts) creates a named Emotion instance using @emotion/css/create-instance, reading globalThis.UNOVIS_NONCE at module evaluation time and forwarding it as the Emotion cache's nonce. 

Shared / Gallery — A Vite plugin added to packages/shared/vite.config.ts enables an end-to-end CSP verification harness (activated by UNOVIS_CSP=1). It sets a real Content-Security-Policy response header, adds nonces to every <script>/<style> tag in the HTML transform, and injects a bootstrap script that stamps the nonce onto dynamically created elements via document.createElement and Node.prototype monkey-patching.

Website — A new csp.mdx guide covers the Quick Start, the recommended CSP header, per-framework integration snippets (React/Next.js, Angular, SvelteKit, Vue/Nuxt, SolidStart, vanilla TS), known limitations, and local verification instructions.

## Checklist

<!-- Tick what applies; delete what doesn't. A new component usually touches all four. -->

- [ ] Dev examples
- [ ] Dev gallery examples (`pnpm dev:gallery`)
- [ ] Wrappers (regenerated via `pnpm generate`)
- [ ] Gallery example
- [ ] Docs
- [ ] Lint passes on the files I changed
- [ ] Builds locally (`pnpm build`)
- [ ] All commands pass (`pnpm cmds-report`)

## Screenshots / recordings

<img width="1433" height="103" alt="image" src="https://github.com/user-attachments/assets/912604ce-e870-422e-a577-0b6b71fab19b" />

