### PR TITLE
Component | Area: Fix dark mode styling

### DIFF
--- a/packages/ts/src/components/area/style.ts
+++ b/packages/ts/src/components/area/style.ts
@@ -22,7 +22,6 @@ export const globalStyles = injectGlobal`
   }
 
   ${darkThemeCssSelectors} ${`.${root}`} {
-    --vis-area-fill-opacity: 0.5;
     --vis-area-stroke-color: var(--vis-dark-area-stroke-color);
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing to Unovis!
  • Commit messages follow our format: `Type | Scope: Sentence-case subject`
    → https://unovis.dev/contributing/pull-requests#commit-messages
  • First-time contributors: the F5 CLA bot will ask you to sign the CLA.
  • Using an AI coding agent (Claude Code, Codex, Cursor)? See AGENTS.md at the repo root.
-->

## What & why

<!-- A short description of the change and the motivation behind it. Link any related issues. -->
https://github.com/f5/unovis/pull/649/changes#diff-46a259f55d685bd46aba0807282adbb692349b1080405fc0fad357cf631d31f3R25
In this PR, a fill-opacity was accidentally introduced to area chart, causing inconsistent behavior for dark and light mode.
fill opacity should be overwrite by user, but from a library level.


## Screenshots / recordings

<!-- For anything visual, include light and dark mode. -->

https://github.com/user-attachments/assets/90229842-5c52-453c-9d87-9f44bd042263

