### PR TITLE
GroupedBar: Exit transition fix and new `barStyle` accessor

### DIFF
--- a/packages/angular/src/components/grouped-bar/grouped-bar.component.ts
+++ b/packages/angular/src/components/grouped-bar/grouped-bar.component.ts
@@ -11,6 +11,7 @@ import {
   ContinuousScale,
   GenericAccessor,
   FillPatternType,
+  StyleDeclaration,
   StringAccessor,
   Orientation,
 } from '@unovis/ts'
@@ -110,6 +111,13 @@ export class VisGroupedBarComponent<Datum> implements GroupedBarConfigInterface<
   /** Bar fill pattern accessor. Resolves to a `FillPatternType`. Default: `undefined` */
   @Input() pattern?: GenericAccessor<FillPatternType, Datum>
 
+  /** Per-bar inline styles accessor, called with the datum and the bar's index within the group.
+   * The returned object is applied as inline styles, with camelCase keys converted to kebab-case.
+   * Keys the component manages itself (`fill`, `cursor`, `mask`) take precedence over their
+   * defaults (e.g. the `color` accessor) and stay animated; all other keys are applied
+   * instantly. Keys no longer returned are cleaned up on the next render. Default: `undefined` */
+  @Input() barStyle?: GenericAccessor<StyleDeclaration, Datum>
+
   /** Force set the group width in pixels. Default: `undefined` */
   @Input() groupWidth?: number
 
