### PR TITLE
Angular | Fix: Package.json main, module, typings paths for ng-packagr 20 output

### DIFF
--- a/packages/angular/gallery/tsconfig.app.json
+++ b/packages/angular/gallery/tsconfig.app.json
@@ -22,7 +22,7 @@
     "noUnusedLocals": true,
     "importHelpers": true,
     "typeRoots": [
-        "node_modules/@types"
+        "../node_modules/@types"
     ],
     "lib": [
         "ES2019",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -34,9 +34,9 @@
     "gallery": "node gallery",
     "license:check": "pnpm license-report --config=../../lic-report-config.json > licences.md"
   },
-  "main": "dist/lib/bundles/unovis-angular.umd.js",
-  "module": "dist/lib/fesm2015/unovis-angular.mjs",
-  "typings": "dist/lib/public-api.d.ts",
+  "main": "dist/lib/fesm2022/unovis-angular.mjs",
+  "module": "dist/lib/fesm2022/unovis-angular.mjs",
+  "typings": "dist/lib/index.d.ts",
   "type": "module",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
In this pr, the path was not updated. 1.6.7 (our latest version is not impacted)
When installing the latest patch, got path error for unovis/angular. 
Traced back to this:
https://github.com/f5/unovis/pull/704/changes#diff-d08139eef05218816a5597154199c170727c5bcd22546a9e6367735e6b223fb0R37-R39