### PR TITLE
Revert/tooltip optimisation

### DIFF
--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -135,9 +135,9 @@ export class Tooltip {
 
   private _display (): void {
     window.clearTimeout(this._hideDelayTimeoutId)
-    this.div.classed(s.hidden, false) // The `hidden` class sets `display: none;`
-    this.element.getBoundingClientRect() // force a reflow so it has a frame to fade in from
-    this.div.classed(s.show, true) // The `show` class triggers the opacity transition
+    this.div
+      .classed(s.hidden, false) // The `hidden` class sets `display: none;`
+      .classed(s.show, true) // The `show` class triggers the opacity transition
 
     this._isShown = true
   }
@@ -348,11 +348,8 @@ export class Tooltip {
     // We use the Event Delegation pattern to set up Tooltip events
     // Every component will have single `mousemove` and `mouseleave` event listener functions, where we'll check
     // the `path` of the event and trigger corresponding callbacks
-    // We also attach to the container itself: a gap between triggers (e.g. between bars) can be
-    // covered by a sibling component's element, which the per-component listener below never sees
-    const elements = [...this.components.map(c => c.element), this._container]
-    elements.forEach(element => {
-      const selection = select(element)
+    this.components.forEach(component => {
+      const selection = select(component.element)
       selection
         .on('mousemove.tooltip', (e: MouseEvent) => {
           const { config: currentConfig } = this // get latest config because it could have been changed after the event was triggered
@@ -391,13 +388,6 @@ export class Tooltip {
                 return
               }
             }
-          }
-
-          // No match: keep following the cursor so the tooltip doesn't freeze while it fades out
-          // `_isShown` flips false as soon as `_hide` starts the fade, so check `hidden` instead
-          if (currentConfig.followCursor && !this.div.classed(s.hidden)) {
-            const [x, y] = this.isContainerBody() ? [e.clientX, e.clientY] : pointer(e, this._container)
-            this.place({ x, y })
           }
 
           // Hide the tooltip if the event didn't pass through any of the configured triggers.

--- a/packages/ts/src/components/tooltip/index.ts
+++ b/packages/ts/src/components/tooltip/index.ts
@@ -358,10 +358,6 @@ export class Tooltip {
           const { config: currentConfig } = this // get latest config because it could have been changed after the event was triggered
           const path: (HTMLElement | SVGGElement)[] = (e.composedPath && e.composedPath()) || (e as any).path || [e.target]
 
-          // Events coming from the tooltip itself (possible when `allowHover` is enabled, because the tooltip
-          // lives inside the container) are handled by the tooltip's own hover listeners, see below
-          if (path.includes(this.element)) return
-
           // Go through all of the configured triggers
           for (const className of Object.keys(currentConfig.triggers)) {
             const template = currentConfig.triggers[className]


### PR DESCRIPTION
<!--
  Thanks for contributing to Unovis!
  • Commit messages follow our format: `Type | Scope: Sentence-case subject`
    → https://unovis.dev/contributing/pull-requests#commit-messages
  • First-time contributors: the F5 CLA bot will ask you to sign the CLA.
  • Using an AI coding agent (Claude Code, Codex, Cursor)? See AGENTS.md at the repo root.
-->

## What & why

<!-- A short description of the change and the motivation behind it. Link any related issues. -->
We decided to revert this update, as this introduced a regression: 
https://github.com/f5/unovis/pull/898
The above PR itself could use a bit work, so we are holding off that for now.

## Checklist

<!-- Tick what applies; delete what doesn't. A new component usually touches all four. -->

- [ ] Dev examples
- [ ] Dev gallery examples (`pnpm dev:gallery`)
- [ ] Wrappers (regenerated via `pnpm generate`)
- [ ] Gallery example
- [ ] Docs
- [ ] Lint passes on the files I changed
- [ ] Builds locally (`pnpm build`)
- [x] All commands pass (`pnpm cmds-report`)

## Screenshots / recordings

<!-- For anything visual, include light and dark mode. -->
