### PR TITLE
StackedBar: Transition fixes and new `barStyle` accessor

### DIFF
--- a/packages/angular/src/components/stacked-bar/stacked-bar.component.ts
+++ b/packages/angular/src/components/stacked-bar/stacked-bar.component.ts
@@ -11,6 +11,7 @@ import {
   ContinuousScale,
   GenericAccessor,
   FillPatternType,
+  StyleDeclaration,
   StringAccessor,
   Orientation,
 } from '@unovis/ts'
@@ -110,6 +111,13 @@ export class VisStackedBarComponent<Datum> implements StackedBarConfigInterface<
   /** Bar fill pattern accessor. Resolves to a `FillPatternType`. Default: `undefined` */
   @Input() pattern?: GenericAccessor<FillPatternType, Datum>
 
+  /** Per-bar inline styles accessor, called with the datum and its stack index. The returned
+   * object is applied as inline styles, with camelCase keys converted to kebab-case.
+   * Keys the component manages itself (`fill`, `opacity`, `cursor`, `mask`) take precedence over
+   * their defaults (e.g. the `color` accessor) and stay animated; all other keys are applied
+   * instantly. Keys no longer returned are cleaned up on the next render. Default: `undefined` */
+  @Input() barStyle?: GenericAccessor<StyleDeclaration, Datum>
+
   /** The value each bar's stack starts from, instead of zero. Number or accessor function.
    * Useful for floating bars and waterfall charts, where every bar starts where the previous one ended.
    * Default: `undefined` */
@@ -166,8 +174,8 @@ export class VisStackedBarComponent<Datum> implements StackedBarConfigInterface<
   }
 
   private getConfig (): StackedBarConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, baseline, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor, barMinHeight1Px, barMinHeightZeroValue, orientation } = this
