### PR TITLE
Component | Tooltip: Don't hide or move externally controlled tooltips from delegated handlers

### DIFF
--- a/packages/ts/src/components/crosshair/index.ts
+++ b/packages/ts/src/components/crosshair/index.ts
@@ -173,7 +173,11 @@ export class Crosshair<Datum> extends XYComponentCore<Datum, CrosshairConfigInte
 
     const isCrosshairWithinXRange = (xPx >= xRange[0]) && (xPx <= xRange[1])
     const isCrosshairWithinYRange = (this._yPx >= Math.min(yRange[0], yRange[1])) && (this._yPx <= Math.max(yRange[0], yRange[1]))
-    let shouldShow = config.skipRangeCheck ? !!this._xPx : (this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange)
+    // When `forceShowAt` is set, the crosshair is pinned to that position, so its visibility
+    // shouldn't depend on where the pointer is — only on the pinned position being within the X range
+    let shouldShow = isForceShowAtDefined
+      ? isCrosshairWithinXRange
+      : config.skipRangeCheck ? !!this._xPx : (this._xPx ? isCrosshairWithinXRange && isCrosshairWithinYRange : isCrosshairWithinXRange)
 
     // Distance in pixels between the pointer and the snapped datum: the full 2D distance in
     // `CrosshairSnapMode.XY` mode (so a point that's close in X but far in Y still counts as far),

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -26,6 +26,10 @@ export class Tooltip {
   private _setUpEventsThrottled = throttle(this._setUpEvents, 500)
   private _setContainerPositionThrottled = throttle(this._setContainerPosition, 500)
   private _isShown = false
+  // Set when the tooltip is shown imperatively via `show()` (e.g. by Crosshair). While set, the component
+  // that called `show()` owns the tooltip's visibility and position, so the delegated mousemove / mouseleave
+  // handlers below must not hide or re-place it. Released by `hide()`.
+  private _isControlledExternally = false
   private _container: HTMLElement
   private _mutationObserver: MutationObserver
   private _hoveredElement: HTMLElement | SVGElement
@@ -106,6 +110,7 @@ export class Tooltip {
 
   /** Show the tooltip immediately by providing content and position */
   public show (html: string | HTMLElement | null | void, pos: { x: number; y: number }): void {
+    this._isControlledExternally = true
     this.render(html)
     this.place(pos)
   }
@@ -124,6 +129,7 @@ export class Tooltip {
 
   /** Hides the tooltip after `hideDelay` */
   public hide (): void {
+    this._isControlledExternally = false
     window.clearTimeout(this._showDelayTimeoutId)
     if (this.config.hideDelay) {
       window.clearTimeout(this._hideDelayTimeoutId)
@@ -397,6 +403,10 @@ export class Tooltip {
             }
           }
 
+          // No triggers matched. If the tooltip is controlled externally (e.g. by Crosshair via `show()`,
+          // possibly pinned with `forceShowAt`), its owner decides when to move or hide it — not us
+          if (this._isControlledExternally) return
+
           // No match: keep following the cursor so the tooltip doesn't freeze while it fades out
           // `_isShown` flips false as soon as `_hide` starts the fade, so check `hidden` instead
           if (currentConfig.followCursor && !this.div.classed(s.hidden)) {
@@ -411,6 +421,7 @@ export class Tooltip {
         })
         .on('mouseleave.tooltip', (e: MouseEvent) => {
           e.stopPropagation() // Stop propagation to prevent other interfering events from being triggered, e.g. Crosshair
+          if (this._isControlledExternally) return
           this.hide()
         })
     })


### PR DESCRIPTION
## Problem

`Crosshair`'s `forceShowAt` is broken: the pinned tooltip disappears as soon as the mouse moves anywhere on the page (repro: the *Force Show At Position* example in `packages/dev`).

The regression was introduced in #859. That PR added the tooltip **container** to the list of elements the Tooltip's delegated `mousemove` handler is attached to (to fix follow-cursor freezing over trigger gaps). But that handler has a "no trigger matched → `hide()`" fallback, and when the tooltip container is `document.body`, it now runs on **every mouse movement on the page**:

- Crosshair shows its tooltip imperatively via `tooltip.show()` and never registers any `triggers`, so no trigger ever matches.
- While the pointer is over the chart SVG, Crosshair's own `mousemove` handler re-shows the tooltip in the same frame, so the conflict stays invisible (as it always has — this hide/re-show race predates #859).
- Once the pointer moves **outside** the SVG, Crosshair never gets a chance to re-show, and the container-level handler hides the pinned tooltip for good.

The new follow-cursor fallback from #859 also calls `place()` with the raw cursor position on non-trigger mousemoves, yanking a `forceShowAt`-pinned tooltip toward the pointer (Crosshair force-sets `followCursor: true`).

The underlying gap: the delegated handler assumes it exclusively owns show/hide based on `triggers`, with no notion that a component like Crosshair is managing the tooltip imperatively.

## Fix

**Tooltip** — make ownership explicit. `show()` (the imperative API — Crosshair is its only caller in the codebase) marks the tooltip as externally controlled; `hide()` releases it. While the flag is set, the delegated `mousemove`/`mouseleave` handlers neither hide the tooltip nor re-place it — the owning component decides.

No Crosshair changes needed for this part: it already calls `tooltip.hide()` whenever the crosshair should disappear (out of range, mouseout, wheel), which releases the flag. Trigger-driven tooltips never call `show()`, so their behavior is untouched. As a side benefit, mouse-driven crosshair tooltips no longer get hidden and re-shown by the delegated handler on every mousemove.

**Crosshair** — a pre-existing flicker in the same scenario: with `forceShowAt` set, `shouldShow` still required the *pointer* to be within the Y range, so moving the mouse over the axis area (inside the SVG but outside the plot) hid the pinned crosshair and tooltip, and leaving the SVG re-showed them. A pinned crosshair's visibility now depends only on the forced position being within the X range, not on where the pointer is.

## Verified

- `Force Show At Position` dev example: tooltip stays pinned while the mouse moves anywhere on the page, including over the axis area and across the container edge (no flicker).
- `Simple Crosshair` dev example (regression check): tooltip still follows the pointer over the chart and hides when the pointer leaves the SVG (via Crosshair's own `mouseout` → `hide()` path).
- Trigger-based tooltips unaffected (`show()` is never called on that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)