@@ -159,8 +167,8 @@ export class VisGroupedBarComponent<Datum> implements GroupedBarConfigInterface<
   }
 
   private getConfig (): GroupedBarConfigInterface<Datum> {
-    const { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, groupWidth, groupMaxWidth, dataStep, groupPadding, barPadding, roundedCorners, barMinHeight, cursor, orientation } = this
-    const config = { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, groupWidth, groupMaxWidth, dataStep, groupPadding, barPadding, roundedCorners, barMinHeight, cursor, orientation }
+    const { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, barStyle, groupWidth, groupMaxWidth, dataStep, groupPadding, barPadding, roundedCorners, barMinHeight, cursor, orientation } = this
+    const config = { duration, events, attributes, x, y, id, color, colorKeys, xScale, yScale, excludeFromDomainCalculation, pattern, barStyle, groupWidth, groupMaxWidth, dataStep, groupPadding, barPadding, roundedCorners, barMinHeight, cursor, orientation }
     const keys = Object.keys(config) as (keyof GroupedBarConfigInterface<Datum>)[]
     keys.forEach(key => { if (config[key] === undefined) delete config[key] })
 

--- a/packages/dev/src/examples/xy-components/grouped-bar/per-bar-styles/index.tsx
+++ b/packages/dev/src/examples/xy-components/grouped-bar/per-bar-styles/index.tsx
@@ -1,0 +1,47 @@
+import React, { useMemo, useState } from 'react'
+import { VisXYContainer, VisGroupedBar, VisAxis } from '@unovis/react'
+
+import { ExampleViewerDurationProps } from '@src/components/ExampleViewer/index'
+
+export const title = 'Per-Bar Styles'
+export const subTitle = 'Custom styles via `barStyle`'
+
+type Rec = { x: number; y: number; y1: number }
+
+export const component = (props: ExampleViewerDurationProps): React.ReactNode => {
+  const [currentMonth, setCurrentMonth] = useState(6)
+  const data = useMemo<Rec[]>(() => Array.from({ length: 12 }, (_, i) => ({
+    x: i + 1,
+    y: 6 + 4 * Math.sin(i / 2) + (i % 3),
+    y1: 2 + (i % 4),
+  })), [])
+
+  // Bars after the current month are projections: dashed outline, translucent fill
+  const projectedStyle = {
+    strokeDasharray: '4 3',
+    strokeWidth: 1,
+    fillOpacity: 0.2,
+  }
+
+  return (
+    <div>
+      <button onClick={() => setCurrentMonth(m => Math.max(1, m - 1))}>−1 month</button>
+      <button onClick={() => setCurrentMonth(m => Math.min(12, m + 1))}>+1 month</button>
+      <span style={{ marginLeft: 10 }}>current month: {currentMonth}</span>
+      <VisXYContainer<Rec> data={data} height={300}>
+        <VisGroupedBar<Rec>
+          x={d => d.x}
+          y={[d => d.y, d => d.y1]}
+          id={d => String(d.x)}
+          dataStep={1}
+          barStyle={(d, i) => (d.x > currentMonth
+            ? { ...projectedStyle, stroke: `var(--vis-color${i})` }
+            : undefined)}
+          duration={props.duration}
+        />
+        <VisAxis type='x' numTicks={12} duration={props.duration}/>
+        <VisAxis type='y' duration={props.duration}/>
+      </VisXYContainer>
+    </div>
+  )
+}

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@emotion/css": "^11.7.1",
     "@juggle/resize-observer": "^3.3.1",
+    "csstype": "^3.2.3",
     "d3-array": "~3",
     "d3-shape": "~3",
     "d3-hierarchy": "~3",

--- a/packages/ts/src/components/grouped-bar/config.ts
+++ b/packages/ts/src/components/grouped-bar/config.ts
@@ -4,12 +4,19 @@ import { XYComponentConfigInterface, XYComponentDefaultConfig } from '@/core/xy-
 import { ColorAccessor, GenericAccessor, StringAccessor } from '@/types/accessor'
 import { FillPatternType } from '@/styles/patterns'
 import { Orientation } from '@/types/position'
+import { StyleDeclaration } from '@/types/style'
 
 export interface GroupedBarConfigInterface<Datum> extends XYComponentConfigInterface<Datum> {
   /** Bar color accessor function. Default: `d => d.color` */
   color?: ColorAccessor<Datum>;
   /** Bar fill pattern accessor. Resolves to a `FillPatternType`. Default: `undefined` */
   pattern?: GenericAccessor<FillPatternType, Datum>;
+  /** Per-bar inline styles accessor, called with the datum and the bar's index within the group.
+   * The returned object is applied as inline styles, with camelCase keys converted to kebab-case.
+   * Keys the component manages itself (`fill`, `cursor`, `mask`) take precedence over their
+   * defaults (e.g. the `color` accessor) and stay animated; all other keys are applied
+   * instantly. Keys no longer returned are cleaned up on the next render. Default: `undefined` */
+  barStyle?: GenericAccessor<StyleDeclaration, Datum>;
   /** Force set the group width in pixels. Default: `undefined` */
   groupWidth?: number;
   /** Maximum group width for dynamic sizing. Limits the groupWidth property from the top. Default: `undefined` */
@@ -36,6 +43,7 @@ export const GroupedBarDefaultConfig: GroupedBarConfigInterface<unknown> = {
   ...XYComponentDefaultConfig,
   color: undefined,
   pattern: undefined,
+  barStyle: undefined,
   groupMaxWidth: undefined,
   groupWidth: undefined,
   dataStep: undefined,

--- a/packages/ts/src/components/grouped-bar/constants.ts
+++ b/packages/ts/src/components/grouped-bar/constants.ts
@@ -1,0 +1,4 @@
+// Style properties the component sets itself during render (and animates via transitions).
+// `barStyle` values for these keys are merged into those transitions as target values instead
+// of being applied as instant inline styles, so they don't get stomped by the next render.
+export const MANAGED_BAR_STYLES = new Set(['fill', 'cursor', 'mask'])

--- a/packages/ts/src/components/grouped-bar/index.ts
+++ b/packages/ts/src/components/grouped-bar/index.ts
@@ -125,7 +125,12 @@ export class GroupedBar<Datum> extends XYComponentCore<Datum, GroupedBarConfigIn
       .style('opacity', 1)
 
     const barGroupExit = barGroups.exit().attr('class', s.barGroupExit)
-    smartTransition(barGroupExit, duration).style('opacity', 0).remove()
+    smartTransition(barGroupExit, duration)
+      .style('opacity', 0)
+      .remove()
+      // `transition.remove()` only fires on `end`; if the exit is interrupted by a re-render, the group
+      // would linger in the DOM forever — its class was swapped, so no data join can re-adopt or remove it
+      .on('interrupt', function () { this.remove() })
 
     // Animate exiting bars going down
     smartTransition(barGroupExit.selectAll<SVGPathElement, Datum>(`.${s.bar}`), duration)

--- a/packages/ts/src/components/grouped-bar/index.ts
+++ b/packages/ts/src/components/grouped-bar/index.ts
@@ -5,9 +5,9 @@ import { min, max, range } from 'd3-array'
 import { XYComponentCore } from '@/core/xy-component'
 
 // Utils
-import { clamp, getExtent, getMax, getMin, getNumber, getString, isArray, isEmpty, isNumber } from '@/utils/data'
+import { clamp, getExtent, getMax, getMin, getNumber, getString, getValue, isArray, isEmpty, isNumber } from '@/utils/data'
 import { roundedRectPath } from '@/utils/path'
-import { smartTransition } from '@/utils/d3'
+import { smartTransition, applyInlineStyles } from '@/utils/d3'
 import { getColor } from '@/utils/color'
 import { getPattern, getFillPatternValue, UNOVIS_PATTERN_INDEX_ATTR } from '@/utils/pattern'
 
@@ -17,9 +17,13 @@ import { Spacing } from '@/types/spacing'
 import { Direction } from '@/types/direction'
 import { Orientation } from '@/types/position'
 import { ContinuousScale } from '@/types/scale'
+import { StyleDeclaration } from '@/types/style'
 
 // Config
 import { GroupedBarDefaultConfig, GroupedBarConfigInterface } from './config'
+
+// Constants
+import { MANAGED_BAR_STYLES } from './constants'
 
 // Styles
 import * as s from './style'
@@ -158,11 +162,16 @@ export class GroupedBar<Datum> extends XYComponentCore<Datum, GroupedBarConfigIn
         return this._getBarPath(x, y, width, height, false, valueAxisDirection)
       })
       .attr(UNOVIS_PATTERN_INDEX_ATTR, (d, i) => i)
-      .style('fill', (d, i) => getColor(d, config.color, i, config.colorKeys?.[i], colorOptions))
-      .style('mask', (d, i) => getFillPatternValue(getPattern(d, config.pattern, i)))
+      .style('fill', (d, i) => this._getBarStyle(d, i)?.fill ?? getColor(d, config.color, i, config.colorKeys?.[i], colorOptions))
+      .style('mask', (d, i) => this._getBarStyle(d, i)?.mask ?? getFillPatternValue(getPattern(d, config.pattern, i)))
 
     const barsMerged = barsEnter.merge(bars)
-    barsMerged.style('mask', (d, i) => getFillPatternValue(getPattern(d, config.pattern, i)))
+    barsMerged.style('mask', (d, i) => this._getBarStyle(d, i)?.mask ?? getFillPatternValue(getPattern(d, config.pattern, i)))
+
+    // Custom per-bar styles; the managed keys are merged into the transition below instead,
+    // so they keep animating and don't get stomped by the next render
+    applyInlineStyles(barsMerged, (d, i) => this._getBarStyle(d, i), MANAGED_BAR_STYLES)
+
     smartTransition(barsMerged, duration)
       .attr('d', (d, j) => {
         const x = innerBandScale(j)
@@ -182,10 +191,14 @@ export class GroupedBar<Datum> extends XYComponentCore<Datum, GroupedBarConfigIn
         }
         return this._getBarPath(x, y, width, height, isNegative, valueAxisDirection)
       })