-    const config = { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, baseline, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor, barMinHeight1Px, barMinHeightZeroValue, orientation }
+    const { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, barStyle, baseline, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor, barMinHeight1Px, barMinHeightZeroValue, orientation } = this
+    const config = { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, barStyle, baseline, barWidth, barMaxWidth, dataStep, barPadding, roundedCorners, cursor, barMinHeight1Px, barMinHeightZeroValue, orientation }
     const keys = Object.keys(config) as (keyof StackedBarConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
+++ b/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
@@ -22,7 +22,7 @@ const datasets: Rec[][] = [
 export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
   const [index, setIndex] = useState(0)
   const [running, setRunning] = useState<number | false>(false)
-  const intervalRef = useRef<ReturnType<typeof setInterval>>()
+  const intervalRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined)
 
   useEffect(() => {
     if (running) intervalRef.current = setInterval(() => setIndex(i => i + 1), running)
@@ -49,6 +49,9 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
           y={[d => d.y, d => d.y1]}
           id={d => String(d.x)}
           dataStep={1}
+          barStyle={(d, i) => (i === 1 && d.y1 < 0
+            ? { strokeDasharray: '4 3', stroke: 'var(--vis-color1)', strokeWidth: 1, fillOpacity: 0.25 }
+            : undefined)}
           duration={props.duration ?? 1000}
         />
         <VisAxis type='x' duration={props.duration ?? 1000}/>

--- a/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
+++ b/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
@@ -4,8 +4,8 @@ import { VisXYContainer, VisStackedBar, VisAxis } from '@unovis/react'
 
 import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
 
-export const title = 'Exit Transition Stress Test'
-export const subTitle = 'Rapid data updates'
+export const title = 'Enter & Exit Transitions'
+export const subTitle = 'Rapid data updates, negative stacks'
 
 type Rec = { x: number; y: number; y1: number }
 
@@ -15,6 +15,7 @@ const datasets: Rec[][] = [
   [1, 3, 5, 7].map(x => ({ x, y: 4, y1: x })),
   [4].map(x => ({ x, y: 8, y1: 1 })),
   [],
+  [1, 3, 4, 6].map(x => ({ x, y: 4 + x, y1: -3 - (x % 3) })),
   [1, 2, 6, 7].map(x => ({ x, y: 6, y1: 2 })),
 ]
 
@@ -47,6 +48,7 @@ export const component = (props: ExampleViewerDurationProps): React.ReactNode =>
           x={d => d.x}
           y={[d => d.y, d => d.y1]}
           id={d => String(d.x)}
+          dataStep={1}
           duration={props.duration ?? 1000}
         />
         <VisAxis type='x' duration={props.duration ?? 1000}/>

--- a/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
+++ b/packages/dev/src/examples/xy-components/stacked-bar/exit-transition-repro/index.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
+import { VisXYContainer, VisStackedBar, VisAxis } from '@unovis/react'
+
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Exit Transition Stress Test'
+export const subTitle = 'Rapid data updates'
+
+type Rec = { x: number; y: number; y1: number }
+
+const datasets: Rec[][] = [
+  [1, 2, 3, 4, 5].map(x => ({ x, y: 5 + x, y1: 3 })),
+  [2, 4, 6].map(x => ({ x, y: 10 - x, y1: 2 })),
+  [1, 3, 5, 7].map(x => ({ x, y: 4, y1: x })),
+  [4].map(x => ({ x, y: 8, y1: 1 })),
+  [],
+  [1, 2, 6, 7].map(x => ({ x, y: 6, y1: 2 })),
+]
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [index, setIndex] = useState(0)
+  const [running, setRunning] = useState<number | false>(false)
+  const intervalRef = useRef<ReturnType<typeof setInterval>>()
+
+  useEffect(() => {
+    if (running) intervalRef.current = setInterval(() => setIndex(i => i + 1), running)
+    else clearInterval(intervalRef.current)
+    return () => clearInterval(intervalRef.current)
+  }, [running])
+
+  const next = useCallback(() => setIndex(i => i + 1), [])
+  const doubleUpdate = useCallback(() => {
+    flushSync(() => setIndex(i => i + 1))
+    flushSync(() => setIndex(i => i + 1))
+  }, [])
+
+  return (
+    <div>
+      <button onClick={next}>Next dataset</button>
+      <button onClick={doubleUpdate}>Double update</button>
+      <button onClick={() => setRunning(r => (r ? false : 350))}>{running ? 'Stop' : 'Auto-cycle'}</button>
+      <button onClick={() => setRunning(r => (r ? false : 16))}>Auto-fast</button>
+      <span style={{ marginLeft: 10 }}>dataset: {index % datasets.length}</span>
+      <VisXYContainer<Rec> data={datasets[index % datasets.length]} height={300} xDomain={[0, 8]}>
+        <VisStackedBar<Rec>
+          x={d => d.x}
+          y={[d => d.y, d => d.y1]}
+          id={d => String(d.x)}
+          duration={props.duration ?? 1000}
+        />
+        <VisAxis type='x' duration={props.duration ?? 1000}/>
+        <VisAxis type='y' duration={props.duration ?? 1000}/>
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/dev/src/examples/xy-components/stacked-bar/per-bar-styles/index.tsx
+++ b/packages/dev/src/examples/xy-components/stacked-bar/per-bar-styles/index.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo, useState } from 'react'
+import { VisXYContainer, VisStackedBar, VisAxis } from '@unovis/react'
+
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Per-Bar Styles'
+export const subTitle = 'Custom styles via `barStyle`'
+
+type Rec = { x: number; y: number; y1: number }
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [currentMonth, setCurrentMonth] = useState(6)
+  const data = useMemo<Rec[]>(() => Array.from({ length: 12 }, (_, i) => ({
+    x: i + 1,
+    y: 6 + 4 * Math.sin(i / 2) + (i % 3),
+    y1: 2 + (i % 4),
+  })), [])
+
+  // Bars after the current month are projections: dashed outline, translucent fill
+  const projectedStyle = {
+    strokeDasharray: '4 3',
+    strokeWidth: 1,
+    fillOpacity: 0.2,
+  }
+
+  return (
+    <div>
+      <button onClick={() => setCurrentMonth(m => Math.max(1, m - 1))}>−1 month</button>
+      <button onClick={() => setCurrentMonth(m => Math.min(12, m + 1))}>+1 month</button>
+      <span style={{ marginLeft: 10 }}>current month: {currentMonth}</span>
+      <VisXYContainer<Rec> data={data} height={300}>
+        <VisStackedBar<Rec>
+          x={d => d.x}
+          y={[d => d.y, d => d.y1]}
+          id={d => String(d.x)}
+          dataStep={1}
+          barStyle={(d, i) => (d.x > currentMonth
+            ? { ...projectedStyle, stroke: `var(--vis-color${i})` }
+            : undefined)}
+          duration={props.duration}
+        />
+        <VisAxis type='x' numTicks={12} duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@emotion/css": "^11.7.1",
     "@juggle/resize-observer": "^3.3.1",
+    "csstype": "^3.2.3",
     "d3-array": "~3",
     "d3-shape": "~3",
     "d3-hierarchy": "~3",

--- a/packages/ts/src/components/stacked-bar/config.ts
+++ b/packages/ts/src/components/stacked-bar/config.ts
@@ -4,12 +4,19 @@ import { XYComponentConfigInterface, XYComponentDefaultConfig } from '@/core/xy-
 import { ColorAccessor, GenericAccessor, NumericAccessor, StringAccessor } from '@/types/accessor'
 import { FillPatternType } from '@/styles/patterns'
 import { Orientation } from '@/types/position'
+import { StyleDeclaration } from '@/types/style'
 
 export interface StackedBarConfigInterface<Datum> extends XYComponentConfigInterface<Datum> {
   /** Bar color accessor function. Default: `d => d.color` */
   color?: ColorAccessor<Datum>;
   /** Bar fill pattern accessor. Resolves to a `FillPatternType`. Default: `undefined` */
   pattern?: GenericAccessor<FillPatternType, Datum>;
+  /** Per-bar inline styles accessor, called with the datum and its stack index. The returned
+   * object is applied as inline styles, with camelCase keys converted to kebab-case.
+   * Keys the component manages itself (`fill`, `opacity`, `cursor`, `mask`) take precedence over
+   * their defaults (e.g. the `color` accessor) and stay animated; all other keys are applied
+   * instantly. Keys no longer returned are cleaned up on the next render. Default: `undefined` */
+  barStyle?: GenericAccessor<StyleDeclaration, Datum>;
   /** The value each bar's stack starts from, instead of zero. Number or accessor function.
    * Useful for floating bars and waterfall charts, where every bar starts where the previous one ended.
    * Default: `undefined` */
@@ -42,6 +49,7 @@ export const StackedBarDefaultConfig: StackedBarConfigInterface<unknown> = {
   ...XYComponentDefaultConfig,
   color: undefined,
   pattern: undefined,
+  barStyle: undefined,
   baseline: undefined,
   barMaxWidth: undefined,
   barWidth: undefined,

--- a/packages/ts/src/components/stacked-bar/constants.ts
+++ b/packages/ts/src/components/stacked-bar/constants.ts
@@ -1,0 +1,4 @@
+// Style properties the component sets itself during render (and animates via transitions).
+// `barStyle` values for these keys are merged into those transitions as target values instead
+// of being applied as instant inline styles, so they don't get stomped by the next render.
+export const MANAGED_BAR_STYLES = new Set(['fill', 'opacity', 'cursor', 'mask'])

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -4,9 +4,20 @@ import { min, max } from 'd3-array'
 import { XYComponentCore } from '@/core/xy-component'
 
 // Utils
-import { isNumber, isArray, isEmpty, clamp, getStackedExtentWithBaseline, getString, getNumber, getStackedData, getExtent } from '@/utils/data'
+import {
+  isNumber,
+  isArray,
+  isEmpty,
+  clamp,
+  getStackedExtentWithBaseline,
+  getString,
+  getNumber,
+  getValue,
+  getStackedData,
+  getExtent,
+} from '@/utils/data'
 import { roundedRectPath } from '@/utils/path'
-import { smartTransition } from '@/utils/d3'
+import { smartTransition, applyInlineStyles } from '@/utils/d3'
 import { getColor } from '@/utils/color'
 import { getPattern, getFillPatternValue, UNOVIS_PATTERN_INDEX_ATTR } from '@/utils/pattern'
 
@@ -15,12 +26,16 @@ import { ContinuousScale } from '@/types/scale'
 import { NumericAccessor } from '@/types/accessor'
 import { Spacing } from '@/types/spacing'
 import { Orientation } from '@/types/position'
+import { StyleDeclaration } from '@/types/style'
 
 // Local Types
 import { StackedBarDataRecord } from './types'
 
 // Config
 import { StackedBarDefaultConfig, StackedBarConfigInterface } from './config'
+
+// Constants
+import { MANAGED_BAR_STYLES } from './constants'
 
 // Styles
 import * as s from './style'
@@ -177,18 +192,23 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
       .attr('class', s.bar)
       .attr('d', d => this._getBarPath(d, true))
       .attr(UNOVIS_PATTERN_INDEX_ATTR, d => d.stackIndex)
-      .style('fill', d => getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
-      .style('mask', d => getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
+      .style('fill', d => this._getBarStyle(d)?.fill ?? getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
+      .style('mask', d => this._getBarStyle(d)?.mask ?? getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
 
     const barsMerged = barsEnter.merge(bars)
 
-    barsMerged.style('mask', d => getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
+    barsMerged.style('mask', d => this._getBarStyle(d)?.mask ?? getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
+
+    // Custom per-bar styles; the managed keys are merged into the transitions below instead,
+    // so they keep animating and don't get stomped by the next render
+    applyInlineStyles(barsMerged, d => this._getBarStyle(d), MANAGED_BAR_STYLES)
+
     smartTransition(barsMerged, duration)
       .attr('d', d => this._getBarPath(d))
       // A re-entering bar can be mid exit fade; bring it back instead of leaving it semi-transparent
-      .style('opacity', 1)
-      .style('fill', d => getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
-      .style('cursor', d => getString(d.datum, config.cursor, d.stackIndex))
+      .style('opacity', d => this._getBarStyle(d)?.opacity ?? 1)
+      .style('fill', d => this._getBarStyle(d)?.fill ?? getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
+      .style('cursor', d => this._getBarStyle(d)?.cursor ?? getString(d.datum, config.cursor, d.stackIndex))
 
     // No `interrupt` removal here: an interrupted exit means the next data join has re-adopted the node
     // (it keeps the `bar` class), so it either re-enters the update selection or exits and fades again.
@@ -245,6 +265,10 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     })
 
     return filtered
+  }
+
+  private _getBarStyle (d: StackedBarDataRecord<Datum>): StyleDeclaration | null | undefined {
+    return getValue<Datum, StyleDeclaration>(d.datum, this.config.barStyle, d.stackIndex)
   }
 
   _getBarPath (d: StackedBarDataRecord<Datum>, isEntering = false): string {

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -185,15 +185,17 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     barsMerged.style('mask', d => getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
     smartTransition(barsMerged, duration)
       .attr('d', d => this._getBarPath(d))
+      // A re-entering bar can be mid exit fade; bring it back instead of leaving it semi-transparent
+      .style('opacity', 1)
       .style('fill', d => getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
       .style('cursor', d => getString(d.datum, config.cursor, d.stackIndex))
 
+    // No `interrupt` removal here: an interrupted exit means the next data join has re-adopted the node
+    // (it keeps the `bar` class), so it either re-enters the update selection or exits and fades again.
+    // Removing it on `interrupt` would delete bars that legitimately re-entered on a rapid re-render.
     smartTransition(bars.exit(), duration)
       .style('opacity', 0)
       .remove()
-      // `transition.remove()` only fires on `end`; if the transition is interrupted by a re-render,
-      // the node would linger in the DOM with opacity < 1 and could be picked up by the next data join.
-      .on('interrupt', function () { this.remove() })
   }
 
   _getBarWidth (): number {

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -188,9 +188,10 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
         d => d.stackIndex // Key function for proper transitions
       )
 
+    const enteringGroupNodes = new Set(barGroupsEnter.nodes())
     const barsEnter = bars.enter().append('path')
       .attr('class', s.bar)
-      .attr('d', d => this._getBarPath(d, true))
+      .attr('d', (d, i, els) => this._getBarPath(d, true, enteringGroupNodes.has(els[i].parentNode as SVGGElement)))
       .attr(UNOVIS_PATTERN_INDEX_ATTR, d => d.stackIndex)
       .style('fill', d => this._getBarStyle(d)?.fill ?? getColor(d.datum, config.color, d.stackIndex, config.colorKeys?.[d.stackIndex], colorOptions))
       .style('mask', d => this._getBarStyle(d)?.mask ?? getFillPatternValue(getPattern(d.datum, config.pattern, d.stackIndex)))
@@ -271,7 +272,7 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     return getValue<Datum, StyleDeclaration>(d.datum, this.config.barStyle, d.stackIndex)
   }
 
-  _getBarPath (d: StackedBarDataRecord<Datum>, isEntering = false): string {
+  _getBarPath (d: StackedBarDataRecord<Datum>, isEntering = false, isNewGroup = true): string {
     const { config } = this
     const yAccessors = this.getAccessors()
     const barWidth = this._getBarWidth()
@@ -283,10 +284,13 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     const value = getNumber(d.datum, yAccessors[d.stackIndex], d.index)
     const height = isEntering ? 0 : Math.abs(this.valueScale(d.stacked[0]) - this.valueScale(d.stacked[1]))
     const h = !isEntering && config.barMinHeight1Px && (height < 1) && isFinite(value) && (value !== config.barMinHeightZeroValue) ? 1 : height
-    // Entering bars collapse onto the stack's origin (the baseline, zero by default), so the whole
-    // stack grows out of it instead of each segment growing from the start of its own span
+    // Entering bars collapse onto their growth origin. For a brand-new group that's the stack's
+    // origin (the baseline, zero by default), so the whole stack grows out of it. For a segment
+    // entering an already-rendered group it's the start of its own span, so it grows in place
+    // instead of flying from the baseline through its siblings
+    const baselineValue = config.baseline ? getNumber(d.datum, config.baseline, d.index) || 0 : 0
     const y = isEntering
-      ? this.valueScale(config.baseline ? getNumber(d.datum, config.baseline, d.index) || 0 : 0)
+      ? this.valueScale(isNewGroup ? baselineValue : d.stacked[0])
       : this.valueScale(isNegative ? d.stacked[0] : d.stacked[1]) - (height < 1 && config.barMinHeight1Px ? 1 : 0)
 
     const x = -barWidth / 2

--- a/packages/ts/src/components/stacked-bar/index.ts
+++ b/packages/ts/src/components/stacked-bar/index.ts
@@ -259,10 +259,10 @@ export class StackedBar<Datum> extends XYComponentCore<Datum, StackedBarConfigIn
     const value = getNumber(d.datum, yAccessors[d.stackIndex], d.index)
     const height = isEntering ? 0 : Math.abs(this.valueScale(d.stacked[0]) - this.valueScale(d.stacked[1]))
     const h = !isEntering && config.barMinHeight1Px && (height < 1) && isFinite(value) && (value !== config.barMinHeightZeroValue) ? 1 : height
-    // Entering bars collapse onto the start of their own span, so they grow out of the place they
-    // belong to instead of flying in from the zero line
+    // Entering bars collapse onto the stack's origin (the baseline, zero by default), so the whole
+    // stack grows out of it instead of each segment growing from the start of its own span
     const y = isEntering
-      ? this.valueScale(d.stacked[0])
+      ? this.valueScale(config.baseline ? getNumber(d.datum, config.baseline, d.index) || 0 : 0)
       : this.valueScale(isNegative ? d.stacked[0] : d.stacked[1]) - (height < 1 && config.barMinHeight1Px ? 1 : 0)
 
     const x = -barWidth / 2

--- a/packages/ts/src/types.ts
+++ b/packages/ts/src/types.ts
@@ -14,6 +14,7 @@ export * from '@/types/graph'
 export * from '@/types/data'
 export * from '@/types/direction'
 export * from '@/types/misc'
+export * from '@/types/style'
 
 // Component Types
 export * from '@/core/component/types'

--- a/packages/ts/src/types/style.ts
+++ b/packages/ts/src/types/style.ts
@@ -1,1 +1,10 @@
+import type * as CSS from 'csstype'
+
 export type UnovisCssVariablesDefinition = Record<string, string | undefined>
+
+/** An inline style object: standard CSS and SVG properties in camelCase or kebab-case,
+ * plus `--custom-property` keys */
+export type StyleDeclaration =
+  CSS.Properties<string | number> &
+  CSS.PropertiesHyphen<string | number> &
+  { [key: `--${string}`]: string | number }

--- a/packages/ts/src/utils/d3.ts
+++ b/packages/ts/src/utils/d3.ts
@@ -2,6 +2,12 @@ import { interrupt, Transition } from 'd3-transition'
 import { BaseType, Selection } from 'd3-selection'
 import { ValueFn } from 'd3'
 
+// Types
+import { StyleDeclaration } from '@/types/style'
+
+// Utils
+import { kebabCase } from '@/utils/text'
+
 export function smartTransition<Element extends BaseType, Datum, ParentElement extends BaseType, ParentDatum> (
   selection: Selection<Element, Datum, ParentElement, ParentDatum>,
   duration?: number,
@@ -13,6 +19,43 @@ export function smartTransition<Element extends BaseType, Datum, ParentElement e
     if (easing) transition.ease(easing)
     return transition
   } else return selection
+}
+
+// Inline style keys previously applied by `applyInlineStyles`, so keys that are no longer
+// returned by the accessor can be removed from the element on the next call
+const appliedInlineStyles = new WeakMap<Element, string[]>()
+
+/** Applies an object of inline styles to every node of a selection, converting camelCase keys
+ * to kebab-case. Keys applied on a previous call but absent from the current object (or set
+ * to `null`/`undefined`) are removed, so per-datum styles clean up after themselves.
+ * Keys listed in `skipKeys` are ignored — useful when a component manages some of them itself. */
+export function applyInlineStyles<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> (
+  selection: Selection<GElement, Datum, PElement, PDatum>,
+  getStyles: (d: Datum, i: number) => StyleDeclaration | null | undefined,
+  skipKeys?: ReadonlySet<string>
+): void {
+  selection.each((d, i, elements) => {
+    const element = elements[i] as SVGElement | HTMLElement
+    const styles = (getStyles(d, i) ?? {}) as Record<string, string | number | null | undefined>
+    const appliedKeys: string[] = []
+    for (const key of Object.keys(styles)) {
+      if (skipKeys?.has(key)) continue
+      const value = styles[key]
+      if (value === null || value === undefined) continue
+      const property = key.startsWith('--') ? key : kebabCase(key)
+      element.style.setProperty(property, `${value}`)
+      appliedKeys.push(property)
+    }
+
+    const prevKeys = appliedInlineStyles.get(element)
+    if (prevKeys) {
+      for (const key of prevKeys) {
+        if (!appliedKeys.includes(key)) element.style.removeProperty(key)
+      }
+    }
+    if (appliedKeys.length) appliedInlineStyles.set(element, appliedKeys)
+    else appliedInlineStyles.delete(element)
+  })
 }
 
 export interface VisAttrStylePatch<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {

--- a/packages/website/docs/components/StackedBar.mdx
+++ b/packages/website/docs/components/StackedBar.mdx
@@ -150,6 +150,29 @@ const color = (d: DataRecord) => d.y > 7 ? '#FF4F4E' : '#1acb9a'}
 <XYWrapper excludeTabs {...stackedBarProps()} showContext="minimal" showAxes={true} color={(d,i) => d.y > 7 ? '#FF4F4E' : '#1acb9a'}/>
 
 
+## Custom Bar Styles
+When color alone isn't enough, the `barStyle` accessor lets you style individual bars. It's called for
+every bar with the datum and its stack index, and the returned object is applied to the bar as inline
+styles. Property names can be camelCase or kebab-case, and CSS custom properties (`--*`) are supported.
+A common use case is rendering projected or estimated values differently from actuals:
+
+```ts
+const barStyle = (d: DataRecord, i: number) => d.x > 5
+  ? { strokeDasharray: '4 3', strokeWidth: 1, fillOpacity: 0.2 }
+  : undefined
+```
+
+<XYWrapper excludeTabs {...stackedBarProps()} showContext="minimal" showAxes y={[d => d.y, d => d.y1]} barStyle={(d, i) => d.x > 5 ? ({ strokeDasharray: '4 3', strokeWidth: 1, stroke: `var(--vis-color${i})`, fillOpacity: 0.2 }) : undefined}/>
+
+A few things to keep in mind:
+- The properties the component manages itself — `fill`, `opacity`, `cursor` and `mask` — take precedence
+over their regular sources (like the `color` accessor) and stay animated; all other properties are applied
+instantly.
+- Properties that are no longer returned for a bar are removed on the next render, so conditional styles
+clean up after themselves.
+- Since inline styles bypass the CSS cascade, use CSS variable references (e.g. `stroke: 'var(--my-color)'`)
+for values that should respond to theming.
+
 ## Bar Sizing
 ### Bar Width
 By default, the width of the bars is calculated automatically based on their count. But you can also strictly set the bar's width in pixels using the barWidth property:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       '@unovis/graphlibrary':
         specifier: 2.2.0-2
         version: 2.2.0-2
+      csstype:
+        specifier: ^3.2.3
+        version: 3.2.3
       d3:
         specifier: ^7.2.1
         version: 7.9.0


### PR DESCRIPTION
This PR:
- Fixes a StackedBar transition bug 
- Tweaks enter animation (bars now grow altogether from 0, instead of appearing in the center
- Adds a new config option for custom per-bar styling.

**Disappearing bars on rapid data updates.** The exit transitions' `.on('interrupt', remove)` handler (added in 98f8c9ad, shipped in 1.6.6) deletes bars that were legitimately re-adopted by a subsequent data join: when a re-render arrives mid exit fade and the segment's data is back, `smartTransition`'s `interrupt()` fires the old exit handler and removes the live node. Fixed by dropping the handler on `bars.exit()` — an interrupted exit always means the next join re-adopted the node (it either re-enters the update selection, which now restores `opacity`, or exits again and gets a fresh fade + remove). The group-level handler stays: exiting groups swap their class, so they can never be re-adopted.

**Enter animation.** Entering bars used to grow out of the start of their own stacked span, so non-first segments appeared to grow from the middle of the bar. They now collapse onto the stack's origin — the zero line, or the datum's `baseline` value when set — so the whole stack grows out of it. Works for positive and negative segments in both orientations.

**New `barStyle` accessor.** `(datum, stackIndex) => StyleDeclaration` applies custom inline styles per bar (typed via `csstype`, camelCase or kebab-case keys, `--custom-property` support). Keys the component manages itself (`fill`, `opacity`, `cursor`, `mask`) are merged into the render transitions as target values, so they win over defaults like the `color` accessor while staying animated; other keys are applied instantly via a new reusable `applyInlineStyles` util that also cleans up keys no longer returned. Useful for e.g. dashed "projected value" bars.

---

- [x] Dev examples (`Enter & Exit Transitions` stress-test: rapid updates, same-tick double renders, negative stacks; `Per-Bar Styles`: actual-vs-projected chart with a movable boundary demonstrating `barStyle` application and cleanup)
- [x] Wrappers
- [x] Docs (new "Custom Bar Styles" section with a live example; `barStyle` appears in the auto-generated props table)

### Fixes the issue with "hanging" bars
<img width="842" height="379" alt="SCR-20260826-jlur" src="https://github.com/user-attachments/assets/0c9e157b-a885-4e37-9edc-ac5c62ebcd93" />


### New dev examples
<img width="975" height="422" alt="SCR-20260826-oxdu" src="https://github.com/user-attachments/assets/eaab16f4-cf37-4897-a9ab-af6a21a84056" />

https://github.com/user-attachments/assets/cfd86b87-e5f5-494b-bfe8-6101c23bb05b




### Docs update
<img width="1501" height="854" alt="SCR-20260826-paiq" src="https://github.com/user-attachments/assets/773d6ec2-fc19-420b-84ad-a5ae27d81490" />