-      .style('fill', (d, i) => getColor(d, config.color, i, config.colorKeys?.[i], colorOptions))
-      .style('cursor', (d, i) => getString(d, config.cursor, i))
+      .style('fill', (d, i) => this._getBarStyle(d, i)?.fill ?? getColor(d, config.color, i, config.colorKeys?.[i], colorOptions))
+      .style('cursor', (d, i) => this._getBarStyle(d, i)?.cursor ?? getString(d, config.cursor, i))
 
     smartTransition(bars.exit(), duration).remove()
+  }
+
+  private _getBarStyle (d: Datum, index: number): StyleDeclaration | null | undefined {
+    return getValue<Datum, StyleDeclaration>(d, this.config.barStyle, index)
   }
 
   _getValueAxisDirection (): Direction.North | Direction.South {

--- a/packages/ts/src/types.ts
+++ b/packages/ts/src/types.ts
@@ -14,6 +14,7 @@ export * from '@/types/graph'
 export * from '@/types/data'
 export * from '@/types/direction'
 export * from '@/types/misc'
+export * from '@/types/style'
 
 // Component Types
 export * from '@/core/component/types'

--- a/packages/ts/src/types/style.ts
+++ b/packages/ts/src/types/style.ts
@@ -1,1 +1,10 @@
+import type * as CSS from 'csstype'
+
 export type UnovisCssVariablesDefinition = Record<string, string | undefined>
+
+/** An inline style object: standard CSS and SVG properties in camelCase or kebab-case,
+ * plus `--custom-property` keys */
+export type StyleDeclaration =
+  CSS.Properties<string | number> &
+  CSS.PropertiesHyphen<string | number> &
+  { [key: `--${string}`]: string | number }

--- a/packages/ts/src/utils/d3.ts
+++ b/packages/ts/src/utils/d3.ts
@@ -2,6 +2,12 @@ import { interrupt, Transition } from 'd3-transition'
 import { BaseType, Selection } from 'd3-selection'
 import { ValueFn } from 'd3'
 
+// Types
+import { StyleDeclaration } from '@/types/style'
+
+// Utils
+import { kebabCase } from '@/utils/text'
+
 export function smartTransition<Element extends BaseType, Datum, ParentElement extends BaseType, ParentDatum> (
   selection: Selection<Element, Datum, ParentElement, ParentDatum>,
   duration?: number,
@@ -13,6 +19,43 @@ export function smartTransition<Element extends BaseType, Datum, ParentElement e
     if (easing) transition.ease(easing)
     return transition
   } else return selection
+}
+
+// Inline style keys previously applied by `applyInlineStyles`, so keys that are no longer
+// returned by the accessor can be removed from the element on the next call
+const appliedInlineStyles = new WeakMap<Element, string[]>()
+
+/** Applies an object of inline styles to every node of a selection, converting camelCase keys
+ * to kebab-case. Keys applied on a previous call but absent from the current object (or set
+ * to `null`/`undefined`) are removed, so per-datum styles clean up after themselves.
+ * Keys listed in `skipKeys` are ignored — useful when a component manages some of them itself. */
+export function applyInlineStyles<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> (
+  selection: Selection<GElement, Datum, PElement, PDatum>,
+  getStyles: (d: Datum, i: number) => StyleDeclaration | null | undefined,
+  skipKeys?: ReadonlySet<string>
+): void {
+  selection.each((d, i, elements) => {
+    const element = elements[i] as SVGElement | HTMLElement
+    const styles = (getStyles(d, i) ?? {}) as Record<string, string | number | null | undefined>
+    const appliedKeys: string[] = []
+    for (const key of Object.keys(styles)) {
+      if (skipKeys?.has(key)) continue
+      const value = styles[key]
+      if (value === null || value === undefined) continue
+      const property = key.startsWith('--') ? key : kebabCase(key)
+      element.style.setProperty(property, `${value}`)
+      appliedKeys.push(property)
+    }
+
+    const prevKeys = appliedInlineStyles.get(element)
+    if (prevKeys) {
+      for (const key of prevKeys) {
+        if (!appliedKeys.includes(key)) element.style.removeProperty(key)
+      }
+    }
+    if (appliedKeys.length) appliedInlineStyles.set(element, appliedKeys)
+    else appliedInlineStyles.delete(element)
+  })
 }
 
 export interface VisAttrStylePatch<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {

--- a/packages/website/docs/components/GroupedBar.mdx
+++ b/packages/website/docs/components/GroupedBar.mdx
@@ -29,6 +29,29 @@ In this example, each bar's color is assigned based on its index:
 <XYWrapper {...groupedBarProps()} showContext="minimal" showAxes color={(d,i) => ['#04c0c7', '#5144d3', '#da348f'][i]}/>
 
 
+## Custom Bar Styles
+When color alone isn't enough, the `barStyle` accessor lets you style individual bars. It's called for
+every bar with the datum and the bar's index within the group, and the returned object is applied to the
+bar as inline styles. Property names can be camelCase or kebab-case, and CSS custom properties (`--*`)
+are supported. A common use case is rendering projected or estimated values differently from actuals:
+
+```ts
+const barStyle = (d: DataRecord, i: number) => d.x > 5
+  ? { strokeDasharray: '4 3', strokeWidth: 1, fillOpacity: 0.2 }
+  : undefined
+```
+
+<XYWrapper excludeTabs {...groupedBarProps()} showContext="minimal" showAxes y={[d => d.y, d => d.y1]} barStyle={(d, i) => d.x > 5 ? ({ strokeDasharray: '4 3', strokeWidth: 1, stroke: `var(--vis-color${i})`, fillOpacity: 0.2 }) : undefined}/>
+
+A few things to keep in mind:
+- The properties the component manages itself — `fill`, `cursor` and `mask` — take precedence
+over their regular sources (like the `color` accessor) and stay animated; all other properties are applied
+instantly.
+- Properties that are no longer returned for a bar are removed on the next render, so conditional styles
+clean up after themselves.
+- Since inline styles bypass the CSS cascade, use CSS variable references (e.g. `stroke: 'var(--my-color)'`)
+for values that should respond to theming.
+
 ## Rounded Corners
 You can apply rounded corners to the top bar in your _Grouped Bar_ component using the `roundedCorners` property, which accepts
 either a `number` (in pixels) or `boolean` argument.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
       '@unovis/graphlibrary':
         specifier: 2.2.0-2
         version: 2.2.0-2
+      csstype:
+        specifier: ^3.2.3
+        version: 3.2.3
       d3:
         specifier: ^7.2.1
         version: 7.9.0


### PR DESCRIPTION
Ports the applicable parts of #896 to _GroupedBar_:

**Fixes lingering groups on rapid data updates.** GroupedBar's group exit transition had no `interrupt` handler: when a re-render arrived mid exit fade, the group was never removed — its class had already been swapped to `barGroupExit`, so no later data join could re-adopt or clean it up, leaving a semi-transparent ghost group (with its bars frozen mid-squash) in the DOM forever. Fixed by removing the node on `interrupt`, mirroring StackedBar's group-level handling.

**New `barStyle` accessor.** Same feature as StackedBar's in #896: `(datum, indexWithinGroup) => StyleDeclaration` applies custom inline styles per bar. Keys the component manages itself (`fill`, `cursor`, `mask`) are merged into the render transitions as target values, so they win over defaults like the `color` accessor while staying animated; other keys are applied instantly and clean up when no longer returned. Unlike StackedBar, `opacity` is not in the managed set — GroupedBar never animates bar-level opacity.

> **Depends on #896** — the two `Core` commits (`applyInlineStyles`, `StyleDeclaration` export) are cherry-picked from it and will dedupe once it merges.

- [x] Dev examples (`Per-Bar Styles`: actual-vs-projected chart with a movable boundary demonstrating `barStyle` application and cleanup)
- [x] Wrappers (Angular regenerated via autogen; others regenerate to no diff)
- [x] Docs (new "Custom Bar Styles" section with a live example; `barStyle` appears in the auto-generated props table)

<img width="981" height="343" alt="SCR-20260828-micf" src="https://github.com/user-attachments/assets/d38cefdc-9866-4123-b40f-4a011e1aa746" />

<img width="1499" height="856" alt="SCR-20260828-miwo" src="https://github.com/user-attachments/assets/6600946f-4631-43e5-9316-bbbba6f9beb6" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)